### PR TITLE
Fix db_get_zoom() to support zooming on empty tables

### DIFF
--- a/R/dm.R
+++ b/R/dm.R
@@ -279,7 +279,7 @@ dm_get_zoom <- function(x, cols = c("table", "zoom"), quiet = FALSE) {
   # Performance
   def <- dm_get_def(x, quiet)
   zoom <- def$zoom
-  where <- which(!map_dbl(zoom, is.null))
+  where <- which(!map_lgl(zoom, is.null))
   if (length(where) != 1) {
     # FIXME: Better error message?
     abort_not_pulling_multiple_zoomed()

--- a/R/dm.R
+++ b/R/dm.R
@@ -279,7 +279,7 @@ dm_get_zoom <- function(x, cols = c("table", "zoom"), quiet = FALSE) {
   # Performance
   def <- dm_get_def(x, quiet)
   zoom <- def$zoom
-  where <- which(lengths(zoom) != 0)
+  where <- which(!map_dbl(zoom, is.null))
   if (length(where) != 1) {
     # FIXME: Better error message?
     abort_not_pulling_multiple_zoomed()

--- a/tests/testthat/test-zoom.R
+++ b/tests/testthat/test-zoom.R
@@ -154,3 +154,10 @@ test_that("zoom output for compound keys", {
     attr(igraph::E(create_graph_from_dm(nyc_comp_3)), "vnames")
   })
 })
+
+test_that("dm_get_zoom() works to zoom on empty tables", {
+  zdm <- dm(x = tibble()) %>% dm_zoom_to(x)
+  expect_identical(
+    dm_get_zoom(zdm),
+    tibble(table = "x", zoom = list(tibble())))
+})


### PR DESCRIPTION
closes #626

This is a small fix for a very interesting error!
In fact the error we see in linked issue is not one, it's just a message, and it's sent by RStudio, not base R.

Here's a minimal reproduction of the issue :
```
length.foo = function(x) stop("error!")
registerS3method("length", "foo", length.foo)
foo <- 1
attributes(foo) <- list(class = "foo")
#> Error in length.foo(obj) : error!
foo
#> [1] 1
#> attr(,"class")
#> [1] "foo"
```

As we see, the `foo`object was properly created and modified, but the fact that the length method fails makes RStudio display the problematic message.

The guilty function is `.rs.describeObject`, it seems to be called after an object is created or modified in the console, and it calls `length()`.

In our case we have ` length()` --> `length.zoomed_dm()` --> `tbl_zoomed()` --> `dm_get_zoom()`, and `dm_get_zoom(dm(x = tibble()))` fails through `abort_not_pulling_multiple_zoomed()`

Our code didn't call `length()` on our object, so the bug is not our fault but
Rstudio's, however this showed us that our length method has a problem since
a zoomed dm containing an empty table is legal but its length isn't.

The idiom `lengths(zoom) != 0` was used to filter the zoomed rows, likely expecting zero length elements to be `NULL`, but `length(tibble())` has length zero too. We use `!map_dbl(zoom, is.null)` instead and the issue disappears.


I opened a RStudio issue too : https://github.com/rstudio/rstudio/issues/9887
