### PR TITLE
Use `rows_check_key*()` like in `dplyr`

### DIFF
--- a/tests/testthat/_snaps/rows-db.md
+++ b/tests/testthat/_snaps/rows-db.md
@@ -17,6 +17,8 @@
       `x` and `y` must share the same src, set `copy` = TRUE (may be slow).
     Code
       rows_insert(data, test_db_src_frame(select = 4, where = "z"))
+    Message <dplyr_message_matching_by>
+      Matching, by = "select"
     Message <message>
       Result is returned as lazy table. Use `in_place = FALSE` to mute this message, or `in_place = TRUE` to write to the underlying table.
     Output
@@ -36,6 +38,8 @@
       3      3 <NA>     2.5
     Code
       rows_insert(data, test_db_src_frame(select = 4, where = "z"), in_place = FALSE)
+    Message <dplyr_message_matching_by>
+      Matching, by = "select"
     Output
         select where exists
          <dbl> <chr>  <dbl>
@@ -53,6 +57,9 @@
       3      3 <NA>     2.5
     Code
       rows_insert(data, test_db_src_frame(select = 4, where = "z"), in_place = TRUE)
+    Message <dplyr_message_matching_by>
+      Matching, by = "select"
+    Code
       data %>% arrange(select)
     Output
         select where exists
@@ -63,6 +70,8 @@
       4      4 z       NA  
     Code
       rows_delete(data, test_db_src_frame(select = 2), in_place = FALSE)
+    Message <dplyr_message_matching_by>
+      Matching, by = "select"
     Output
         select where exists
          <int> <chr>  <dbl>
@@ -80,6 +89,9 @@
       4      4 z       NA  
     Code
       rows_delete(data, test_db_src_frame(select = 2), in_place = TRUE)
+    Message <dplyr_message_matching_by>
+      Matching, by = "select"
+    Code
       data %>% arrange(select)
     Output
         select where exists
@@ -143,6 +155,8 @@
       3      4 z       NA  
     Code
       rows_delete(data, test_db_src_frame(select = 1:3, where = "q"), in_place = FALSE)
+    Message <dplyr_message_matching_by>
+      Matching, by = "select"
     Output
         select where exists
          <int> <chr>  <dbl>
@@ -157,6 +171,9 @@
       3      4 z       NA  
     Code
       rows_delete(data, test_db_src_frame(select = 1:3, where = "q"), in_place = TRUE)
+    Message <dplyr_message_matching_by>
+      Matching, by = "select"
+    Code
       data %>% arrange(select)
     Output
         select where exists
@@ -234,6 +251,9 @@
       3      3 <NA>     2.5
     Code
       rows_update(data, test_db_src_frame(select = 2:3, where = "w"), in_place = TRUE)
+    Message <dplyr_message_matching_by>
+      Matching, by = "select"
+    Code
       data %>% arrange(select)
     Output
         select where exists
@@ -244,6 +264,9 @@
     Code
       rows_update(data, test_db_src_frame(select = 2, where = "w", exists = 3.5),
       in_place = TRUE)
+    Message <dplyr_message_matching_by>
+      Matching, by = "select"
+    Code
       data %>% arrange(select)
     Output
         select where exists
@@ -253,6 +276,9 @@
       3      3 w        2.5
     Code
       rows_update(data, test_db_src_frame(select = 2:3), in_place = TRUE)
+    Message <dplyr_message_matching_by>
+      Matching, by = "select"
+    Code
       data %>% arrange(select)
     Output
         select where exists

--- a/tests/testthat/_snaps/rows-dm.md
+++ b/tests/testthat/_snaps/rows-dm.md
@@ -29,6 +29,9 @@
       out <- dm_rows_insert(flights_sqlite, flights_hour10_sqlite)
     Message <simpleMessage>
       Not persisting, use `in_place = FALSE` to turn off this message.
+    Message <dplyr_message_matching_by>
+      Matching, by = "origin"
+      Matching, by = "year"
     Code
       print(dm_nrow(flights_sqlite))
     Output
@@ -36,6 +39,10 @@
             15       86        0      945        0 
     Code
       dm_rows_insert(flights_sqlite, flights_hour10_sqlite, in_place = TRUE)
+    Message <dplyr_message_matching_by>
+      Matching, by = "origin"
+      Matching, by = "year"
+    Code
       print(dm_nrow(flights_sqlite))
     Output
       airlines airports  flights   planes  weather 
@@ -47,6 +54,10 @@
       hour == 11) %>% dm_update_zoomed()
       flights_hour11_sqlite <- copy_dm_to(sqlite, flights_hour11)
       flights_new <- dm_rows_insert(flights_sqlite, flights_hour11_sqlite, in_place = FALSE)
+    Message <dplyr_message_matching_by>
+      Matching, by = "origin"
+      Matching, by = "year"
+    Code
       print(dm_nrow(flights_new))
     Output
       airlines airports  flights   planes  weather 
@@ -64,6 +75,10 @@
       * Table `flights`: foreign key tailnum into table `planes`: values of `flights$tailnum` not in `planes$tailnum`: N0EGMQ (1), N3BCAA (1), N3CCAA (1), N3CFAA (1), N3EHAA (1), ...
     Code
       dm_rows_insert(flights_sqlite, flights_hour11_sqlite, in_place = TRUE)
+    Message <dplyr_message_matching_by>
+      Matching, by = "origin"
+      Matching, by = "year"
+    Code
       print(dm_nrow(flights_sqlite))
     Output
       airlines airports  flights   planes  weather 


### PR DESCRIPTION
The `rows_*.data.frame()` functions use `rows_check_key()` and `rows_check_key_df()` for nicer error messages. Currently, 

```r
dplyr:::rows_patch.data.frame <- function (x, y, by = NULL, ..., copy = FALSE, in_place = FALSE) {
    key <- rows_check_key(by, x, y)
    y <- auto_copy(x, y, copy = copy)
    rows_df_in_place(in_place)
    rows_check_key_df(x, key, df_name = "x")
    rows_check_key_df(y, key, df_name = "y")
    idx <- vctrs::vec_match(y[key], x[key])
    bad <- which(is.na(idx))
    if (has_length(bad)) {
        abort("Attempting to patch missing rows.")
    }
    new_data <- map2(x[idx, names(y)], y, coalesce)
    x[idx, names(y)] <- new_data
    x
}

dplyr:::rows_check_key_df <- function (df, by, df_name) {
    y_miss <- setdiff(by, colnames(df))
    if (length(y_miss) > 0) {
        abort(glue("All `by` columns must exist in `{df_name}`."))
    }
    if (vctrs::vec_duplicate_any(df[by])) {
        abort(glue("`{df_name}` key values are not unique."))
    }
}

dplyr:::rows_check_key <- function (by, x, y) {
    if (is.null(by)) {
        by <- names(y)[[1]]
        inform(glue("Matching, by = \"{by}\""), class = c("dplyr_message_matching_by", 
            "dplyr_message"))
    }
    if (!is.character(by) || length(by) == 0) {
        abort("`by` must be a character vector.")
    }
    if (any(names2(by) != "")) {
        abort("`by` must be unnamed.")
    }
    bad <- setdiff(colnames(y), colnames(x))
    if (has_length(bad)) {
        abort("All columns in `y` must exist in `x`.")
    }
    by
}
```