### PR TITLE
fix: honor unique keys in parent table for weak fks

### DIFF
--- a/R/dm.R
+++ b/R/dm.R
@@ -845,12 +845,12 @@ print_glimpse_table_pk <- function(x, table_name, width) {
   }
 }
 
-collapse_key_names <- function(keys, tab = FALSE) {
+collapse_key_names <- function(keys, tab = FALSE, MAX_COMMAS = Inf) {
   tab <- ifelse(tab, "  ", "")
   if (length(keys) > 1L) {
-    paste0(tab, "(", paste0(tick(keys), collapse = ", "), ")")
+    paste0(tab, "(", commas(tick(keys), MAX_COMMAS), ")")
   } else {
-    paste0(tab, tick(keys), collapse = ", ")
+    tick(keys)
   }
 }
 

--- a/R/dm.R
+++ b/R/dm.R
@@ -850,7 +850,7 @@ collapse_key_names <- function(keys, tab = FALSE, MAX_COMMAS = Inf) {
   if (length(keys) > 1L) {
     paste0(tab, "(", commas(tick(keys), MAX_COMMAS), ")")
   } else {
-    tick(keys)
+    paste0(tab, tick(keys))
   }
 }
 

--- a/R/examine-constraints.R
+++ b/R/examine-constraints.R
@@ -78,7 +78,7 @@ print.dm_examine_constraints <- function(x, ...) {
       mutate(text = paste0(
         "Table ", tick(table), ": ",
         kind_to_long(kind), " ",
-        format(map(problem_df$columns, tick), justify = "none"),
+        format(map(problem_df$columns, collapse_key_names), justify = "none"),
         into,
         ": ", problem
       )) %>%

--- a/R/examine-constraints.R
+++ b/R/examine-constraints.R
@@ -94,7 +94,11 @@ kind_to_long <- function(kind) {
 }
 
 check_pk_constraints <- function(dm, progress = NA, top_level_fun = NULL) {
-  pks <- dm_get_all_pks_impl(dm)
+  pks <- dm_get_all_pks_impl(dm) %>%
+    union(
+      dm_get_all_fks_impl(dm) %>%
+        select(table = parent_table, pk_col = parent_key_cols)
+    )
   if (nrow(pks) == 0) {
     return(tibble(
       table = character(),

--- a/R/foreign-keys.R
+++ b/R/foreign-keys.R
@@ -571,9 +571,10 @@ check_fk <- function(t1, t1_name, colname, t2, t2_name, pk) {
     glue("{res_tbl$value} ({res_tbl$n})"),
     capped = TRUE
   )
+
   glue(
     "values of ",
-    "{commas(tick(glue('{t1_name}${colname}')), Inf)} not in {commas(tick(glue('{t2_name}${pk}')), Inf)}: {vals_formatted}"
+    "{collapse_key_names(glue('{t1_name}${colname}'))} not in {collapse_key_names(glue('{t2_name}${pk}'))}: {vals_formatted}"
   )
 }
 

--- a/tests/testthat/_snaps/examine-constraints.md
+++ b/tests/testthat/_snaps/examine-constraints.md
@@ -65,6 +65,6 @@
       ! Unsatisfied constraints:
     Output
       * Table `dc_3`: primary key (`b`, `a`): has duplicate values: e, 5 (2)
-      * Table `dc_4`: foreign key (`b`, `a`) into table `dc_3`: values of (`tbl_1$a`, `tbl_1$x`) not in (`tbl_2$id`, `tbl_2$x`): 4, E (1), 5, F (1)
+      * Table `dc_4`: foreign key (`b`, `a`) into table `dc_3`: values of (`dc_4$b`, `dc_4$a`) not in (`dc_3$b`, `dc_3$a`): f, 6 (1)
       * Table `dc_6`: foreign key `c` into table `dc_1`: values of `dc_6$c` not in `dc_1$a`: 6 (1)
 

--- a/tests/testthat/_snaps/examine-constraints.md
+++ b/tests/testthat/_snaps/examine-constraints.md
@@ -57,3 +57,14 @@
       * Table `tbl_1`: foreign key `a`, `x` into table `tbl_2`: values of `tbl_1$a`, `tbl_1$x` not in `tbl_2$id`, `tbl_2$x`: 4, E (1), 5, F (1)
       * Table `tbl_1`: foreign key `b` into table `tbl_3`: values of `tbl_1$b` not in `tbl_3$id`: 1 (1), 5 (1)
 
+# Non-explicit PKs should be tested too
+
+    Code
+      dm_for_card() %>% dm_examine_constraints()
+    Message
+      ! Unsatisfied constraints:
+    Output
+      * Table `dc_3`: primary key `b`, `a`: has duplicate values: e, 5 (2)
+      * Table `dc_4`: foreign key `b`, `a` into table `dc_3`: values of `dc_4$b`, `dc_4$a` not in `dc_3$b`, `dc_3$a`: f, 6 (1)
+      * Table `dc_6`: foreign key `c` into table `dc_1`: values of `dc_6$c` not in `dc_1$a`: 6 (1)
+

--- a/tests/testthat/_snaps/examine-constraints.md
+++ b/tests/testthat/_snaps/examine-constraints.md
@@ -64,7 +64,7 @@
     Message
       ! Unsatisfied constraints:
     Output
-      * Table `dc_3`: primary key `b`, `a`: has duplicate values: e, 5 (2)
-      * Table `dc_4`: foreign key `b`, `a` into table `dc_3`: values of `dc_4$b`, `dc_4$a` not in `dc_3$b`, `dc_3$a`: f, 6 (1)
+      * Table `dc_3`: primary key (`b`, `a`): has duplicate values: e, 5 (2)
+      * Table `dc_4`: foreign key (`b`, `a`) into table `dc_3`: values of `dc_4$b`, `dc_4$a` not in `dc_3$b`, `dc_3$a`: f, 6 (1)
       * Table `dc_6`: foreign key `c` into table `dc_1`: values of `dc_6$c` not in `dc_1$a`: 6 (1)
 

--- a/tests/testthat/_snaps/examine-constraints.md
+++ b/tests/testthat/_snaps/examine-constraints.md
@@ -52,9 +52,9 @@
     Message
       ! Unsatisfied constraints:
     Output
-      * Table `tbl_2`: primary key `id`, `x`: has duplicate values: 3, E (2)
+      * Table `tbl_2`: primary key (`id`, `x`): has duplicate values: 3, E (2)
       * Table `tbl_3`: primary key `id`: has duplicate values: 4 (2)
-      * Table `tbl_1`: foreign key `a`, `x` into table `tbl_2`: values of `tbl_1$a`, `tbl_1$x` not in `tbl_2$id`, `tbl_2$x`: 4, E (1), 5, F (1)
+      * Table `tbl_1`: foreign key (`a`, `x`) into table `tbl_2`: values of (`tbl_1$a`, `tbl_1$x`) not in (`tbl_2$id`, `tbl_2$x`): 4, E (1), 5, F (1)
       * Table `tbl_1`: foreign key `b` into table `tbl_3`: values of `tbl_1$b` not in `tbl_3$id`: 1 (1), 5 (1)
 
 # Non-explicit PKs should be tested too
@@ -65,6 +65,6 @@
       ! Unsatisfied constraints:
     Output
       * Table `dc_3`: primary key (`b`, `a`): has duplicate values: e, 5 (2)
-      * Table `dc_4`: foreign key (`b`, `a`) into table `dc_3`: values of `dc_4$b`, `dc_4$a` not in `dc_3$b`, `dc_3$a`: f, 6 (1)
+      * Table `dc_4`: foreign key (`b`, `a`) into table `dc_3`: values of (`tbl_1$a`, `tbl_1$x`) not in (`tbl_2$id`, `tbl_2$x`): 4, E (1), 5, F (1)
       * Table `dc_6`: foreign key `c` into table `dc_1`: values of `dc_6$c` not in `dc_1$a`: 6 (1)
 

--- a/tests/testthat/test-examine-constraints.R
+++ b/tests/testthat/test-examine-constraints.R
@@ -74,3 +74,13 @@ test_that("output for compound keys", {
       dm_examine_constraints()
   })
 })
+
+# Test unique keys for weak FK (no explicit PK set) -----------------------
+
+test_that("Non-explicit PKs should be tested too", {
+  expect_snapshot(
+    # dm_for_card() has no PKs set, only FKs
+    dm_for_card() %>%
+      dm_examine_constraints()
+  )
+})

--- a/tests/testthat/test-examine-constraints.R
+++ b/tests/testthat/test-examine-constraints.R
@@ -66,7 +66,6 @@ test_that("output as tibble", {
 # test compound keys ------------------------------------------------------
 
 test_that("output for compound keys", {
-  # FIXME: COMPOUND: Need proper test
   skip_if_remote_src()
 
   expect_snapshot({

--- a/tests/testthat/test-examine-constraints.R
+++ b/tests/testthat/test-examine-constraints.R
@@ -78,9 +78,11 @@ test_that("output for compound keys", {
 # Test unique keys for weak FK (no explicit PK set) -----------------------
 
 test_that("Non-explicit PKs should be tested too", {
-  expect_snapshot(
+  skip_if_ide()
+
+  expect_snapshot({
     # dm_for_card() has no PKs set, only FKs
     dm_for_card() %>%
       dm_examine_constraints()
-  )
+  })
 })


### PR DESCRIPTION
a test is implemented as well.

In addition brings printed output of compound keys in line with what was done for `glimpse.dm()` in #1161

closes #1131 