### PR TITLE
rows_truncate_()

### DIFF
--- a/R/rows-dm.R
+++ b/R/rows-dm.R
@@ -242,7 +242,7 @@ get_dm_rows_op <- function(operation_name) {
     "patch"    = list(fun = rows_patch, pb_label = "patching rows"),
     "upsert"   = list(fun = rows_upsert, pb_label = "upserting rows"),
     "delete"   = list(fun = rows_delete, pb_label = "deleting rows"),
-    "truncate" = list(fun = rows_truncate, pb_label = "truncating rows")
+    "truncate" = list(fun = rows_truncate_, pb_label = "truncating rows")
   )
 }
 

--- a/R/rows-truncate.R
+++ b/R/rows-truncate.R
@@ -9,7 +9,11 @@
 #' @param x A data frame or data frame extension (e.g. a tibble).
 #' @export
 rows_truncate <- function(x, ..., in_place = FALSE) {
-  ellipsis::check_dots_used(action = "warn")
+  ellipsis::check_dots_used(action = warn)
+  UseMethod("rows_truncate", x)
+}
+# For dm_rows_truncate
+rows_truncate_ <- function(x, y, ..., in_place = FALSE) {
   UseMethod("rows_truncate", x)
 }
 


### PR DESCRIPTION
to avoid warning on unused argument.