### PR TITLE
get_src_table_names() uses dm_meta()

### DIFF
--- a/R/db-helpers.R
+++ b/R/db-helpers.R
@@ -124,8 +124,8 @@ find_name_clashes <- function(old, new) {
 
 #' @autoglobal
 get_src_tbl_names <- function(src, schema = NULL, dbname = NULL) {
-  if (!is_mssql(src) && !is_postgres(src) && !is_mariadb(src)) {
-    warn_if_arg_not(schema, only_on = c("MSSQL", "Postgres", "MariaDB"))
+  if (!is_mssql(src) && !is_postgres(src) && !is_mariadb(src) && !is_duckdb(src)) {
+    warn_if_arg_not(schema, only_on = c("MSSQL", "Postgres", "MariaDB", "DuckDB"))
     warn_if_arg_not(dbname, only_on = "MSSQL")
     tables <- src_tbls(src)
     out <- purrr::map(tables, ~ DBI::Id(table = .x))
@@ -139,26 +139,10 @@ get_src_tbl_names <- function(src, schema = NULL, dbname = NULL) {
     check_param_class(schema, "character")
   }
 
-  if (is_mssql(src)) {
-    # MSSQL
-    schema <- schema_mssql(con, schema)
-    dbname_sql <- dbname_mssql(con, dbname)
-    names_table <- get_names_table_mssql(con, dbname_sql)
-    dbname <- names(dbname_sql)
-  } else if (is_postgres(src)) {
-    # Postgres
-    schema <- schema_postgres(con, schema)
-    dbname <- warn_if_arg_not(dbname, only_on = "MSSQL")
-    names_table <- get_names_table_postgres(con)
-  } else if (is_mariadb(src)) {
-    # MariaDB
-    schema <- schema_mariadb(con, schema)
-    dbname <- warn_if_arg_not(dbname, only_on = "MSSQL")
-    names_table <- get_names_table_mariadb(con)
-  }
+  meta <- dm_meta(con, catalog = dbname, schema = schema, simple = TRUE)
 
-  names_table <- names_table %>%
-    filter(schema_name %in% !!(if (inherits(schema, "sql")) glue_sql_collapse(schema) else schema)) %>%
+  meta$tables %>%
+    rename(table_schema = table_name) %>%
     collect() %>%
     # create remote names for the tables in the given schema (name is table_name; cannot be duplicated within a single schema)
     mutate(remote_name = schema_if(schema_name, table_name, con, dbname))
@@ -231,25 +215,3 @@ dbname_mssql <- function(con, dbname) {
   }
   set_names(dbname_sql, dbname)
 }
-
-
-get_names_table_mssql <- function(con, dbname_sql) {
-  tbl(
-    con,
-    sql(glue::glue("
-      SELECT tabs.name AS table_name, schemas.name AS schema_name
-      FROM {dbname_sql}sys.tables tabs
-      INNER JOIN {dbname_sql}sys.schemas schemas ON
-      tabs.schema_id = schemas.schema_id
-    "))
-  )
-}
-
-get_names_table_postgres <- function(con) {
-  tbl(
-    con,
-    sql("SELECT table_schema as schema_name, table_name as table_name from information_schema.tables")
-  )
-}
-
-get_names_table_mariadb <- get_names_table_postgres

--- a/R/db-helpers.R
+++ b/R/db-helpers.R
@@ -142,7 +142,7 @@ get_src_tbl_names <- function(src, schema = NULL, dbname = NULL) {
   meta <- dm_meta(con, catalog = dbname, schema = schema, simple = TRUE)
 
   meta$tables %>%
-    rename(table_schema = table_name) %>%
+    rename(schema_name = table_name) %>%
     collect() %>%
     # create remote names for the tables in the given schema (name is table_name; cannot be duplicated within a single schema)
     mutate(remote_name = schema_if(schema_name, table_name, con, dbname))

--- a/R/globals.R
+++ b/R/globals.R
@@ -17,7 +17,8 @@ utils::globalVariables(c(
   "index_name", # <build_copy_queries>
   "columns", # <build_copy_queries>
   "table_name", # <get_src_tbl_names>
-  "table_schema", # <get_src_tbl_names>
+  "schema_name", # <get_src_tbl_names>
+  "remote_name", # <get_src_tbl_names>
   "child_uuid", # <fks_df_from_keys_info>
   "parent_uuid", # <fks_df_from_keys_info>
   "child_fk_cols", # <fks_df_from_keys_info>

--- a/R/globals.R
+++ b/R/globals.R
@@ -16,9 +16,8 @@ utils::globalVariables(c(
   "remote_name_unquoted", # <build_copy_queries>
   "index_name", # <build_copy_queries>
   "columns", # <build_copy_queries>
-  "schema_name", # <get_src_tbl_names>
   "table_name", # <get_src_tbl_names>
-  "remote_name", # <get_src_tbl_names>
+  "table_schema", # <get_src_tbl_names>
   "child_uuid", # <fks_df_from_keys_info>
   "parent_uuid", # <fks_df_from_keys_info>
   "child_fk_cols", # <fks_df_from_keys_info>

--- a/man/utils_table_manipulation.Rd
+++ b/man/utils_table_manipulation.Rd
@@ -13,7 +13,8 @@
 \item{x}{object of class \code{dm_zoomed}}
 
 \item{n}{an integer vector of length up to \code{dim(x)} (or 1,
-    for non-dimensioned objects). Values specify the indices to be
+    for non-dimensioned objects).  A \code{logical} is silently coerced to
+    integer.  Values specify the indices to be
     selected in the corresponding dimension (or along the length) of the
     object. A positive value of \code{n[i]} includes the first/last
     \code{n[i]} indices in that dimension, while a negative value

--- a/man/utils_table_manipulation.Rd
+++ b/man/utils_table_manipulation.Rd
@@ -13,8 +13,7 @@
 \item{x}{object of class \code{dm_zoomed}}
 
 \item{n}{an integer vector of length up to \code{dim(x)} (or 1,
-    for non-dimensioned objects).  A \code{logical} is silently coerced to
-    integer.  Values specify the indices to be
+    for non-dimensioned objects). Values specify the indices to be
     selected in the corresponding dimension (or along the length) of the
     object. A positive value of \code{n[i]} includes the first/last
     \code{n[i]} indices in that dimension, while a negative value

--- a/tests/testthat/test-db-helpers.R
+++ b/tests/testthat/test-db-helpers.R
@@ -164,7 +164,6 @@ test_that("DB helpers work for Postgres", {
 
 test_that("DB helpers work for other DBMS than MSSQL or Postgres", {
   # FIXME: Why does it fail for those databases?
-  skip_if_src("mssql", "postgres")
   skip_if_not_installed("dbplyr")
 
   # for other DBMS than "MSSQL" or "Postgrs", get_src_tbl_names() translates to `src_tbls_impl()`
@@ -178,24 +177,13 @@ test_that("DB helpers work for other DBMS than MSSQL or Postgres", {
     try(dbExecute(con_db, "DROP TABLE test_db_helpers"))
   })
 
-  skip_if_src("maria")
+  expect_true("test_db_helpers" %in% names(get_src_tbl_names(my_db_test_src())))
 
-  # test for 2 warnings and if the output contains the new table
-  expect_dm_warning(
-    expect_dm_warning(
-      expect_true("test_db_helpers" %in% names(get_src_tbl_names(my_db_test_src(), schema = "schema", dbname = "dbname"))),
-      class = "arg_not"
-    ),
-    class = "arg_not"
-  )
+  # test that the output doesn't contain the new tabe if dbname and schema are passed
+  expect_false("test_db_helpers" %in% names(get_src_tbl_names(my_db_test_src(), schema = "schema", dbname = "dbname")))
 
-  skip_if_src("mssql", "postgres")
-
-  # test for warning and if the output contains the new table
-  expect_dm_warning(
-    expect_true("test_db_helpers" %in% names(get_src_tbl_names(my_db_test_src(), dbname = "dbname"))),
-    class = "arg_not"
-  )
+  # test that the output doesn't contain the new tabe if dbname is passed
+  expect_false("test_db_helpers" %in% names(get_src_tbl_names(my_db_test_src(), dbname = "dbname")))
 })
 
 test_that("find name clashes", {


### PR DESCRIPTION
This is more complicated than it should be, because `get_src_table_names()` does some implicit filtering on the default schema, and the learn tests fail (but in parallel only):

```sh
DM_TEST_SRC=postgres R -q -e 'testthat::test_local()'
```
