### PR TITLE
662 always disambiguate col names

### DIFF
--- a/R/disambiguate.R
+++ b/R/disambiguate.R
@@ -44,19 +44,20 @@ get_table_colnames <- function(dm, tables = NULL, exclude_pk = TRUE) {
     unnest_col("column", character())
 
   if(exclude_pk) {
-  pks <- dm_get_all_pks_def_impl(def)
+    pks <- dm_get_all_pks_def_impl(def)
 
-  keep_colnames <-
-    pks[c("table", "pk_col")] %>%
-    set_names(c("table", "column")) %>%
-    unnest_col("column", character())
+    keep_colnames <-
+      pks[c("table", "pk_col")] %>%
+      set_names(c("table", "column")) %>%
+      unnest_col("column", character())
 
-  table_colnames <-
-    table_colnames %>%
-    # in case of flattening, the primary key columns will never be responsible for the name
-    # of the resulting column in the end, so they do not need to be disambiguated
-    anti_join(keep_colnames, by = c("table", "column"))
+    table_colnames <-
+      table_colnames %>%
+      # in case of flattening, the primary key columns will never be responsible for the name
+      # of the resulting column in the end, so they do not need to be disambiguated
+      anti_join(keep_colnames, by = c("table", "column"))
   }
+
   table_colnames
 }
 

--- a/R/disambiguate.R
+++ b/R/disambiguate.R
@@ -26,7 +26,7 @@ dm_disambiguate_cols <- function(dm, sep = ".", quiet = FALSE) {
 }
 
 dm_disambiguate_cols_impl <- function(dm, tables, sep = ".", quiet = FALSE) {
-  table_colnames <- get_table_colnames(dm, tables)
+  table_colnames <- get_table_colnames(dm, tables, exclude_pk = FALSE)
   recipe <- compute_disambiguate_cols_recipe(table_colnames, sep = sep)
   if (!quiet) explain_col_rename(recipe)
   col_rename(dm, recipe)

--- a/R/disambiguate.R
+++ b/R/disambiguate.R
@@ -32,7 +32,7 @@ dm_disambiguate_cols_impl <- function(dm, tables, sep = ".", quiet = FALSE) {
   col_rename(dm, recipe)
 }
 
-get_table_colnames <- function(dm, tables = NULL) {
+get_table_colnames <- function(dm, tables = NULL, exclude_pk = TRUE) {
   def <- dm_get_def(dm)
 
   if (!is.null(tables)) {
@@ -43,6 +43,7 @@ get_table_colnames <- function(dm, tables = NULL) {
     tibble(table = def$table, column = map(def$data, colnames)) %>%
     unnest_col("column", character())
 
+  if(exclude_pk) {
   pks <- dm_get_all_pks_def_impl(def)
 
   keep_colnames <-
@@ -50,10 +51,13 @@ get_table_colnames <- function(dm, tables = NULL) {
     set_names(c("table", "column")) %>%
     unnest_col("column", character())
 
-  table_colnames %>%
+  table_colnames <-
+    table_colnames %>%
     # in case of flattening, the primary key columns will never be responsible for the name
     # of the resulting column in the end, so they do not need to be disambiguated
     anti_join(keep_colnames, by = c("table", "column"))
+  }
+  table_colnames
 }
 
 compute_disambiguate_cols_recipe <- function(table_colnames, sep) {


### PR DESCRIPTION
closes #662 

We add an argument `exclude_pk = TRUE` to `get_table_colnames()` and we set it to `TRUE` in `dm_disambiguate_cols_impl()`.

`get_table_colnames()` is called also in `prepare_dm_for_flatten()` and there it keeps the default behaviour.

``` r
library(dm, warn.conflicts = FALSE)
library(tidyverse)

person  <- tibble(id = 1, person = "Joe")
hobby   <- tibble(id = c(1,1), hobby = c("R Programming", "Basketball"))
country <- tibble(id = 1, place = "Switzerland")
city    <- tibble(country_id = c(1,1), city = c("Zurich", "Geneva"))

dm <-
  dm(person, hobby, country, city) %>%
  dm_add_pk(person, id) %>%
  dm_add_pk(country, id) %>%
  dm_add_fk(hobby, id, person, id) %>% 
  dm_add_fk(city, country_id, country, id)

dm <- dm_disambiguate_cols(dm)
#> Renamed columns:
#> * id -> person.id, hobby.id, country.id
dm_draw(dm, view_type = "all")
```

![](https://i.imgur.com/WeWo8RB.png)

<sup>Created on 2021-11-01 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>


Note: `get_table_colnames()` has a `tables` argument, `NULL` by default and never used unless set to `NULL`, so it can be removed without affecting the code, is it there for a reason, future plans ? flexibility ? or is it dead code that we should trim off ?