### PR TITLE
WIP: Deprecate dm_get_filters()

### DIFF
--- a/R/dm.R
+++ b/R/dm.R
@@ -371,6 +371,12 @@ dm_get_data_model_fks <- function(x) {
 dm_get_filters <- function(x) {
   check_not_zoomed(x)
 
+  deprecate_soft("0.1.6", "dm_get_filters()")
+
+  dm_get_filters_impl(x)
+}
+
+dm_get_filters_impl <- function(x) {
   filter_df <-
     dm_get_def(x) %>%
     select(table, filters) %>%


### PR DESCRIPTION
and others.

Closes (when done) #426 and #403.