### PR TITLE
no proactive checks for schema existence and tweak MSSQL-schema-code

### DIFF
--- a/R/error-helpers.R
+++ b/R/error-helpers.R
@@ -594,19 +594,6 @@ warn_if_arg_not <- function(arg,
 
 # Errors for schema handling functions ------------------------------------
 
-abort_no_schema_exists <- function(schema, dbname = NULL) {
-  abort(error_txt_no_schema_exists(schema, dbname),
-    class = dm_error_full("no_schema_exists")
-  )
-}
-
-error_txt_no_schema_exists <- function(schema, dbname) {
-  msg_suffix <- fix_msg(dbname)
-  glue(
-    "No schema named {tick(schema)} exists{msg_suffix}."
-  )
-}
-
 abort_no_schemas_supported <- function(dbms = NULL, con = NULL) {
   abort(
     error_txt_no_schemas_supported(dbms, con),

--- a/R/global.R
+++ b/R/global.R
@@ -51,6 +51,7 @@ utils::globalVariables(c(
   "need_ref",
   "new_display",
   "new_name",
+  "node",
   "old",
   "origin",
   "parent",

--- a/R/schema.R
+++ b/R/schema.R
@@ -60,7 +60,7 @@ db_schema_list.src_dbi <- function(con, include_default = TRUE, ...) {
   # https://docs.microsoft.com/en-us/sql/relational-databases/security/authentication-access/ownership-and-user-schema-separation?view=sql-server-ver15
   DBI::dbGetQuery(con, glue::glue("SELECT s.name as schema_name
     FROM {dbname_sql}sys.schemas s
-    WHERE s.name NOT IN ('sys', 'INFORMATION_SCHEMA', 'db_accessadmin',
+    WHERE s.name NOT IN ('sys', 'guest', 'INFORMATION_SCHEMA', 'db_accessadmin',
           'db_backupoperator', 'db_datareader', 'db_datawriter', 'db_ddladmin',
           'db_denydatareader', 'db_denydatawriter', 'db_owner',
           'db_securityadmin'){default_if_true}")) %>%

--- a/R/schema.R
+++ b/R/schema.R
@@ -263,9 +263,6 @@ sql_schema_table_list_mssql <- function(con, schema = NULL, dbname = NULL) {
     check_param_class(schema, "character")
     check_param_length(schema)
   }
-  if (!is_null(schema) && !db_schema_exists(src$con, schema, dbname)) {
-    abort_no_schema_exists(sql_to_character(src$con, schema), dbname)
-  }
   if (!is_null(dbname)) {
     check_param_class(dbname, "character")
     check_param_length(dbname)
@@ -285,9 +282,6 @@ sql_schema_table_list_postgres <- function(con, schema = NULL) {
   if (!is_null(schema)) {
     check_param_class(schema, "character")
     check_param_length(schema)
-  }
-  if (!is_null(schema) && !db_schema_exists(src$con, schema)) {
-    abort_no_schema_exists(sql_to_character(src$con, schema))
   }
   enframe(
     get_src_tbl_names(src, schema = sql_to_character(src$con, schema)),
@@ -339,9 +333,6 @@ db_schema_drop <- function(con, schema, force = FALSE, ...) {
     deprecate_soft("0.2.5", 'dm::db_schema_drop(con = "must be a DBI connection, not a dbplyr source,")', )
   }
 
-  if (!db_schema_exists(con, schema, ...)) {
-    abort_no_schema_exists(sql_to_character(con_from_src_or_con(con), schema), ...)
-  }
   UseMethod("db_schema_drop")
 }
 

--- a/man/dplyr_table_manipulation.Rd
+++ b/man/dplyr_table_manipulation.Rd
@@ -109,7 +109,7 @@ The default returns the last column (on the assumption that's the
 column you've created most recently).
 
 This argument is taken by expression and supports
-\link[rlang:nse-force]{quasiquotation} (you can unquote column
+\link[rlang:topic-inject]{quasiquotation} (you can unquote column
 names and column locations).}
 }
 \description{

--- a/tests/testthat/_snaps/error-helpers.md
+++ b/tests/testthat/_snaps/error-helpers.md
@@ -242,14 +242,6 @@
     Output
       NULL
     Code
-      abort_no_schema_exists("table_1")
-    Error <dm_error_no_schema_exists>
-      No schema named `table_1` exists.
-    Code
-      abort_no_schema_exists("fastfood", "gala_dinner")
-    Error <dm_error_no_schema_exists>
-      No schema named `fastfood` exists on database `gala_dinner`.
-    Code
       abort_no_schemas_supported("FantasticDatabaseManagementSystem",
         "hyperconnection")
     Error <dm_error_no_schemas_supported>

--- a/tests/testthat/test-error-helpers.R
+++ b/tests/testthat/test-error-helpers.R
@@ -60,8 +60,6 @@ test_that("output", {
     abort_parameter_not_correct_class("number", correct_class = "numeric", class = "logical")
     abort_parameter_not_correct_length("length_1_parameter", 1, letters[1:26])
     warn_if_arg_not("NULL", c("MSSQL", "Postgres"), arg_name = "dbms_dependent_arg")
-    abort_no_schema_exists("table_1")
-    abort_no_schema_exists("fastfood", "gala_dinner")
     abort_no_schemas_supported("FantasticDatabaseManagementSystem", "hyperconnection")
     abort_no_schemas_supported(con = 1)
     abort_no_schemas_supported()

--- a/tests/testthat/test-schema.R
+++ b/tests/testthat/test-schema.R
@@ -35,7 +35,7 @@ test_that("schema handling on MSSQL and Postgres works", {
   )
   expect_true(db_schema_exists(con_db, "1-dm_schema_TEST"))
   expect_message(db_schema_drop(con_db, "1-dm_schema_TEST"), "Dropped schema")
-  expect_dm_error(db_schema_drop(con_db, "1-dm_schema_TEST"), "no_schema_exists")
+  expect_error(db_schema_drop(con_db, "1-dm_schema_TEST"))
   expect_false(db_schema_exists(con_db, "1-dm_schema_TEST"))
 
   expect_deprecated(expect_message(db_schema_create(src_db, "1-dm_schema_TEST"), "created"))


### PR DESCRIPTION
partly addresses #672: the proactive checks for schema existence are abolished.

For listing schemas on MSSQL we also now avoid matching `schema owner id` to `user id`. I just ran into trouble here (`schema owner id` didn't exist in `user id` list and therefore schema wasn't listed, even though it existed). 
Now used 3054912 as a workaround, that schemas that exist by default for backward compatibility are filtered out.