### PR TITLE
Print code in `dm_disambiguate_cols()`

### DIFF
--- a/R/disambiguate.R
+++ b/R/disambiguate.R
@@ -56,6 +56,17 @@ get_table_colnames <- function(dm, tables = NULL) {
     anti_join(keep_colnames, by = c("table", "column"))
 }
 
+#' create a disambiguation recipe tibble
+#'
+#' It will contain :
+#'   * table: the table name
+#'   * renames: a list of named symbols to be substituted in
+#'     `db_rename(dm, tbl, new = old)`
+#'   * name and a list of tibbles containing character cols `new_name` and `column`
+#'     that will be used to print`db_rename` instructions through explain_col_rename
+#' @param table_colnames a table containing table name and col names of dm
+#' @param sep separator used to create new names for dupe cols
+#' @noRd
 compute_disambiguate_cols_recipe <- function(table_colnames, sep) {
   dupes <- vec_duplicate_detect(table_colnames$column)
   dup_colnames <- table_colnames[dupes, ]

--- a/R/disambiguate.R
+++ b/R/disambiguate.R
@@ -62,13 +62,14 @@ compute_disambiguate_cols_recipe <- function(table_colnames, sep) {
 
   dup_colnames$new_name <- paste0(dup_colnames$table, sep, dup_colnames$column)
   dup_data <- dup_colnames[c("new_name", "column")]
-  dup_data$column <- syms(dup_data$column)
+  dup_data$column_sym <- syms(dup_data$column)
 
   dup_nested <-
     vec_split(dup_data, dup_colnames$table) %>%
     set_names("table", "renames")
 
-  dup_nested$renames <- map(dup_nested$renames, deframe)
+  dup_nested$names <- map(dup_nested$renames, select, new_name, column)
+  dup_nested$renames <- map(dup_nested$renames, ~deframe(select(., -column)))
   as_tibble(dup_nested)
 }
 

--- a/tests/testthat/_snaps/disambiguate.md
+++ b/tests/testthat/_snaps/disambiguate.md
@@ -4,8 +4,12 @@
       dm_for_flatten() %>% dm_disambiguate_cols() %>% dm_paste(options = c("select",
         "keys"))
     Message <simpleMessage>
-      Renamed columns:
-      * something -> fact.something, dim_1.something, dim_2.something, dim_3.something, dim_4.something
+      Renaming ambiguous columns: %>%
+        dm_rename(fact, fact.something = something) %>%
+        dm_rename(dim_1, dim_1.something = something) %>%
+        dm_rename(dim_2, dim_2.something = something) %>%
+        dm_rename(dim_3, dim_3.something = something) %>%
+        dm_rename(dim_4, dim_4.something = something)
     Message <cliMessage>
       dm::dm(
         fact,

--- a/tests/testthat/_snaps/dplyr.md
+++ b/tests/testthat/_snaps/dplyr.md
@@ -5,8 +5,9 @@
       zoomed_dm() %>% left_join(tf_3, select = c(d = g, f, f1)) %>% dm_update_zoomed() %>%
         get_all_keys()
     Message <simpleMessage>
-      Renamed columns:
-      * d -> tf_2.d, tf_3.d
+      Renaming ambiguous columns: %>%
+        dm_rename(tf_2, tf_2.d = d) %>%
+        dm_rename(tf_3, tf_3.d = d)
     Output
       $pks
       # A tibble: 6 x 2
@@ -518,41 +519,57 @@
     Code
       zoomed_comp_dm %>% left_join(flights) %>% nrow()
     Message <simpleMessage>
-      Renamed columns:
-      * year -> weather.year, flights.year
-      * month -> weather.month, flights.month
-      * day -> weather.day, flights.day
-      * hour -> weather.hour, flights.hour
+      Renaming ambiguous columns: %>%
+        dm_rename(weather, weather.year = year) %>%
+        dm_rename(weather, weather.month = month) %>%
+        dm_rename(weather, weather.day = day) %>%
+        dm_rename(weather, weather.hour = hour) %>%
+        dm_rename(flights, flights.year = year) %>%
+        dm_rename(flights, flights.month = month) %>%
+        dm_rename(flights, flights.day = day) %>%
+        dm_rename(flights, flights.hour = hour)
     Output
       [1] 1800
     Code
       zoomed_comp_dm %>% right_join(flights) %>% nrow()
     Message <simpleMessage>
-      Renamed columns:
-      * year -> weather.year, flights.year
-      * month -> weather.month, flights.month
-      * day -> weather.day, flights.day
-      * hour -> weather.hour, flights.hour
+      Renaming ambiguous columns: %>%
+        dm_rename(weather, weather.year = year) %>%
+        dm_rename(weather, weather.month = month) %>%
+        dm_rename(weather, weather.day = day) %>%
+        dm_rename(weather, weather.hour = hour) %>%
+        dm_rename(flights, flights.year = year) %>%
+        dm_rename(flights, flights.month = month) %>%
+        dm_rename(flights, flights.day = day) %>%
+        dm_rename(flights, flights.hour = hour)
     Output
       [1] 1761
     Code
       zoomed_comp_dm %>% inner_join(flights) %>% nrow()
     Message <simpleMessage>
-      Renamed columns:
-      * year -> weather.year, flights.year
-      * month -> weather.month, flights.month
-      * day -> weather.day, flights.day
-      * hour -> weather.hour, flights.hour
+      Renaming ambiguous columns: %>%
+        dm_rename(weather, weather.year = year) %>%
+        dm_rename(weather, weather.month = month) %>%
+        dm_rename(weather, weather.day = day) %>%
+        dm_rename(weather, weather.hour = hour) %>%
+        dm_rename(flights, flights.year = year) %>%
+        dm_rename(flights, flights.month = month) %>%
+        dm_rename(flights, flights.day = day) %>%
+        dm_rename(flights, flights.hour = hour)
     Output
       [1] 1761
     Code
       zoomed_comp_dm %>% full_join(flights) %>% nrow()
     Message <simpleMessage>
-      Renamed columns:
-      * year -> weather.year, flights.year
-      * month -> weather.month, flights.month
-      * day -> weather.day, flights.day
-      * hour -> weather.hour, flights.hour
+      Renaming ambiguous columns: %>%
+        dm_rename(weather, weather.year = year) %>%
+        dm_rename(weather, weather.month = month) %>%
+        dm_rename(weather, weather.day = day) %>%
+        dm_rename(weather, weather.hour = hour) %>%
+        dm_rename(flights, flights.year = year) %>%
+        dm_rename(flights, flights.month = month) %>%
+        dm_rename(flights, flights.day = day) %>%
+        dm_rename(flights, flights.hour = hour)
     Output
       [1] 1800
     Code

--- a/tests/testthat/test-flatten.R
+++ b/tests/testthat/test-flatten.R
@@ -276,7 +276,7 @@ test_that("tidyselect works for flatten", {
 
 test_that("`dm_join_to_tbl()` works", {
   expect_equivalent_tbl(
-    expect_message_obj(dm_join_to_tbl(dm_for_flatten(), fact, dim_3), "Renamed"),
+    expect_message_obj(dm_join_to_tbl(dm_for_flatten(), fact, dim_3), "Renaming"),
     left_join(
       fact_clean(),
       dim_3_clean(),


### PR DESCRIPTION
Closes #684 

We tried to be consistent with `dm_rm_fk()`

``` r
library(dm, warn.conflicts = FALSE)
dm_nycflights13() %>% 
  dm_disambiguate_cols()
#> Renaming ambiguous columns: %>%
#>   dm_rename(airlines, airlines.name = name) %>%
#>   dm_rename(airports, airports.name = name) %>%
#>   dm_rename(flights, flights.year = year) %>%
#>   dm_rename(flights, flights.month = month) %>%
#>   dm_rename(flights, flights.day = day) %>%
#>   dm_rename(flights, flights.hour = hour) %>%
#>   dm_rename(planes, planes.year = year) %>%
#>   dm_rename(weather, weather.year = year) %>%
#>   dm_rename(weather, weather.month = month) %>%
#>   dm_rename(weather, weather.day = day) %>%
#>   dm_rename(weather, weather.hour = hour)
#> ── Metadata ────────────────────────────────────────────────────────────────────
#> Tables: `airlines`, `airports`, `flights`, `planes`, `weather`
#> Columns: 53
#> Primary keys: 4
#> Foreign keys: 4
```

<sup>Created on 2021-11-01 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>