### PR TITLE
FIX: avoid NULL if no fks after disentangle

### DIFF
--- a/R/disentangle.R
+++ b/R/disentangle.R
@@ -31,5 +31,6 @@ dm_disentangle <- function(dm, start, quiet = FALSE) {
     left_join(fk_table, by = c("table" = "new_parent_table")) %>%
     select(-fks) %>%
     relocate(fks = new_fks, .after = pks) %>%
+    mutate(fks = vctrs::as_list_of(map(fks, ~ if (is.null(.x)) {new_fk()} else {.x}))) %>%
     new_dm3()
 }

--- a/R/disentangle.R
+++ b/R/disentangle.R
@@ -31,10 +31,6 @@ dm_disentangle <- function(dm, start, quiet = FALSE) {
     left_join(fk_table, by = c("table" = "new_parent_table")) %>%
     select(-fks) %>%
     relocate(fks = new_fks, .after = pks) %>%
-    mutate(fks = vctrs::as_list_of(map(fks, ~ if (is.null(.x)) {
-      new_fk()
-    } else {
-      .x
-    }))) %>%
+    mutate(fks = vctrs::as_list_of(map(fks, ~ .x %||% new_fk()))) %>%
     new_dm3()
 }

--- a/R/disentangle.R
+++ b/R/disentangle.R
@@ -31,6 +31,10 @@ dm_disentangle <- function(dm, start, quiet = FALSE) {
     left_join(fk_table, by = c("table" = "new_parent_table")) %>%
     select(-fks) %>%
     relocate(fks = new_fks, .after = pks) %>%
-    mutate(fks = vctrs::as_list_of(map(fks, ~ if (is.null(.x)) {new_fk()} else {.x}))) %>%
+    mutate(fks = vctrs::as_list_of(map(fks, ~ if (is.null(.x)) {
+      new_fk()
+    } else {
+      .x
+    }))) %>%
     new_dm3()
 }

--- a/R/validate.R
+++ b/R/validate.R
@@ -71,6 +71,8 @@ validate_dm <- function(x) {
     )
   }
 
+  check_no_nulls(def)
+
   invisible(x)
 }
 
@@ -138,6 +140,18 @@ check_one_zoom <- function(def, zoomed) {
     if (sum(!map_lgl(def$col_tracker_zoom, is_null)) != 0) {
       abort_dm_invalid("Key tracker for zoomed table activated despite `dm` not a `zoomed_dm`.")
     }
+  }
+}
+
+check_no_nulls <- function(def) {
+  check_no_nulls_col(def$fks, "foreign keys")
+  check_no_nulls_col(def$pks, "primary keys")
+  check_no_nulls_col(def$filters, "filter conditions")
+}
+
+check_no_nulls_col <- function(x, where) {
+  if (any(map_lgl(x, is.null))) {
+    abort_dm_invalid(paste0("Found `NULL` entry in ", where, "."))
   }
 }
 

--- a/tests/testthat/test-pack_join.R
+++ b/tests/testthat/test-pack_join.R
@@ -7,8 +7,9 @@ test_that("`pack_join()` works", {
   expect_snapshot(pack_join(df1, df3, by = c(key = "key3")))
   expect_snapshot(pack_join(df1, df3, by = c(key = "key3"), keep = TRUE))
 
+
   # fails with remote table
-  dm_fin <- dm_financial_sqlite()
+  dm_fin <- skip_if_error(dm_financial_sqlite())
   expect_snapshot_error(pack_join(df1, dm_fin$accounts, by = c(col1 = "id")))
   # unless copy = TRUE
   expect_snapshot(pack_join(df1, dm_fin$accounts, by = c(col1 = "id"), copy = TRUE))

--- a/tests/testthat/test-validate.R
+++ b/tests/testthat/test-validate.R
@@ -149,7 +149,11 @@ test_that("validator speaks up when something's wrong", {
   expect_dm_error(
     dm_for_filter() %>%
       dm_get_def() %>%
-      mutate(fks = vctrs::as_list_of(map2(fks, table, ~ if (.y == "tf_2") {NULL} else {.x}))) %>%
+      mutate(fks = vctrs::as_list_of(map2(fks, table, ~ if (.y == "tf_2") {
+        NULL
+      } else {
+        .x
+      }))) %>%
       new_dm3() %>%
       validate_dm(),
     "dm_invalid"
@@ -158,7 +162,11 @@ test_that("validator speaks up when something's wrong", {
   expect_dm_error(
     dm_for_filter() %>%
       dm_get_def() %>%
-      mutate(pks = vctrs::as_list_of(map2(pks, table, ~ if (.y == "tf_2") {NULL} else {.x}))) %>%
+      mutate(pks = vctrs::as_list_of(map2(pks, table, ~ if (.y == "tf_2") {
+        NULL
+      } else {
+        .x
+      }))) %>%
       new_dm3() %>%
       validate_dm(),
     "dm_invalid"
@@ -167,7 +175,11 @@ test_that("validator speaks up when something's wrong", {
   expect_dm_error(
     dm_for_filter() %>%
       dm_get_def() %>%
-      mutate(filters = vctrs::as_list_of(map2(filters, table, ~ if (.y == "tf_2") {NULL} else {.x}))) %>%
+      mutate(filters = vctrs::as_list_of(map2(filters, table, ~ if (.y == "tf_2") {
+        NULL
+      } else {
+        .x
+      }))) %>%
       new_dm3() %>%
       validate_dm(),
     "dm_invalid"

--- a/tests/testthat/test-validate.R
+++ b/tests/testthat/test-validate.R
@@ -145,6 +145,33 @@ test_that("validator speaks up when something's wrong", {
       validate_dm(),
     "dm_invalid"
   )
+
+  expect_dm_error(
+    dm_for_filter() %>%
+      dm_get_def() %>%
+      mutate(fks = vctrs::as_list_of(map2(fks, table, ~ if (.y == "tf_2") {NULL} else {.x}))) %>%
+      new_dm3() %>%
+      validate_dm(),
+    "dm_invalid"
+  )
+
+  expect_dm_error(
+    dm_for_filter() %>%
+      dm_get_def() %>%
+      mutate(pks = vctrs::as_list_of(map2(pks, table, ~ if (.y == "tf_2") {NULL} else {.x}))) %>%
+      new_dm3() %>%
+      validate_dm(),
+    "dm_invalid"
+  )
+
+  expect_dm_error(
+    dm_for_filter() %>%
+      dm_get_def() %>%
+      mutate(filters = vctrs::as_list_of(map2(filters, table, ~ if (.y == "tf_2") {NULL} else {.x}))) %>%
+      new_dm3() %>%
+      validate_dm(),
+    "dm_invalid"
+  )
 })
 
 test_that("validator speaks up (sqlite())", {


### PR DESCRIPTION
NULL appears in `def$fks`, need to avoid, otherwise something like this fails (and in general no valid dm is produced):
```
dm_disentangle(dm_nycflights13(cycle = TRUE), flights) %>% 
  dm_select_tbl(-`airports-1`)
```