### PR TITLE
Add scratch/code_generation_middleware_2.R to snapshot tests

### DIFF
--- a/tests/testthat/_snaps/enum-ops.md
+++ b/tests/testthat/_snaps/enum-ops.md
@@ -81,6 +81,138 @@
     Output
       dm_add_pk(., parent, a)
 
+# snapshot of code_generation_middleware_2.R is unchanged
+
+    Code
+      parent <- tibble(a = c(1L, 1:3), b = -1)
+      child <- tibble(a = 1:4, c = 3)
+      dm <- dm(parent, child)
+      ops <- enum_ops(dm)
+      ops
+    Output
+      $input
+      $input$dm
+      -- Metadata --------------------------------------------------------------------
+      Tables: `parent`, `child`
+      Columns: 4
+      Primary keys: 0
+      Foreign keys: 0
+      
+      
+      $single
+      $single$op_name
+      [1] "dm_rm_fk"
+      
+      
+      $multiple
+      $multiple$table_names
+      [1] "parent" "child" 
+      
+      
+    Code
+      ops$multiple
+    Output
+      $table_names
+      [1] "parent" "child" 
+      
+    Code
+      user_choice <- list(table_names = "parent")
+      ops_2 <- exec(enum_ops, !!!ops$input, !!!user_choice)
+      ops_2
+    Output
+      $input
+      $input$dm
+      -- Metadata --------------------------------------------------------------------
+      Tables: `parent`, `child`
+      Columns: 4
+      Primary keys: 0
+      Foreign keys: 0
+      
+      $input$table_names
+      [1] "parent"
+      
+      
+      $single
+      $single$op_name
+      [1] "dm_add_pk" "dm_rm_fk" 
+      
+      
+      $multiple
+      $multiple$column_names
+      [1] "a" "b"
+      
+      
+    Code
+      ops_2$single
+    Output
+      $op_name
+      [1] "dm_add_pk" "dm_rm_fk" 
+      
+    Code
+      user_choice_2 <- list(op_name = "dm_add_pk")
+      ops_3 <- exec(enum_ops, !!!ops_2$input, !!!user_choice_2)
+      ops_3
+    Output
+      $input
+      $input$dm
+      -- Metadata --------------------------------------------------------------------
+      Tables: `parent`, `child`
+      Columns: 4
+      Primary keys: 0
+      Foreign keys: 0
+      
+      $input$op_name
+      [1] "dm_add_pk"
+      
+      $input$table_names
+      [1] "parent"
+      
+      
+      $single
+      named list()
+      
+      $multiple
+      $multiple$column_names
+      [1] "a" "b"
+      
+      
+    Code
+      ops_3$multiple
+    Output
+      $column_names
+      [1] "a" "b"
+      
+    Code
+      user_choice_3 <- list(column_names = c("a"))
+      ops_4 <- exec(enum_ops, !!!ops_3$input, !!!user_choice_3)
+      ops_4
+    Output
+      $input
+      $input$dm
+      -- Metadata --------------------------------------------------------------------
+      Tables: `parent`, `child`
+      Columns: 4
+      Primary keys: 0
+      Foreign keys: 0
+      
+      $input$table_names
+      [1] "parent"
+      
+      $input$column_names
+      [1] "a"
+      
+      $input$op_name
+      [1] "dm_add_pk"
+      
+      
+      $call
+      dm_add_pk(., parent, a)
+      
+    Code
+      ops_4$call
+    Output
+      dm_add_pk(., parent, a)
+
 # snapshot of code_generation_middleware_3.R is unchanged
 
     Code

--- a/tests/testthat/test-enum-ops.R
+++ b/tests/testthat/test-enum-ops.R
@@ -25,6 +25,79 @@ test_that("snapshot of code_generation_middleware.R is unchanged", {
   })
 })
 
+test_that("snapshot of code_generation_middleware_2.R is unchanged", {
+  expect_snapshot({
+    parent <- tibble(a = c(1L, 1:3), b = -1)
+    child <- tibble(a = 1:4, c = 3)
+
+    dm <- dm(parent, child)
+
+    # This is done by the Shiny app
+    ops <- enum_ops(dm)
+    ops
+
+    ops$multiple
+
+    # Choice options (the user can choose arbitrarily many):
+    user_choice <- list(
+      table_names = "parent"
+    )
+
+    # Called by the Shiny app, always with the same pattern:
+    ops_2 <- exec(
+      # Always enum_ops
+      enum_ops,
+      # Returned by the previous call to enum_ops()
+      !!!ops$input,
+      # Input selected by the user
+      !!!user_choice
+    )
+    # Same as:
+    # ops_2 <- enum_ops(dm = ops$input$dm, table_names = table_names)
+
+    ops_2
+
+    # Choice options (the user can choose only one of those):
+    ops_2$single
+
+    # User's choice:
+    user_choice_2 <- list(op_name = "dm_add_pk")
+
+    # Called by the Shiny app, always with the same pattern:
+    ops_3 <- exec(
+      # Always enum_ops
+      enum_ops,
+      # Returned by the previous call to enum_ops()
+      !!!ops_2$input,
+      # Input selected by the user
+      !!!user_choice_2
+    )
+
+    ops_3
+
+    # Choice options (the user can choose arbitrarily many):
+    ops_3$multiple
+
+    # User's choice:
+    user_choice_3 <- list(column_names = c("a"))
+
+    # Called by the Shiny app, always with the same pattern:
+    ops_4 <- exec(
+      # Always enum_ops
+      enum_ops,
+      # Returned by the previous call to enum_ops()
+      !!!ops_3$input,
+      # Input selected by the user
+      !!!user_choice_3
+    )
+
+    ops_4
+
+    # Final result:
+    ops_4$call
+  })
+})
+
 test_that("snapshot of code_generation_middleware_3.R is unchanged", {
   expect_snapshot({
     parent <- tibble(a = c(1L, 1:3), b = -1)


### PR DESCRIPTION
Cf. #1155, #1154.

This adds the missing snapshot test of `enum_ops()`, prior to its simplification #1162.