### PR TITLE
Issue 566 testthat wrappers

### DIFF
--- a/R/testthat-wrappers.R
+++ b/R/testthat-wrappers.R
@@ -1,7 +1,7 @@
 expect_error_obj <- function(object, regexp = NULL, class = NULL, ...,
-                               info = NULL, label = NULL) {
+                             info = NULL, label = NULL) {
   testthat::expect_error(
-    obj <- rlang::eval_tidy({{object}}),
+    obj <- rlang::eval_tidy({{ object }}),
     regexp = regexp,
     class = class,
     ...,
@@ -14,7 +14,7 @@ expect_error_obj <- function(object, regexp = NULL, class = NULL, ...,
 expect_warning_obj <- function(object, regexp = NULL, class = NULL, ...,
                                info = NULL, label = NULL) {
   testthat::expect_warning(
-    obj <- rlang::eval_tidy({{object}}),
+    obj <- rlang::eval_tidy({{ object }}),
     regexp = regexp,
     class = class,
     ...,
@@ -26,7 +26,7 @@ expect_warning_obj <- function(object, regexp = NULL, class = NULL, ...,
 expect_message_obj <- function(object, regexp = NULL, class = NULL, ...,
                                info = NULL, label = NULL) {
   testthat::expect_message(
-    obj <- rlang::eval_tidy({{object}}),
+    obj <- rlang::eval_tidy({{ object }}),
     regexp = regexp,
     class = class,
     ...,
@@ -36,9 +36,9 @@ expect_message_obj <- function(object, regexp = NULL, class = NULL, ...,
 }
 
 expect_condition_obj <- function(object, regexp = NULL, class = NULL, ...,
-                               info = NULL, label = NULL) {
+                                 info = NULL, label = NULL) {
   testthat::expect_condition(
-    obj <- rlang::eval_tidy({{object}}),
+    obj <- rlang::eval_tidy({{ object }}),
     regexp = regexp,
     class = class,
     ...,
@@ -46,4 +46,3 @@ expect_condition_obj <- function(object, regexp = NULL, class = NULL, ...,
     label = label)
   invisible(obj)
 }
-

--- a/R/testthat-wrappers.R
+++ b/R/testthat-wrappers.R
@@ -1,0 +1,49 @@
+expect_error_obj <- function(object, regexp = NULL, class = NULL, ...,
+                               info = NULL, label = NULL) {
+  testthat::expect_error(
+    obj <- rlang::eval_tidy({{object}}),
+    regexp = regexp,
+    class = class,
+    ...,
+    all = all,
+    info = info,
+    label = label)
+  invisible(obj)
+}
+
+expect_warning_obj <- function(object, regexp = NULL, class = NULL, ...,
+                               info = NULL, label = NULL) {
+  testthat::expect_warning(
+    obj <- rlang::eval_tidy({{object}}),
+    regexp = regexp,
+    class = class,
+    ...,
+    info = info,
+    label = label)
+  invisible(obj)
+}
+
+expect_message_obj <- function(object, regexp = NULL, class = NULL, ...,
+                               info = NULL, label = NULL) {
+  testthat::expect_message(
+    obj <- rlang::eval_tidy({{object}}),
+    regexp = regexp,
+    class = class,
+    ...,
+    info = info,
+    label = label)
+  invisible(obj)
+}
+
+expect_condition_obj <- function(object, regexp = NULL, class = NULL, ...,
+                               info = NULL, label = NULL) {
+  testthat::expect_condition(
+    obj <- rlang::eval_tidy({{object}}),
+    regexp = regexp,
+    class = class,
+    ...,
+    info = info,
+    label = label)
+  invisible(obj)
+}
+

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -308,7 +308,7 @@ test_that("basic test: 'join()'-methods for `zoomed.dm` work (2)", {
 test_that("basic test: 'join()'-methods for `zoomed.dm` work (3)", {
   skip_if_src("maria")
   # multi-column "by" argument
-  out <- expect_message(
+  out <- expect_message_obj(
     dm_for_disambiguate() %>%
       dm_zoom_to(iris_2) %>%
       left_join(iris_2, by = c("key", "Sepal.Width", "other_col")) %>%

--- a/tests/testthat/test-flatten.R
+++ b/tests/testthat/test-flatten.R
@@ -1,7 +1,7 @@
 test_that("`dm_flatten_to_tbl()` does the right things for 'left_join()'", {
   # for left join test the basic flattening also on all DBs
   expect_equivalent_tbl(
-    expect_message(dm_flatten_to_tbl(dm_for_flatten(), fact)),
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact)),
     result_from_flatten()
   )
 
@@ -14,7 +14,7 @@ test_that("`dm_flatten_to_tbl()` does the right things for 'left_join()'", {
   )
 
   # explicitly choose parent tables
-  out <- expect_message(dm_flatten_to_tbl(
+  out <- expect_message_obj(dm_flatten_to_tbl(
     dm_for_flatten(), fact, dim_1, dim_2
   ))
   expect_equivalent_tbl(
@@ -28,7 +28,7 @@ test_that("`dm_flatten_to_tbl()` does the right things for 'left_join()'", {
   )
 
   # change order of parent tables
-  out <- expect_message(dm_flatten_to_tbl(
+  out <- expect_message_obj(dm_flatten_to_tbl(
     dm_for_flatten(), fact, dim_2, dim_1
   ))
   expect_equivalent_tbl(
@@ -61,7 +61,7 @@ test_that("`dm_flatten_to_tbl()` does the right things for 'left_join()'", {
 })
 
 test_that("`dm_flatten_to_tbl()` does the right things for 'inner_join()'", {
-  out <- expect_message(dm_flatten_to_tbl(
+  out <- expect_message_obj(dm_flatten_to_tbl(
     dm_for_flatten(), fact,
     join = inner_join
   ))
@@ -71,7 +71,7 @@ test_that("`dm_flatten_to_tbl()` does the right things for 'inner_join()'", {
 test_that("`dm_flatten_to_tbl()` does the right things for 'full_join()'", {
   skip_if_src("sqlite")
   skip_if_src("maria")
-  out <- expect_message(dm_flatten_to_tbl(
+  out <- expect_message_obj(dm_flatten_to_tbl(
     dm_for_flatten(), fact,
     join = full_join
   ))
@@ -110,7 +110,7 @@ test_that("`dm_flatten_to_tbl()` does the right things for 'nest_join()'", {
 test_that("`dm_flatten_to_tbl()` does the right things for 'right_join()'", {
   skip_if_src("sqlite")
   expect_equivalent_tbl(
-    expect_message(expect_warning(
+    expect_message_obj(expect_warning_obj(
       dm_flatten_to_tbl(dm_for_flatten(), fact, join = right_join),
       "right_join"
     )),
@@ -122,7 +122,7 @@ test_that("`dm_flatten_to_tbl()` does the right things for 'right_join()'", {
   )
 
   # change order of parent tables
-  out <- expect_message(dm_flatten_to_tbl(
+  out <- expect_message_obj(dm_flatten_to_tbl(
     dm_for_flatten(), fact, dim_2, dim_1,
     join = right_join
   ))
@@ -195,7 +195,7 @@ test_that("`dm_squash_to_tbl()` does the right things", {
 
 test_that("prepare_dm_for_flatten() works", {
   # unfiltered with rename
-  out <- expect_message(prepare_dm_for_flatten(
+  out <- expect_message_obj(prepare_dm_for_flatten(
     dm_for_flatten(),
     c("fact", "dim_1", "dim_3"),
     gotta_rename = TRUE
@@ -220,7 +220,7 @@ test_that("prepare_dm_for_flatten() works", {
 
   prep_dm_renamed <- dm_disambiguate_cols(prep_dm, quiet = TRUE)
 
-  out <- expect_message(prepare_dm_for_flatten(
+  out <- expect_message_obj(prepare_dm_for_flatten(
     dm_filter(dm_for_flatten(), dim_1, dim_1_pk_1 > 7, dim_1_pk_2 > !!LETTERS[7]),
     c("fact", "dim_1", "dim_3"),
     gotta_rename = TRUE
@@ -245,19 +245,19 @@ test_that("prepare_dm_for_flatten() works", {
 test_that("tidyselect works for flatten", {
   # test if deselecting works
   expect_equivalent_tbl(
-    expect_message(dm_flatten_to_tbl(dm_for_flatten(), fact, -dim_2, dim_3, -dim_4, dim_1)),
-    expect_message(dm_flatten_to_tbl(dm_for_flatten(), fact, dim_1, dim_3))
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, -dim_2, dim_3, -dim_4, dim_1)),
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, dim_1, dim_3))
   )
 
   # test if select helpers work
   expect_equivalent_tbl(
-    expect_message(dm_flatten_to_tbl(dm_for_flatten(), fact, ends_with("3"), ends_with("1"))),
-    expect_message(dm_flatten_to_tbl(dm_for_flatten(), fact, dim_3, dim_1))
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, ends_with("3"), ends_with("1"))),
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, dim_3, dim_1))
   )
 
   expect_equivalent_tbl(
-    expect_message(dm_flatten_to_tbl(dm_for_flatten(), fact, everything())),
-    expect_message(dm_flatten_to_tbl(dm_for_flatten(), fact))
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, everything())),
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact))
   )
 
   # if only deselecting one potential candidate for flattening, the tables that are not
@@ -276,7 +276,7 @@ test_that("tidyselect works for flatten", {
 
 test_that("`dm_join_to_tbl()` works", {
   expect_equivalent_tbl(
-    expect_message(dm_join_to_tbl(dm_for_flatten(), fact, dim_3), "Renamed"),
+    expect_message_obj(dm_join_to_tbl(dm_for_flatten(), fact, dim_3), "Renamed"),
     left_join(
       fact_clean(),
       dim_3_clean(),

--- a/tests/testthat/test-testthat-wrappers.R
+++ b/tests/testthat/test-testthat-wrappers.R
@@ -1,15 +1,30 @@
 
 testthat::test_that("testthat wrappers return the object", {
   expect_equal(
-    expect_message_obj({message("abc");"foo"}, "a"),
+    expect_message_obj(
+      {
+        message("abc")
+        "foo"
+      },
+      "a"),
     "foo"
   )
   expect_equal(
-    expect_warning_obj({warning("abc");"foo"}, "a"),
+    expect_warning_obj(
+      {
+        warning("abc")
+        "foo"
+      },
+      "a"),
     "foo"
   )
   expect_equal(
-    expect_condition_obj({message("abc");"foo"}, "a"),
+    expect_condition_obj(
+      {
+        message("abc")
+        "foo"
+      },
+      "a"),
     "foo"
   )
 })

--- a/tests/testthat/test-testthat-wrappers.R
+++ b/tests/testthat/test-testthat-wrappers.R
@@ -1,0 +1,15 @@
+
+testthat::test_that("testthat wrappers return the object", {
+  expect_equal(
+    expect_message_obj({message("abc");"foo"}, "a"),
+    "foo"
+  )
+  expect_equal(
+    expect_warning_obj({warning("abc");"foo"}, "a"),
+    "foo"
+  )
+  expect_equal(
+    expect_condition_obj({message("abc");"foo"}, "a"),
+    "foo"
+  )
+})

--- a/tests/testthat/test-zzx-deprecated.R
+++ b/tests/testthat/test-zzx-deprecated.R
@@ -37,8 +37,8 @@ test_that("cdm_disambiguate_cols() works as intended", {
   local_options(lifecycle_verbosity = "quiet")
 
   expect_equivalent_dm(
-    expect_message(cdm_disambiguate_cols(dm_for_disambiguate())),
-    expect_message(dm_disambiguate_cols(dm_for_disambiguate()))
+    expect_message_obj(cdm_disambiguate_cols(dm_for_disambiguate())),
+    expect_message_obj(dm_disambiguate_cols(dm_for_disambiguate()))
   )
 })
 
@@ -94,12 +94,12 @@ test_that("`cdm_flatten_to_tbl()`, `cdm_join_to_tbl()` and `dm_squash_to_tbl()` 
   local_options(lifecycle_verbosity = "quiet")
 
   expect_equivalent_tbl(
-    expect_message(cdm_flatten_to_tbl(dm_for_flatten(), fact)),
+    expect_message_obj(cdm_flatten_to_tbl(dm_for_flatten(), fact)),
     result_from_flatten()
   )
 
   expect_equivalent_tbl(
-    expect_message(cdm_join_to_tbl(dm_for_flatten(), fact, dim_3)),
+    expect_message_obj(cdm_join_to_tbl(dm_for_flatten(), fact, dim_3)),
     select(result_from_flatten(), fact:fact.something, dim_3.something)
   )
 })


### PR DESCRIPTION
closes #566

We build wrappers by replacing the tunneled argument `{{object}}` with `obj <- rlang::eval_tidy({{object}})`, this way we don't execute object 2 times, as we would if we'd just have `object` as the last call of these functions.

We add a simple test for each of these wrappers.

We replace some instances of `expect_message` and `expect_warning` by their counterpart, so relevant tests are now passed.