### PR TITLE
Exclude `information_schema` tables from dm by default if `schema = NULL`

### DIFF
--- a/R/dm_from_con.R
+++ b/R/dm_from_con.R
@@ -25,6 +25,7 @@
 #'
 #'   - `schema`: supported for MSSQL (default: `"dbo"`), Postgres (default: `"public"`), and MariaDB/MySQL
 #'     (default: current database). Learn the tables in a specific schema (or database for MariaDB/MySQL).
+#'     If NULL, tables from `"information_schema"` are not included.
 #'   - `dbname`: supported for MSSQL. Access different databases on the connected MSSQL-server;
 #'     default: active database.
 #'   - `table_type`: supported for Postgres (default: `"BASE TABLE"`). Specify the table type. Options are:

--- a/R/meta.R
+++ b/R/meta.R
@@ -254,6 +254,13 @@ filter_dm_meta <- function(dm_meta, catalog = NULL, schema = NULL) {
     table_constraints <- table_constraints %>% filter(table_schema %in% !!schema)
     key_column_usage <- key_column_usage %>% filter(table_schema %in% !!schema)
     constraint_column_usage <- constraint_column_usage %>% filter(table_schema %in% !!schema)
+  } else {
+    schemata <- schemata %>% filter(schema_name != "information_schema")
+    tables <- tables %>% filter(table_schema != "information_schema")
+    columns <- columns %>% filter(table_schema != "information_schema")
+    table_constraints <- table_constraints %>% filter(table_schema != "information_schema")
+    key_column_usage <- key_column_usage %>% filter(table_schema != "information_schema")
+    constraint_column_usage <- constraint_column_usage %>% filter(table_schema != "information_schema")
   }
 
   dm(
@@ -285,6 +292,10 @@ filter_dm_meta_simple <- function(dm_meta, catalog = NULL, schema = NULL) {
     schemata <- schemata %>% filter(schema_name %in% !!schema)
     tables <- tables %>% filter(table_schema %in% !!schema)
     columns <- columns %>% filter(table_schema %in% !!schema)
+  } else {
+    schemata <- schemata %>% filter(schema_name != "information_schema")
+    tables <- tables %>% filter(table_schema != "information_schema")
+    columns <- columns %>% filter(table_schema != "information_schema")
   }
 
   dm(schemata, tables, columns) %>%

--- a/man/dm_from_con.Rd
+++ b/man/dm_from_con.Rd
@@ -24,6 +24,7 @@ Additional parameters for the schema learning query.
 \itemize{
 \item \code{schema}: supported for MSSQL (default: \code{"dbo"}), Postgres (default: \code{"public"}), and MariaDB/MySQL
 (default: current database). Learn the tables in a specific schema (or database for MariaDB/MySQL).
+If NULL, tables from \code{"information_schema"} are not included.
 \item \code{dbname}: supported for MSSQL. Access different databases on the connected MSSQL-server;
 default: active database.
 \item \code{table_type}: supported for Postgres (default: \code{"BASE TABLE"}). Specify the table type. Options are:

--- a/man/dm_from_src.Rd
+++ b/man/dm_from_src.Rd
@@ -24,6 +24,7 @@ Additional parameters for the schema learning query.
 \itemize{
 \item \code{schema}: supported for MSSQL (default: \code{"dbo"}), Postgres (default: \code{"public"}), and MariaDB/MySQL
 (default: current database). Learn the tables in a specific schema (or database for MariaDB/MySQL).
+If NULL, tables from \code{"information_schema"} are not included.
 \item \code{dbname}: supported for MSSQL. Access different databases on the connected MSSQL-server;
 default: active database.
 \item \code{table_type}: supported for Postgres (default: \code{"BASE TABLE"}). Specify the table type. Options are:


### PR DESCRIPTION
Addressing #366.  Does not address case of MSSQL using `dbname` instead of schema (yet), as I'm unfamiliar with how that differs.