### PR TITLE
fix: don't print rule in glimpse.dm() for empty_dm()

### DIFF
--- a/R/dm.R
+++ b/R/dm.R
@@ -739,11 +739,10 @@ as.list.zoomed_dm <- function(x, ...) {
 #' @export
 glimpse.dm <- function(x, width = NULL, ...) {
   glimpse_width <- width %||% getOption("width")
-
   table_names_list <- names(dm_get_tables_impl(x))
 
   print_glimpse_table_meta(x, glimpse_width)
-  print_rule_between_tables()
+  if (!is_empty(table_names_list)) {print_rule_between_tables()}
   walk(table_names_list, ~ print_glimpse_table(x, .x, glimpse_width, ...))
 
   invisible(x)

--- a/tests/testthat/_snaps/dm.md
+++ b/tests/testthat/_snaps/dm.md
@@ -144,8 +144,6 @@
       glimpse(empty_dm())
     Output
       dm of 0 tables
-      
-      --------------------------------------------------------------------------------
     Code
       glimpse(dm_for_disambiguate())
     Output


### PR DESCRIPTION
minor oversight in #1161 