### PR TITLE
Fix regression: compound columns must be grouped with c()

### DIFF
--- a/R/enum_ops.R
+++ b/R/enum_ops.R
@@ -61,7 +61,8 @@ enum <- function(op) {
 
 enum_ops_dm_add_pk <- function(dm, tbls, cols) {
   stopifnot(length(tbls) == 1)
-  out <- list(call = expr(dm_add_pk(., !!sym(tbls), !!!syms(cols))))
+  columns <- if (length(cols) == 1) sym(cols) else expr(c(!!!syms(cols)))
+  out <- list(call = expr(dm_add_pk(., !!sym(tbls), !!columns)))
   if (dm_has_pk(eval_tidy(dm), !!sym(tbls))) {
     out[["call"]] <- as.call(c(as.list(out[["call"]]), force = TRUE))
     out[["confirmation_message"]] <- paste(

--- a/tests/testthat/_snaps/enum-ops.md
+++ b/tests/testthat/_snaps/enum-ops.md
@@ -80,6 +80,11 @@
         call
     Output
       dm_add_pk(., parent, a)
+    Code
+      enum_ops(dm, op_name = "dm_add_pk", table_names = "parent", column_names = c(
+        "a", "b"))$call
+    Output
+      dm_add_pk(., parent, c(a, b))
 
 # snapshot of code_generation_middleware_2.R is unchanged
 

--- a/tests/testthat/test-enum-ops.R
+++ b/tests/testthat/test-enum-ops.R
@@ -22,6 +22,7 @@ test_that("snapshot of code_generation_middleware.R is unchanged", {
     enum_ops(dm, op_name = "dm_add_pk", table_names = "parent")
 
     enum_ops(dm, op_name = "dm_add_pk", table_names = "parent", column_names = "a")$call
+    enum_ops(dm, op_name = "dm_add_pk", table_names = "parent", column_names = c("a", "b"))$call
   })
 })
 


### PR DESCRIPTION
#1162 introduced a regression: it produced incorrect `dm_add_pk()` calls for compound primary keys, e.g., `dm_add_pk(., table, col1, col2)` instead of `dm_add_pk(., table, c(col1, col2))`.