### PR TITLE
remove soft deprecated dplyr-src funs

### DIFF
--- a/R/flatten.R
+++ b/R/flatten.R
@@ -31,7 +31,7 @@
 #' Then all involved foreign tables are joined to the `start` table successively, with the join function given in the `join` argument.
 #'
 #' **Case 2**, filter conditions are set for at least one table that is connected to `start`:
-#' First, disambiguation will be performed if necessary. The `start` table is then calculated using `dm[["start"]]`.
+#' First, disambiguation will be performed if necessary. The `start` table is then calculated using `dm[[start]]`.
 #' This implies
 #' that the effect of the filters on this table is taken into account.
 #' For `right_join`, `full_join` and `nest_join`, an error

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -31,7 +31,7 @@
 #' Then all involved foreign tables are joined to the `start` table successively, with the join function given in the `join` argument.
 #'
 #' **Case 2**, filter conditions are set for at least one table that is connected to `start`:
-#' First, disambiguation will be performed if necessary. The `start` table is then calculated using `tbl(dm, "start")`.
+#' First, disambiguation will be performed if necessary. The `start` table is then calculated using `dm[["start"]]`.
 #' This implies
 #' that the effect of the filters on this table is taken into account.
 #' For `right_join`, `full_join` and `nest_join`, an error
@@ -265,7 +265,7 @@ prepare_dm_for_flatten <- function(dm, tables, gotta_rename) {
   red_dm <-
     dm_reset_all_filters(dm) %>%
     dm_select_tbl(!!!tables)
-  # Only need to compute `tbl(dm, start)`, `dm_apply_filters()` not necessary
+  # Only need to compute `dm[[start]]`, `dm_apply_filters()` not necessary
   # Need to use `dm` and not `clean_dm` here, because of possible filter conditions.
   start_tbl <- dm_get_filtered_table(dm, start)
 

--- a/man/dm_flatten_to_tbl.Rd
+++ b/man/dm_flatten_to_tbl.Rd
@@ -49,7 +49,7 @@ The necessary disambiguations of the column names are performed first.
 Then all involved foreign tables are joined to the \code{start} table successively, with the join function given in the \code{join} argument.
 
 \strong{Case 2}, filter conditions are set for at least one table that is connected to \code{start}:
-First, disambiguation will be performed if necessary. The \code{start} table is then calculated using \code{tbl(dm, "start")}.
+First, disambiguation will be performed if necessary. The \code{start} table is then calculated using \code{dm[["start"]]}.
 This implies
 that the effect of the filters on this table is taken into account.
 For \code{right_join}, \code{full_join} and \code{nest_join}, an error

--- a/vignettes/howto-dm-db.Rmd
+++ b/vignettes/howto-dm-db.Rmd
@@ -70,8 +70,8 @@ Note that the tables arguments have to all be from the same source, in this case
 dbListTables(my_db)
 
 library(dbplyr)
-loans <- my_db[["loans"]]
-accounts <- my_db[["accounts"]]
+loans <- tbl(my_db, "loans")
+accounts <- tbl(my_db, "accounts")
 
 my_manual_dm <- dm(loans, accounts)
 my_manual_dm
@@ -116,7 +116,7 @@ Once you have instantiated a dm object you can continue to add tables to it.
 For tables from the original source for the dm, use `dm_add_tbl()`
 
 ``````{r }
-trans <- my_db[["trans"]]
+trans <- tbl(my_db, "trans")
 
 my_dm_keys %>%
   dm_add_tbl(trans)

--- a/vignettes/howto-dm-db.Rmd
+++ b/vignettes/howto-dm-db.Rmd
@@ -70,8 +70,8 @@ Note that the tables arguments have to all be from the same source, in this case
 dbListTables(my_db)
 
 library(dbplyr)
-loans <- tbl(my_db, "loans")
-accounts <- tbl(my_db, "accounts")
+loans <- my_db[["loans"]]
+accounts <- my_db[["accounts"]]
 
 my_manual_dm <- dm(loans, accounts)
 my_manual_dm
@@ -116,7 +116,7 @@ Once you have instantiated a dm object you can continue to add tables to it.
 For tables from the original source for the dm, use `dm_add_tbl()`
 
 ``````{r }
-trans <- tbl(my_db, "trans")
+trans <- my_db[["trans"]]
 
 my_dm_keys %>%
   dm_add_tbl(trans)

--- a/vignettes/tech-dm-class.Rmd
+++ b/vignettes/tech-dm-class.Rmd
@@ -111,7 +111,7 @@ validate_dm(base_dm)
 
 ## Access tables
 
-We can get the list of tables with `dm_get_tables()` and the `src` object with `dm_get_src()`.
+We can get the list of tables with `dm_get_tables()` and the `src` object with `dm_get_con()`.
 
 In order to pull a specific table from a `dm`, use:
 ```{r}

--- a/vignettes/tech-dm-join.Rmd
+++ b/vignettes/tech-dm-join.Rmd
@@ -95,12 +95,10 @@ As you can see below, the `dm_joined` dataframe has one more column than the `fl
 The difference is the `name` column from the `airlines` table.
 
 ```{r}
-dm %>%
-  .[["flights"]] %>%
+dm$flights %>%
   names()
 
-dm %>%
-  .[["airlines"]] %>%
+dm$airlines %>%
   names()
 
 dm_joined %>%

--- a/vignettes/tech-dm-join.Rmd
+++ b/vignettes/tech-dm-join.Rmd
@@ -96,11 +96,11 @@ The difference is the `name` column from the `airlines` table.
 
 ```{r}
 dm %>%
-  tbl("flights") %>%
+  .[["flights"]] %>%
   names()
 
 dm %>%
-  tbl("airlines") %>%
+  .[["airlines"]] %>%
   names()
 
 dm_joined %>%


### PR DESCRIPTION
close https://github.com/cynkra/dm/issues/999

I have found many other calls to those functions but I decided to leave them - here goes my explanation:
- `dm_get_src()`
![image](https://user-images.githubusercontent.com/12943682/169566743-bc7997d2-87bb-473a-8e36-81cd7cfe7c66.png)
  - `R/` - only deprecated function itself
  - `scratch` - I have left your notes untouched
  - `tests/` - as you soft-deprecated then that means that you still expect it to work - would be good to keep that check

- `tbl()`
![image](https://user-images.githubusercontent.com/12943682/169565726-118c36e8-9f9f-43e2-8bef-4eeeff6f2bf5.png)
  - I left `demo/` directory as it is as I assume it's for demoes that already happened so this code is unlikely to be executed again. If yes - should be done on the current version at that point in time.
  - `R/` - only comments and deprecated function itself
  - `tests/` - same as above

- `src_tbls()`
![image](https://user-images.githubusercontent.com/12943682/169567119-4374adae-52c0-4d63-accd-3850cb296474.png)
  - `demo/` - as above
  - I think that the last occurence is intended to call `dplyr::src_tbls` (would be good to prefix though) - please confirm

- `copy_to()`
![image](https://user-images.githubusercontent.com/12943682/169567807-31d81fcb-440d-4c25-8b03-fc9af837a26e.png)
  - `R/` - same as above
  - `tests/` - same as above
  - `vignettes/` - here I probably need your help with assessment. Should it stay or not?