### PR TITLE
fix: mariaDB key guessing in financial example

### DIFF
--- a/R/meta.R
+++ b/R/meta.R
@@ -248,7 +248,7 @@ filter_dm_meta <- function(dm_meta, catalog = NULL, schema = NULL) {
     table_constraints <- table_constraints %>% filter(table_schema %in% !!schema)
     key_column_usage <- key_column_usage %>% filter(table_schema %in% !!schema)
     constraint_column_usage <- constraint_column_usage %>% filter(table_schema %in% !!schema)
-  } else if (!is.na(schema) && is_mariadb(dm_get_con(dm_meta))) {
+  } else if (!isTRUE(is.na(schema)) && is_mariadb(dm_get_con(dm_meta))) {
     schemata <- schemata %>% filter(schema_name == DATABASE() | is.na(DATABASE()))
     tables <- tables %>% filter(table_schema == DATABASE() | is.na(DATABASE()))
     columns <- columns %>% filter(table_schema == DATABASE() | is.na(DATABASE()))

--- a/tests/testthat/_snaps/learn.md
+++ b/tests/testthat/_snaps/learn.md
@@ -367,3 +367,42 @@
         ]
       }
 
+# dm_from_con() with mariaDB
+
+    
+
+---
+
+    Code
+      dm::dm_get_all_fks(my_dm)
+    Output
+      # A tibble: 8 x 5
+        child_table child_fk_cols parent_table parent_key_cols on_delete
+        <chr>       <keys>        <chr>        <keys>          <chr>    
+      1 disps       account_id    accounts     id              no_action
+      2 loans       account_id    accounts     id              no_action
+      3 orders      account_id    accounts     id              no_action
+      4 trans       account_id    accounts     id              no_action
+      5 disps       client_id     clients      id              no_action
+      6 cards       disp_id       disps        id              no_action
+      7 accounts    district_id   districts    id              no_action
+      8 clients     district_id   districts    id              no_action
+
+---
+
+    Code
+      dm::dm_get_all_pks(my_dm)
+    Output
+      # A tibble: 9 x 2
+        table     pk_col
+        <chr>     <keys>
+      1 accounts  id    
+      2 cards     id    
+      3 clients   id    
+      4 disps     id    
+      5 districts id    
+      6 loans     id    
+      7 orders    id    
+      8 tkeys     id    
+      9 trans     id    
+

--- a/tests/testthat/test-learn.R
+++ b/tests/testthat/test-learn.R
@@ -474,14 +474,13 @@ test_that("dm_meta() contents", {
 test_that("dm_from_con() with mariaDB", {
   skip_if_offline()
   my_db <- RMariaDB::dbConnect(
-  RMariaDB::MariaDB(),
-  username = "guest",
-  password = "relational",
-  dbname = "Financial_ijs",
-  host = "relational.fit.cvut.cz"
-)
+    RMariaDB::MariaDB(),
+    username = "guest",
+    password = "relational",
+    dbname = "Financial_ijs",
+    host = "relational.fit.cvut.cz"
+  )
   expect_snapshot_output(my_dm <- dm_from_con(my_db))
   expect_snapshot(dm::dm_get_all_fks(my_dm))
   expect_snapshot(dm::dm_get_all_pks(my_dm))
-
 })

--- a/tests/testthat/test-learn.R
+++ b/tests/testthat/test-learn.R
@@ -470,3 +470,18 @@ test_that("dm_meta() contents", {
       writeLines()
   })
 })
+
+test_that("dm_from_con() with mariaDB", {
+  skip_if_offline()
+  my_db <- RMariaDB::dbConnect(
+  RMariaDB::MariaDB(),
+  username = "guest",
+  password = "relational",
+  dbname = "Financial_ijs",
+  host = "relational.fit.cvut.cz"
+)
+  expect_snapshot_output(my_dm <- dm_from_con(my_db))
+  expect_snapshot(dm::dm_get_all_fks(my_dm))
+  expect_snapshot(dm::dm_get_all_pks(my_dm))
+
+})


### PR DESCRIPTION
Fix #1168

The branch name says it all. :sweat_smile: 

I'll add a test, leaving this as draft while I add it. (tested interactively)

``` r
library(RMariaDB)

my_db <- dbConnect(
  MariaDB(),
  username = "guest",
  password = "relational",
  dbname = "Financial_ijs",
  host = "relational.fit.cvut.cz"
)
library("dm")
#> 
#> Attachement du package : 'dm'
#> L'objet suivant est masqué depuis 'package:stats':
#> 
#>     filter
my_dm <- dm_from_con(my_db)
#> Keys queried successfully, use `learn_keys = TRUE` to mute this message.
```

<sup>Created on 2022-06-27 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>