### PR TITLE
docs: BS5 for greater readability

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -167,48 +167,42 @@ reference:
   - dm_validate
 
 navbar:
-  title: ~
-  type: default
-  left:
-  - text: Intro
-    href: articles/dm.html
-  - text: Reference
-    href: reference/index.html
-  - text: Tutorials
-    menu:
-    - text: Introduction to relational data models
-      href: articles/howto-dm-theory.html
-    - text: Create a dm object from data frames
-      href: articles/howto-dm-df.html
-    - text: Create a dm object from a database
-      href: articles/howto-dm-db.html
-    - text: Copy data to and from a database
-      href: articles/howto-dm-copy.html
-    - text: Insert, update or remove rows in a database
-      href: articles/howto-dm-rows.html
-  - text: Technical articles
-    menu:
-    - text: Joining in relational data models
-      href: articles/tech-dm-join.html
-    - text: Zooming and manipulating tables
-      href: articles/tech-dm-zoom.html
-    - text: Filtering in relational data models
-      href: articles/tech-dm-filter.html
-    - text: Visualizing dm objects
-      href: articles/tech-dm-draw.html
-    - text: Model verification - keys, constraints and normalization
-      href: articles/tech-dm-low-level.html
-    - text: Class 'dm' and basic operations
-      href: articles/tech-dm-class.html
-    - text: Function naming logic
-      href: articles/tech-dm-naming.html
-    - text: 'Migration guide: ''cdm'' -> ''dm'''
-      href: articles/tech-dm-cdm.html
-  - text: News
-    href: news/index.html
-  right:
-  - icon: fa-github fa-lg
-    href: https://github.com/cynkra/dm
+  structure:
+    left:  [intro, reference, tutorials, tech, news]
+    right: [search, github]
+  components:
+    tutorials:
+      text: Tutorials
+      menu:
+      - text: Introduction to relational data models
+        href: articles/howto-dm-theory.html
+      - text: Create a dm object from data frames
+        href: articles/howto-dm-df.html
+      - text: Create a dm object from a database
+        href: articles/howto-dm-db.html
+      - text: Copy data to and from a database
+        href: articles/howto-dm-copy.html
+      - text: Insert, update or remove rows in a database
+        href: articles/howto-dm-rows.html
+    tech:
+      text: Technical articles
+      menu:
+      - text: Joining in relational data models
+        href: articles/tech-dm-join.html
+      - text: Zooming and manipulating tables
+        href: articles/tech-dm-zoom.html
+      - text: Filtering in relational data models
+        href: articles/tech-dm-filter.html
+      - text: Visualizing dm objects
+        href: articles/tech-dm-draw.html
+      - text: Model verification - keys, constraints and normalization
+        href: articles/tech-dm-low-level.html
+      - text: Class 'dm' and basic operations
+        href: articles/tech-dm-class.html
+      - text: Function naming logic
+        href: articles/tech-dm-naming.html
+      - text: 'Migration guide: ''cdm'' -> ''dm'''
+        href: articles/tech-dm-cdm.html
 
 development:
   mode: auto

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -1,6 +1,7 @@
 url: https://cynkra.github.io/dm
 
 template:
+  bootstrap: 5
   assets:
   - pkgdown/assets
 


### PR DESCRIPTION
- bigger font
- search

IMHO #1064 should come after cynkratemplate itself uses BS5 and therefore has a search bar.

![image](https://user-images.githubusercontent.com/8360597/173329507-2e55d8b4-be4e-4c35-9b1b-6d1fb4363530.png)
