### PR TITLE
pkgdown: use `cynkratemplate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,4 @@ If you encounter a clear bug, please file an issue with a minimal reproducible e
 
 ------------------------------------------------------------------------
 
-License: MIT © cynkra GmbH.
-
-Funded by:
-
-[![energie360°](man/figures/energie-72.png)](https://www.energie360.ch/de/) <span style="padding-right:50px"> </span> [![cynkra](man/figures/cynkra-72.png)](https://www.cynkra.com/)
-
-------------------------------------------------------------------------
-
 Please note that the ‘dm’ project is released with a [Contributor Code of Conduct](https://cynkra.github.io/dm/CODE_OF_CONDUCT.html). By contributing to this project, you agree to abide by its terms.

--- a/man/dplyr_table_manipulation.Rd
+++ b/man/dplyr_table_manipulation.Rd
@@ -109,7 +109,7 @@ The default returns the last column (on the assumption that's the
 column you've created most recently).
 
 This argument is taken by expression and supports
-\link[rlang:nse-force]{quasiquotation} (you can unquote column
+\link[rlang:topic-inject]{quasiquotation} (you can unquote column
 names and column locations).}
 }
 \description{

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -1,8 +1,7 @@
-url: https://cynkra.github.io/dm
+url: https://dm.cynkra.com
 
 template:
-  assets:
-  - pkgdown/assets
+  package: cynkratemplate
 
 reference:
 - title: Basic


### PR DESCRIPTION
- Removed the footer in the README because it looks misplaced in the pkgdown site. Not sure if ok but the current format should be updated? Funder acknowledgements are also shown in the side bar of the "home" page, yet way smaller.
- Created the CNAME entry in our DNS for dm.cynkra.com