### PR TITLE
api: `dm()` accepts dm objects, deprecate `dm_bind()` and `dm_add_tbl()`

### DIFF
--- a/R/add-tbl.R
+++ b/R/add-tbl.R
@@ -30,7 +30,8 @@
 #'   dm_add_tbl(new_tbl = mtcars, new_tbl = iris)
 dm_add_tbl <- function(dm, ..., repair = "unique", quiet = FALSE) {
   deprecate_soft("1.0.0", "dm_add_tbl()", "dm()",
-    details = 'Use `.name_repair = "unique"` if necessary.')
+    details = 'Use `.name_repair = "unique"` if necessary.'
+  )
 
   check_not_zoomed(dm)
 

--- a/R/add-tbl.R
+++ b/R/add-tbl.R
@@ -90,7 +90,7 @@ dm_add_tbl_impl <- function(dm, tbls, table_name, filters = list_of(new_filter()
 #'
 #' @return The `dm` without the removed table(s) that were present in the initial `dm`.
 #'
-#' @seealso [dm_add_tbl()], [dm_select_tbl()]
+#' @seealso [dm()], [dm_select_tbl()]
 #'
 #' @param dm A [`dm`] object.
 #' @param ... One or more unquoted table names to remove from the `dm`.
@@ -126,7 +126,7 @@ check_new_tbls <- function(dm, tbls) {
 #' For now, the column names must be identical.
 #' This restriction may be levied optionally in the future.
 #'
-#' @seealso [dm_add_tbl()], [dm_rm_tbl()]
+#' @seealso [dm()], [dm_rm_tbl()]
 #'
 #' @param dm A [`dm`] object.
 #' @param ... One or more tables to update in the `dm`.

--- a/R/add-tbl.R
+++ b/R/add-tbl.R
@@ -1,8 +1,14 @@
 #' Add tables to a [`dm`]
 #'
 #' @description
+#' `r lifecycle::badge("deprecated")`
+#'
 #' Adds one or more new tables to a [`dm`].
 #' Existing tables are not overwritten.
+#'
+#' @section Life cycle:
+#' This function is deprecated as of dm 1.0.0, because the same functionality
+#' is offered by [dm()] with `.name_repair = "unique"`.
 #'
 #' @return The initial `dm` with the additional table(s).
 #'
@@ -13,6 +19,8 @@
 #'   If no explicit name is given, the name of the expression is used.
 #' @inheritParams vctrs::vec_as_names
 #'
+#' @export
+#' @keywords internal
 #' @examples
 #' dm() %>%
 #'   dm_add_tbl(mtcars, flowers = iris)
@@ -20,8 +28,10 @@
 #' # renaming table names if necessary (depending on the `repair` argument)
 #' dm() %>%
 #'   dm_add_tbl(new_tbl = mtcars, new_tbl = iris)
-#' @export
 dm_add_tbl <- function(dm, ..., repair = "unique", quiet = FALSE) {
+  deprecate_soft("1.0.0", "dm_add_tbl()", "dm()",
+    details = 'Use `.name_repair = "unique"` if necessary.')
+
   check_not_zoomed(dm)
 
   new_names <- names(exprs(..., .named = TRUE))

--- a/R/bind.R
+++ b/R/bind.R
@@ -31,7 +31,7 @@ dm_bind <- function(..., repair = "check_unique", quiet = FALSE) {
   new_dm3(new_def)
 }
 
-dm_bind_impl <- function(dms, repair, quiet) {
+dm_bind_impl <- function(dms, repair, quiet, repair_arg = "", caller = caller_env()) {
   if (length(dms) == 0) {
     return(new_dm_def())
   }
@@ -44,15 +44,44 @@ dm_bind_impl <- function(dms, repair, quiet) {
 
   # repair table names
   table_names <- map(dms, src_tbls_impl) %>% flatten_chr()
-  new_table_names <- repair_names_vec(table_names, repair, quiet)
+  new_table_names <- vec_as_names(
+    table_names,
+    repair = repair,
+    quiet = quiet,
+    repair_arg = repair_arg,
+    call = caller
+  )
   # need to individually rename tables for each `dm`
   ntables_dms <- map(dms, length)
-  dms_indices <-
-    map2(lag(cumsum(ntables_dms), default = 0), map(ntables_dms, seq_len), `+`)
-  renaming_recipe <- map(dms_indices, ~ set_names(table_names[.x], new_table_names[.x]))
+  dms_indices <- map(ntables_dms, seq_len)
+  renaming_recipe <- map2(
+    dms_indices,
+    lag(cumsum(ntables_dms), default = 0),
+    ~ set_names(.x, new_table_names[.x + .y])
+  )
 
-  dms_renamed <- map2(dms, renaming_recipe, dm_rename_tbl)
+  dms_renamed <- map2(dms, renaming_recipe, bind_rename_tbl)
 
   new_defs <- map(dms_renamed, dm_get_def)
   vec_rbind(!!!new_defs)
+}
+
+bind_rename_tbl <- function(dm, renamed) {
+  if (length(dm) == 0) {
+    return(dm)
+  }
+
+  def <- dm_get_def(dm)
+
+  renamed_names <- set_names(def$table[renamed], names(renamed))
+
+  def %>%
+    bind_filter_recode_table_def(renamed) %>%
+    filter_recode_table_fks(renamed_names) %>%
+    new_dm3()
+}
+
+bind_filter_recode_table_def <- function(def, renamed) {
+  def$table[renamed] <- names(renamed)
+  def
 }

--- a/R/bind.R
+++ b/R/bind.R
@@ -1,6 +1,13 @@
 #' Merge several `dm`
 #'
+#' @description
+#' `r lifecycle::badge("deprecated")`
+#'
 #' Create a single `dm` from two or more `dm` objects.
+#'
+#' @section Life cycle:
+#' This function is deprecated as of dm 1.0.0, because the same functionality
+#' is offered by [dm()].
 #'
 #' @param ... `dm` objects to bind together.
 #' @inheritParams dm_add_tbl
@@ -15,6 +22,8 @@
 #' dm_2 <- dm(mtcars, iris)
 #' dm_bind(dm_1, dm_2)
 dm_bind <- function(..., repair = "check_unique", quiet = FALSE) {
+  deprecate_soft("1.0.0", "dm_bind()", "dm()")
+
   dms <- list2(...)
 
   new_def <- dm_bind_impl(dms, repair, quiet)

--- a/R/bind.R
+++ b/R/bind.R
@@ -19,6 +19,11 @@ dm_bind <- function(..., repair = "check_unique", quiet = FALSE) {
   if (dots_n(...) == 0) return(dm())
   dms <- list2(...)
 
+  new_def <- dm_bind_impl(dms, repair, quiet)
+  new_dm3(new_def)
+}
+
+dm_bind_impl <- function(dms, repair, quiet) {
   walk(dms, check_dm)
   walk(dms, check_not_zoomed)
   if (!all_same_source(map(dms, dm_get_tables_impl) %>% flatten())) {
@@ -37,6 +42,5 @@ dm_bind <- function(..., repair = "check_unique", quiet = FALSE) {
   dms_renamed <- map2(dms, renaming_recipe, dm_rename_tbl)
 
   new_defs <- map(dms_renamed, dm_get_def)
-  vec_rbind(!!!new_defs) %>%
-    new_dm3()
+  vec_rbind(!!!new_defs)
 }

--- a/R/bind.R
+++ b/R/bind.R
@@ -16,6 +16,7 @@
 #'
 #' @return `dm` containing the tables and key relations of all `dm` objects.
 #' @export
+#' @keywords internal
 #'
 #' @examplesIf rlang::is_installed("nycflights13")
 #' dm_1 <- dm_nycflights13()

--- a/R/bind.R
+++ b/R/bind.R
@@ -15,8 +15,6 @@
 #' dm_2 <- dm(mtcars, iris)
 #' dm_bind(dm_1, dm_2)
 dm_bind <- function(..., repair = "check_unique", quiet = FALSE) {
-  # special case empty ellipsis, cause otherwise we get an empty data.frame of class `dm`
-  if (dots_n(...) == 0) return(dm())
   dms <- list2(...)
 
   new_def <- dm_bind_impl(dms, repair, quiet)
@@ -24,6 +22,10 @@ dm_bind <- function(..., repair = "check_unique", quiet = FALSE) {
 }
 
 dm_bind_impl <- function(dms, repair, quiet) {
+  if (length(dms) == 0) {
+    return(new_dm_def())
+  }
+
   walk(dms, check_dm)
   walk(dms, check_not_zoomed)
   if (!all_same_source(map(dms, dm_get_tables_impl) %>% flatten())) {

--- a/R/dm.R
+++ b/R/dm.R
@@ -56,10 +56,27 @@ dm <- function(...,
                .name_repair = c("check_unique", "unique", "universal", "minimal"),
                .quiet = FALSE) {
   quos <- enquos(...)
+  names <- names2(quos)
 
   dots <- map(quos, eval_tidy)
 
   is_dm <- map_lgl(dots, is_dm)
+
+  for (i in which(is_dm)) {
+    if (names[[i]] != "") {
+      abort(c(
+        "All dm objects passed to `dm()` must be unnamed.",
+        i = paste0("Argument ", i, " has name ", tick(names[[i]]), ".")
+      ))
+    }
+
+    if (is_zoomed(dots[[i]])) {
+      abort(c(
+        "All dm objects passed to `dm()` must be unzoomed.",
+        i = paste0("Argument ", i, " is a zoomed dm.")
+      ))
+    }
+  }
 
   # FIXME: check not zoomed, prettier
   stopifnot(names2(quos)[is_dm] == "")

--- a/R/dm.R
+++ b/R/dm.R
@@ -58,14 +58,6 @@ dm <- function(..., .name_repair = c("check_unique", "unique", "universal", "min
 
   tbls <- map(quos, eval_tidy)
 
-  if (has_length(quos)) {
-    src_index <- c(which(names(quos) == "src"), 1)[[1]]
-    if (is.src(tbls[[src_index]])) {
-      deprecate_soft("0.0.4.9001", "dm::dm(src = )")
-      return(exec(dm_from_con, con_from_src_or_con(tbls[[src_index]]), !!!tbls[-src_index]))
-    }
-  }
-
   names(tbls) <- vec_as_names(names(quos_auto_name(quos)), repair = .name_repair)
   dm <- new_dm(tbls)
   dm_validate(dm)

--- a/R/dm.R
+++ b/R/dm.R
@@ -60,17 +60,17 @@ dm <- function(...,
 
   tbls <- map(quos, eval_tidy)
 
-  names(tbls) <- vec_as_names(
-    names(quos_auto_name(quos)),
-    repair = .name_repair,
-    quiet = .quiet
-  )
-
-  def <- new_dm_def(tbls)
+  def <- dm_impl(tbls, names(quos_auto_name(quos)), .name_repair, .quiet)
 
   dm <- new_dm3(def)
   dm_validate(dm)
   dm
+}
+
+dm_impl <- function(tbls, names, repair, quiet, call = caller_env()) {
+  names(tbls) <- vec_as_names(names, repair = repair, quiet = quiet, call = call)
+
+  new_dm_def(tbls)
 }
 
 #' A low-level constructor

--- a/R/dm.R
+++ b/R/dm.R
@@ -10,9 +10,8 @@
 #' `dm()` creates a `dm` object from [tbl] objects
 #' (tibbles or lazy data objects).
 #'
-#' @param ... Tables to add to the `dm` object.
-#'   If no names are provided, the tables
-#'   are auto-named.
+#' @param ... Tables or existing `dm` objects to add to the `dm` object.
+#'   Unnamed tables are auto-named, `dm` objects must not be named.
 #' @param .name_repair,.quiet Options for name repair.
 #'   Forwarded as `repair` and `quiet` to [vctrs::vec_as_names()].
 #'
@@ -61,6 +60,8 @@ dm <- function(...,
   dots <- map(quos, eval_tidy)
 
   is_dm <- map_lgl(dots, is_dm)
+
+  stopifnot(names2(quos)[is_dm] == "")
 
   def_dm <- dm_bind_impl(dots[is_dm], .name_repair, .quiet)
   def_tbl <- dm_impl(dots[!is_dm], names(quos_auto_name(quos[!is_dm])), .name_repair, .quiet)

--- a/R/dm.R
+++ b/R/dm.R
@@ -61,6 +61,7 @@ dm <- function(...,
 
   is_dm <- map_lgl(dots, is_dm)
 
+  # FIXME: check not zoomed, prettier
   stopifnot(names2(quos)[is_dm] == "")
 
   dm_tbl <- dm_impl(dots[!is_dm], names(quos_auto_name(quos[!is_dm])))

--- a/R/dm.R
+++ b/R/dm.R
@@ -65,7 +65,10 @@ dm <- function(...,
     repair = .name_repair,
     quiet = .quiet
   )
-  dm <- new_dm(tbls)
+
+  def <- new_dm_def(tbls)
+
+  dm <- new_dm3(def)
   dm_validate(dm)
   dm
 }

--- a/R/dm.R
+++ b/R/dm.R
@@ -63,19 +63,17 @@ dm <- function(...,
 
   stopifnot(names2(quos)[is_dm] == "")
 
-  def_dm <- dm_bind_impl(dots[is_dm], .name_repair, .quiet)
-  def_tbl <- dm_impl(dots[!is_dm], names(quos_auto_name(quos[!is_dm])), .name_repair, .quiet)
-  def <- vec_rbind(def_dm, def_tbl)
+  dm_tbl <- dm_impl(dots[!is_dm], names(quos_auto_name(quos[!is_dm])))
+  def <- dm_bind_impl(c(dots[is_dm], list(dm_tbl)), .name_repair, .quiet, repair_arg = "")
 
   dm <- new_dm3(def)
   dm_validate(dm)
   dm
 }
 
-dm_impl <- function(tbls, names, repair, quiet, call = caller_env()) {
-  names(tbls) <- vec_as_names(names, repair = repair, quiet = quiet, call = call)
-
-  new_dm_def(tbls)
+dm_impl <- function(tbls, names) {
+  names(tbls) <- names
+  new_dm(tbls)
 }
 
 #' A low-level constructor

--- a/R/dm.R
+++ b/R/dm.R
@@ -87,13 +87,14 @@ dm <- function(...,
 #' @rdname dm
 #' @export
 new_dm <- function(tables = list()) {
-  new_dm2(tables)
+  def <- new_dm_def(tables)
+  new_dm3(def)
 }
 
-new_dm2 <- function(tables = list(),
-                    pks_df = tibble(table = character(), pks = list()),
-                    fks_df = tibble(table = character(), fks = list()),
-                    validate = TRUE) {
+new_dm_def <- function(tables = list(),
+                       pks_df = tibble(table = character(), pks = list()),
+                       fks_df = tibble(table = character(), fks = list()),
+                       validate = TRUE) {
   # Legacy
   data <- unname(tables)
   table <- names2(tables)
@@ -120,7 +121,7 @@ new_dm2 <- function(tables = list(),
     left_join(zoom, by = "table") %>%
     left_join(col_tracker_zoom, by = "table")
 
-  new_dm3(def, validate = validate)
+  def
 }
 
 new_dm3 <- function(def, zoomed = FALSE, validate = TRUE) {

--- a/R/dm.R
+++ b/R/dm.R
@@ -13,8 +13,8 @@
 #' @param ... Tables to add to the `dm` object.
 #'   If no names are provided, the tables
 #'   are auto-named.
-#' @param .name_repair Options for name repair.
-#'   Forwarded as `repair` to [vctrs::vec_as_names()].
+#' @param .name_repair,.quiet Options for name repair.
+#'   Forwarded as `repair` and `quiet` to [vctrs::vec_as_names()].
 #'
 #' @return For `dm()`, `new_dm()`, `as_dm()`: A `dm` object.
 #'
@@ -53,12 +53,18 @@
 #' dm_nycflights13() %>% names()
 #'
 #' dm_nycflights13() %>% dm_get_tables()
-dm <- function(..., .name_repair = c("check_unique", "unique", "universal", "minimal")) {
+dm <- function(...,
+               .name_repair = c("check_unique", "unique", "universal", "minimal"),
+               .quiet = FALSE) {
   quos <- enquos(...)
 
   tbls <- map(quos, eval_tidy)
 
-  names(tbls) <- vec_as_names(names(quos_auto_name(quos)), repair = .name_repair)
+  names(tbls) <- vec_as_names(
+    names(quos_auto_name(quos)),
+    repair = .name_repair,
+    quiet = .quiet
+  )
   dm <- new_dm(tbls)
   dm_validate(dm)
   dm

--- a/R/dm.R
+++ b/R/dm.R
@@ -58,9 +58,13 @@ dm <- function(...,
                .quiet = FALSE) {
   quos <- enquos(...)
 
-  tbls <- map(quos, eval_tidy)
+  dots <- map(quos, eval_tidy)
 
-  def <- dm_impl(tbls, names(quos_auto_name(quos)), .name_repair, .quiet)
+  is_dm <- map_lgl(dots, is_dm)
+
+  def_dm <- dm_bind_impl(dots[is_dm], .name_repair, .quiet)
+  def_tbl <- dm_impl(dots[!is_dm], names(quos_auto_name(quos[!is_dm])), .name_repair, .quiet)
+  def <- vec_rbind(def_dm, def_tbl)
 
   dm <- new_dm3(def)
   dm_validate(dm)

--- a/R/dm_unnest_tbl.R
+++ b/R/dm_unnest_tbl.R
@@ -61,7 +61,7 @@ dm_unnest_tbl <- function(dm, parent_table, col, ptype) {
     distinct()
 
   # update the dm by adding new table, removing nested col and setting keys
-  dm <- dm_add_tbl(dm, !!new_child_table_name := new_table)
+  dm <- dm(dm, !!new_child_table_name := new_table)
   dm <- dm_select(dm, !!parent_table_name, -all_of(new_child_table_name))
   if (length(parent_fk_names)) {
     dm <- dm_add_fk(dm, !!new_child_table_name, !!child_fk_names, !!parent_table_name, !!parent_fk_names)
@@ -134,7 +134,7 @@ dm_unpack_tbl <- function(dm, child_table, col, ptype) {
     distinct()
 
   # update the dm by adding new table, removing packed col and setting keys
-  dm <- dm_add_tbl(dm, !!new_parent_table_name := new_table)
+  dm <- dm(dm, !!new_parent_table_name := new_table)
   dm <- dm_select(dm, !!child_table_name, -all_of(new_parent_table_name))
   if (length(child_fk_names)) {
     dm <- dm_add_fk(

--- a/R/dplyr-src.R
+++ b/R/dplyr-src.R
@@ -53,7 +53,7 @@ src_tbls.dm <- function(x, ...) {
 }
 
 #' @details
-#' Use [copy_to()] on a table and then [dm_add_tbl()] instead of `copy_to()`
+#' Use [copy_to()] on a table and then [dm()] instead of `copy_to()`
 #' on a `dm` object.
 #' @param dest For `copy_to.dm()`: The `dm` object to which a table should be copied.
 #' @param df For `copy_to.dm()`: A table (can be on a different `src`)
@@ -66,7 +66,7 @@ src_tbls.dm <- function(x, ...) {
 #' @rdname dplyr_src
 #' @keywords internal
 copy_to.dm <- function(dest, df, name = deparse(substitute(df)), overwrite = FALSE, temporary = TRUE, repair = "unique", quiet = FALSE, ...) {
-  deprecate_soft("0.2.0", "dm::copy_to.dm()", details = "Use `copy_to(dm_get_con(dm), ...)` and `dm_add_tbl()`.")
+  deprecate_soft("0.2.0", "dm::copy_to.dm()", details = "Use `copy_to(dm_get_con(dm), ...)` and `dm()`.")
 
   check_not_zoomed(dest)
 

--- a/R/learn.R
+++ b/R/learn.R
@@ -166,7 +166,8 @@ dm_learn_from_db <- function(dest, dbname = NA, schema = NULL, name_format = "{t
     summarize(fks = list(bind_rows(fks))) %>%
     ungroup()
 
-  new_dm2(tables, pks_df, fks_df)
+  def <- new_dm_def(tables, pks_df, fks_df)
+  new_dm3(def)
 }
 
 schema_if <- function(schema, table, con, dbname = NULL) {

--- a/R/select-tbl.R
+++ b/R/select-tbl.R
@@ -45,7 +45,9 @@ dm_rename_tbl <- function(dm, ...) {
 }
 
 dm_select_tbl_impl <- function(dm, selected) {
-  if (anyDuplicated(names(selected))) abort_need_unique_names(names(selected[duplicated(names(selected))]))
+  if (anyDuplicated(names(selected))) {
+    abort_need_unique_names(names(selected[duplicated(names(selected))]))
+  }
 
   # Required to avoid an error further on
   if (is_empty(selected)) {

--- a/R/validate.R
+++ b/R/validate.R
@@ -26,7 +26,7 @@ dm_validate <- function(x) {
 
   def <- dm_get_def(x)
 
-  boilerplate <- dm_get_def(new_dm2(validate = FALSE))
+  boilerplate <- new_dm_def(validate = FALSE)
 
   table_names <- def$table
   if (any(table_names == "")) abort_dm_invalid("Not all tables are named.")

--- a/man/dm.Rd
+++ b/man/dm.Rd
@@ -8,7 +8,11 @@
 \alias{as_dm}
 \title{Data model class}
 \usage{
-dm(..., .name_repair = c("check_unique", "unique", "universal", "minimal"))
+dm(
+  ...,
+  .name_repair = c("check_unique", "unique", "universal", "minimal"),
+  .quiet = FALSE
+)
 
 new_dm(tables = list())
 
@@ -23,8 +27,8 @@ as_dm(x)
 If no names are provided, the tables
 are auto-named.}
 
-\item{.name_repair}{Options for name repair.
-Forwarded as \code{repair} to \code{\link[vctrs:vec_as_names]{vctrs::vec_as_names()}}.}
+\item{.name_repair, .quiet}{Options for name repair.
+Forwarded as \code{repair} and \code{quiet} to \code{\link[vctrs:vec_as_names]{vctrs::vec_as_names()}}.}
 
 \item{tables}{A named list of the tables (tibble-objects, not names),
 to be included in the \code{dm} object.}

--- a/man/dm.Rd
+++ b/man/dm.Rd
@@ -23,9 +23,8 @@ is_dm(x)
 as_dm(x)
 }
 \arguments{
-\item{...}{Tables to add to the \code{dm} object.
-If no names are provided, the tables
-are auto-named.}
+\item{...}{Tables or existing \code{dm} objects to add to the \code{dm} object.
+Unnamed tables are auto-named, \code{dm} objects must not be named.}
 
 \item{.name_repair, .quiet}{Options for name repair.
 Forwarded as \code{repair} and \code{quiet} to \code{\link[vctrs:vec_as_names]{vctrs::vec_as_names()}}.}

--- a/man/dm_add_tbl.Rd
+++ b/man/dm_add_tbl.Rd
@@ -42,9 +42,17 @@ Users can silence the name repair messages by setting the
 The initial \code{dm} with the additional table(s).
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
 Adds one or more new tables to a \code{\link{dm}}.
 Existing tables are not overwritten.
 }
+\section{Life cycle}{
+
+This function is deprecated as of dm 1.0.0, because the same functionality
+is offered by \code{\link[=dm]{dm()}} with \code{.name_repair = "unique"}.
+}
+
 \examples{
 dm() \%>\%
   dm_add_tbl(mtcars, flowers = iris)
@@ -56,3 +64,4 @@ dm() \%>\%
 \seealso{
 \code{\link[=dm_mutate_tbl]{dm_mutate_tbl()}}, \code{\link[=dm_rm_tbl]{dm_rm_tbl()}}
 }
+\keyword{internal}

--- a/man/dm_bind.Rd
+++ b/man/dm_bind.Rd
@@ -39,11 +39,19 @@ Users can silence the name repair messages by setting the
 \code{dm} containing the tables and key relations of all \code{dm} objects.
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
 Create a single \code{dm} from two or more \code{dm} objects.
 }
 \details{
 The \code{dm} objects have to share the same \code{src}. By default table names need to be unique.
 }
+\section{Life cycle}{
+
+This function is deprecated as of dm 1.0.0, because the same functionality
+is offered by \code{\link[=dm]{dm()}}.
+}
+
 \examples{
 \dontshow{if (rlang::is_installed("nycflights13")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 dm_1 <- dm_nycflights13()

--- a/man/dm_bind.Rd
+++ b/man/dm_bind.Rd
@@ -59,3 +59,4 @@ dm_2 <- dm(mtcars, iris)
 dm_bind(dm_1, dm_2)
 \dontshow{\}) # examplesIf}
 }
+\keyword{internal}

--- a/man/dm_mutate_tbl.Rd
+++ b/man/dm_mutate_tbl.Rd
@@ -26,5 +26,5 @@ dm_nycflights13() \%>\%
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-\code{\link[=dm_add_tbl]{dm_add_tbl()}}, \code{\link[=dm_rm_tbl]{dm_rm_tbl()}}
+\code{\link[=dm]{dm()}}, \code{\link[=dm_rm_tbl]{dm_rm_tbl()}}
 }

--- a/man/dm_rm_tbl.Rd
+++ b/man/dm_rm_tbl.Rd
@@ -27,5 +27,5 @@ dm_nycflights13() \%>\%
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-\code{\link[=dm_add_tbl]{dm_add_tbl()}}, \code{\link[=dm_select_tbl]{dm_select_tbl()}}
+\code{\link[=dm]{dm()}}, \code{\link[=dm_select_tbl]{dm_select_tbl()}}
 }

--- a/man/dplyr_src.Rd
+++ b/man/dplyr_src.Rd
@@ -61,7 +61,7 @@ Use \code{\link[base:Extract]{[[}} instead of \code{tbl()} to access individual 
 Get the names from \code{\link[=dm_get_tables]{dm_get_tables()}} instead of calling \code{dm_get_src()}
 to list the table names in a \code{dm} object.
 
-Use \code{\link[=copy_to]{copy_to()}} on a table and then \code{\link[=dm_add_tbl]{dm_add_tbl()}} instead of \code{copy_to()}
+Use \code{\link[=copy_to]{copy_to()}} on a table and then \code{\link[=dm]{dm()}} instead of \code{copy_to()}
 on a \code{dm} object.
 }
 \keyword{internal}

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -18,7 +18,6 @@ reference:
 
 - title: Tables
   contents:
-  - dm_add_tbl
   - dm_rm_tbl
   - dm_mutate_tbl
   - dm_select_tbl

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -24,7 +24,6 @@ reference:
   - dm_select_tbl
   - dm_rename_tbl
   - pull_tbl
-  - dm_bind
 
 - title: Primary keys
   contents:

--- a/tests/testthat/_snaps/add-tbl.md
+++ b/tests/testthat/_snaps/add-tbl.md
@@ -1,3 +1,11 @@
+# dm_add_tbl() works
+
+    Code
+      dm_add_tbl(dm_for_filter(), tf_1 = data_card_1(), repair = "check_unique")
+    Condition
+      Error in `abort_need_unique_names()`:
+      ! Each new table needs to have a unique name. Duplicate new name(s): `tf_1`.
+
 # dm_add_tbl() and dm_rm_tbl() for compound keys
 
     Code

--- a/tests/testthat/_snaps/add-tbl.md
+++ b/tests/testthat/_snaps/add-tbl.md
@@ -1,4 +1,4 @@
-# dm_add_tbl() works
+# dm_add_tbl() snapshots
 
     Code
       dm_add_tbl(dm_for_filter(), tf_1 = data_card_1(), repair = "check_unique")
@@ -6,7 +6,7 @@
       Error in `abort_need_unique_names()`:
       ! Each new table needs to have a unique name. Duplicate new name(s): `tf_1`.
 
-# dm_add_tbl() and dm_rm_tbl() for compound keys
+---
 
     Code
       dm_add_tbl(dm_for_flatten(), res_flat = result_from_flatten()) %>% dm_paste(
@@ -34,6 +34,9 @@
         dm::dm_add_fk(fact, dim_2_key, dim_2) %>%
         dm::dm_add_fk(fact, dim_3_key, dim_3) %>%
         dm::dm_add_fk(fact, dim_4_key, dim_4)
+
+# dm_rm_tbl() works
+
     Code
       dm_rm_tbl(dm_for_flatten(), dim_1) %>% dm_paste(options = c("select", "keys"))
     Message

--- a/tests/testthat/_snaps/add-tbl.md
+++ b/tests/testthat/_snaps/add-tbl.md
@@ -3,6 +3,10 @@
     Code
       dm_add_tbl(dm_for_filter(), tf_1 = data_card_1(), repair = "check_unique")
     Condition
+      Warning:
+      `dm_add_tbl()` was deprecated in dm 1.0.0.
+      Please use `dm()` instead.
+      Use `.name_repair = "unique"` if necessary.
       Error in `abort_need_unique_names()`:
       ! Each new table needs to have a unique name. Duplicate new name(s): `tf_1`.
 
@@ -11,6 +15,11 @@
     Code
       dm_add_tbl(dm_for_flatten(), res_flat = result_from_flatten()) %>% dm_paste(
         options = c("select", "keys"))
+    Condition
+      Warning:
+      `dm_add_tbl()` was deprecated in dm 1.0.0.
+      Please use `dm()` instead.
+      Use `.name_repair = "unique"` if necessary.
     Message
       dm::dm(
         fact,

--- a/tests/testthat/_snaps/bind.md
+++ b/tests/testthat/_snaps/bind.md
@@ -3,6 +3,10 @@
     Code
       writeLines(conditionMessage(expect_error(dm_bind(dm_for_flatten(),
       dm_for_filter_duckdb()))))
+    Condition
+      Warning:
+      `dm_bind()` was deprecated in dm 1.0.0.
+      Please use `dm()` instead.
     Output
       All `dm` objects need to share the same `src`.
 
@@ -10,14 +14,26 @@
 
     Code
       dm_bind()
+    Condition
+      Warning:
+      `dm_bind()` was deprecated in dm 1.0.0.
+      Please use `dm()` instead.
     Output
       dm()
     Code
       dm_bind(empty_dm())
+    Condition
+      Warning:
+      `dm_bind()` was deprecated in dm 1.0.0.
+      Please use `dm()` instead.
     Output
       dm()
     Code
       dm_bind(dm_for_filter()) %>% collect()
+    Condition
+      Warning:
+      `dm_bind()` was deprecated in dm 1.0.0.
+      Please use `dm()` instead.
     Output
       -- Metadata --------------------------------------------------------------------
       Tables: `tf_1`, `tf_2`, `tf_3`, `tf_4`, `tf_5`, `tf_6`
@@ -27,6 +43,10 @@
     Code
       dm_bind(dm_for_filter(), dm_for_flatten(), dm_for_filter(), repair = "unique",
       quiet = TRUE) %>% collect()
+    Condition
+      Warning:
+      `dm_bind()` was deprecated in dm 1.0.0.
+      Please use `dm()` instead.
     Output
       -- Metadata --------------------------------------------------------------------
       Tables: `tf_1...1`, `tf_2...2`, `tf_3...3`, `tf_4...4`, `tf_5...5`, ... (17 total)
@@ -36,14 +56,22 @@
     Code
       writeLines(conditionMessage(expect_error(dm_bind(dm_for_filter(),
       dm_for_flatten(), dm_for_filter()))))
+    Condition
+      Warning:
+      `dm_bind()` was deprecated in dm 1.0.0.
+      Please use `dm()` instead.
     Output
       Each new table needs to have a unique name. Duplicate new name(s): `tf_1`, `tf_2`, `tf_3`, `tf_4`, `tf_5`, `tf_6`.
 
-# output dev vctrs
+---
 
     Code
       dm_bind(dm_for_filter(), dm_for_flatten(), dm_for_filter(), repair = "unique") %>%
         collect()
+    Condition
+      Warning:
+      `dm_bind()` was deprecated in dm 1.0.0.
+      Please use `dm()` instead.
     Message
       New names:
       * `tf_1` -> `tf_1...1`
@@ -70,6 +98,10 @@
     Code
       dm_bind(dm_for_filter(), dm_for_flatten()) %>% dm_paste(options = c("select",
         "keys"))
+    Condition
+      Warning:
+      `dm_bind()` was deprecated in dm 1.0.0.
+      Please use `dm()` instead.
     Message
       dm::dm(
         tf_1,
@@ -117,6 +149,10 @@
     Code
       dm_bind(dm_for_flatten(), dm_for_filter()) %>% dm_paste(options = c("select",
         "keys"))
+    Condition
+      Warning:
+      `dm_bind()` was deprecated in dm 1.0.0.
+      Please use `dm()` instead.
     Message
       dm::dm(
         fact,
@@ -162,11 +198,15 @@
         dm::dm_add_fk(tf_5, l, tf_4, on_delete = "cascade") %>%
         dm::dm_add_fk(tf_5, m, tf_6, n)
 
-# output for compound keys dev vctrs
+---
 
     Code
       dm_bind(dm_for_flatten(), dm_for_flatten(), repair = "unique") %>% dm_paste(
         options = c("select", "keys"))
+    Condition
+      Warning:
+      `dm_bind()` was deprecated in dm 1.0.0.
+      Please use `dm()` instead.
     Message
       New names:
       * `fact` -> `fact...1`

--- a/tests/testthat/_snaps/bind.md
+++ b/tests/testthat/_snaps/bind.md
@@ -1,3 +1,21 @@
+# errors: duplicate table names, src mismatches
+
+    Code
+      dm_bind(dm_for_filter(), dm_for_flatten(), dm_for_filter())
+    Condition
+      Warning:
+      `dm_bind()` was deprecated in dm 1.0.0.
+      Please use `dm()` instead.
+      Error in `dm_bind()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "tf_1" at locations 1 and 12.
+        * "tf_2" at locations 2 and 13.
+        * "tf_3" at locations 3 and 14.
+        * "tf_4" at locations 4 and 15.
+        * "tf_5" at locations 5 and 16.
+        * ...
+
 # test error output for src mismatches
 
     Code
@@ -61,7 +79,14 @@
       `dm_bind()` was deprecated in dm 1.0.0.
       Please use `dm()` instead.
     Output
-      Each new table needs to have a unique name. Duplicate new name(s): `tf_1`, `tf_2`, `tf_3`, `tf_4`, `tf_5`, `tf_6`.
+      Names must be unique.
+      x These names are duplicated:
+        * "tf_1" at locations 1 and 12.
+        * "tf_2" at locations 2 and 13.
+        * "tf_3" at locations 3 and 14.
+        * "tf_4" at locations 4 and 15.
+        * "tf_5" at locations 5 and 16.
+        * ...
 
 ---
 

--- a/tests/testthat/_snaps/code-generation.md
+++ b/tests/testthat/_snaps/code-generation.md
@@ -48,6 +48,11 @@
         dm_rm_tbl(., planes)
     Code
       cg_eval_block(cg_block_2)
+    Condition
+      Warning:
+      `dm_add_tbl()` was deprecated in dm 1.0.0.
+      Please use `dm()` instead.
+      Use `.name_repair = "unique"` if necessary.
     Output
       -- Metadata --------------------------------------------------------------------
       Tables: `airlines`, `airports`, `flights`, `weather`, `mtcars`

--- a/tests/testthat/_snaps/dm.md
+++ b/tests/testthat/_snaps/dm.md
@@ -31,6 +31,227 @@
       x These names are duplicated:
         * "a" at locations 1 and 2.
 
+# test error output for src mismatches
+
+    Code
+      writeLines(conditionMessage(expect_error(dm(dm_for_flatten(),
+      dm_for_filter_duckdb()))))
+    Output
+      All `dm` objects need to share the same `src`.
+
+# output for dm() with dm
+
+    Code
+      dm()
+    Output
+      dm()
+    Code
+      dm(empty_dm())
+    Output
+      dm()
+    Code
+      dm(dm_for_filter()) %>% collect()
+    Output
+      -- Metadata --------------------------------------------------------------------
+      Tables: `tf_1`, `tf_2`, `tf_3`, `tf_4`, `tf_5`, `tf_6`
+      Columns: 20
+      Primary keys: 6
+      Foreign keys: 5
+    Code
+      dm(dm_for_filter(), dm_for_flatten(), dm_for_filter(), .name_repair = "unique",
+      .quiet = TRUE) %>% collect()
+    Output
+      -- Metadata --------------------------------------------------------------------
+      Tables: `tf_1...1`, `tf_2...2`, `tf_3...3`, `tf_4...4`, `tf_5...5`, ... (17 total)
+      Columns: 56
+      Primary keys: 16
+      Foreign keys: 14
+
+---
+
+    Code
+      dm(dm_for_filter(), dm_for_flatten(), dm_for_filter())
+    Condition
+      Error in `abort_need_unique_names()`:
+      ! Each new table needs to have a unique name. Duplicate new name(s): `tf_1`, `tf_2`, `tf_3`, `tf_4`, `tf_5`, `tf_6`.
+
+# output dev vctrs
+
+    Code
+      dm(dm_for_filter(), dm_for_flatten(), dm_for_filter(), .name_repair = "unique") %>%
+        collect()
+    Message
+      New names:
+      * `tf_1` -> `tf_1...1`
+      * `tf_2` -> `tf_2...2`
+      * `tf_3` -> `tf_3...3`
+      * `tf_4` -> `tf_4...4`
+      * `tf_5` -> `tf_5...5`
+      * `tf_6` -> `tf_6...6`
+      * `tf_1` -> `tf_1...12`
+      * `tf_2` -> `tf_2...13`
+      * `tf_3` -> `tf_3...14`
+      * `tf_4` -> `tf_4...15`
+      * `tf_5` -> `tf_5...16`
+      * `tf_6` -> `tf_6...17`
+    Output
+      -- Metadata --------------------------------------------------------------------
+      Tables: `tf_1...1`, `tf_2...2`, `tf_3...3`, `tf_4...4`, `tf_5...5`, ... (17 total)
+      Columns: 56
+      Primary keys: 16
+      Foreign keys: 14
+
+# output dm() for dm for compound keys
+
+    Code
+      dm(dm_for_filter(), dm_for_flatten()) %>% dm_paste(options = c("select", "keys"))
+    Message
+      dm::dm(
+        tf_1,
+        tf_2,
+        tf_3,
+        tf_4,
+        tf_5,
+        tf_6,
+        fact,
+        dim_1,
+        dim_2,
+        dim_3,
+        dim_4,
+      ) %>%
+        dm::dm_select(tf_1, a, b) %>%
+        dm::dm_select(tf_2, c, d, e, e1) %>%
+        dm::dm_select(tf_3, f, f1, g) %>%
+        dm::dm_select(tf_4, h, i, j, j1) %>%
+        dm::dm_select(tf_5, ww, k, l, m) %>%
+        dm::dm_select(tf_6, zz, n, o) %>%
+        dm::dm_select(fact, fact, dim_1_key_1, dim_1_key_2, dim_2_key, dim_3_key, dim_4_key, something) %>%
+        dm::dm_select(dim_1, dim_1_pk_1, dim_1_pk_2, something) %>%
+        dm::dm_select(dim_2, dim_2_pk, something) %>%
+        dm::dm_select(dim_3, dim_3_pk, something) %>%
+        dm::dm_select(dim_4, dim_4_pk, something) %>%
+        dm::dm_add_pk(tf_1, a) %>%
+        dm::dm_add_pk(tf_2, c) %>%
+        dm::dm_add_pk(tf_3, c(f, f1)) %>%
+        dm::dm_add_pk(tf_4, h) %>%
+        dm::dm_add_pk(tf_5, k) %>%
+        dm::dm_add_pk(tf_6, o) %>%
+        dm::dm_add_pk(dim_1, c(dim_1_pk_1, dim_1_pk_2)) %>%
+        dm::dm_add_pk(dim_2, dim_2_pk) %>%
+        dm::dm_add_pk(dim_3, dim_3_pk) %>%
+        dm::dm_add_pk(dim_4, dim_4_pk) %>%
+        dm::dm_add_fk(tf_2, d, tf_1) %>%
+        dm::dm_add_fk(tf_2, c(e, e1), tf_3) %>%
+        dm::dm_add_fk(tf_4, c(j, j1), tf_3) %>%
+        dm::dm_add_fk(tf_5, l, tf_4, on_delete = "cascade") %>%
+        dm::dm_add_fk(tf_5, m, tf_6, n) %>%
+        dm::dm_add_fk(fact, c(dim_1_key_1, dim_1_key_2), dim_1) %>%
+        dm::dm_add_fk(fact, dim_2_key, dim_2) %>%
+        dm::dm_add_fk(fact, dim_3_key, dim_3) %>%
+        dm::dm_add_fk(fact, dim_4_key, dim_4)
+    Code
+      dm(dm_for_flatten(), dm_for_filter()) %>% dm_paste(options = c("select", "keys"))
+    Message
+      dm::dm(
+        fact,
+        dim_1,
+        dim_2,
+        dim_3,
+        dim_4,
+        tf_1,
+        tf_2,
+        tf_3,
+        tf_4,
+        tf_5,
+        tf_6,
+      ) %>%
+        dm::dm_select(fact, fact, dim_1_key_1, dim_1_key_2, dim_2_key, dim_3_key, dim_4_key, something) %>%
+        dm::dm_select(dim_1, dim_1_pk_1, dim_1_pk_2, something) %>%
+        dm::dm_select(dim_2, dim_2_pk, something) %>%
+        dm::dm_select(dim_3, dim_3_pk, something) %>%
+        dm::dm_select(dim_4, dim_4_pk, something) %>%
+        dm::dm_select(tf_1, a, b) %>%
+        dm::dm_select(tf_2, c, d, e, e1) %>%
+        dm::dm_select(tf_3, f, f1, g) %>%
+        dm::dm_select(tf_4, h, i, j, j1) %>%
+        dm::dm_select(tf_5, ww, k, l, m) %>%
+        dm::dm_select(tf_6, zz, n, o) %>%
+        dm::dm_add_pk(dim_1, c(dim_1_pk_1, dim_1_pk_2)) %>%
+        dm::dm_add_pk(dim_2, dim_2_pk) %>%
+        dm::dm_add_pk(dim_3, dim_3_pk) %>%
+        dm::dm_add_pk(dim_4, dim_4_pk) %>%
+        dm::dm_add_pk(tf_1, a) %>%
+        dm::dm_add_pk(tf_2, c) %>%
+        dm::dm_add_pk(tf_3, c(f, f1)) %>%
+        dm::dm_add_pk(tf_4, h) %>%
+        dm::dm_add_pk(tf_5, k) %>%
+        dm::dm_add_pk(tf_6, o) %>%
+        dm::dm_add_fk(fact, c(dim_1_key_1, dim_1_key_2), dim_1) %>%
+        dm::dm_add_fk(fact, dim_2_key, dim_2) %>%
+        dm::dm_add_fk(fact, dim_3_key, dim_3) %>%
+        dm::dm_add_fk(fact, dim_4_key, dim_4) %>%
+        dm::dm_add_fk(tf_2, d, tf_1) %>%
+        dm::dm_add_fk(tf_2, c(e, e1), tf_3) %>%
+        dm::dm_add_fk(tf_4, c(j, j1), tf_3) %>%
+        dm::dm_add_fk(tf_5, l, tf_4, on_delete = "cascade") %>%
+        dm::dm_add_fk(tf_5, m, tf_6, n)
+
+---
+
+    Code
+      dm(dm_for_flatten(), dm_for_flatten(), .name_repair = "unique") %>% dm_paste(
+        options = c("select", "keys"))
+    Message
+      New names:
+      * `fact` -> `fact...1`
+      * `dim_1` -> `dim_1...2`
+      * `dim_2` -> `dim_2...3`
+      * `dim_3` -> `dim_3...4`
+      * `dim_4` -> `dim_4...5`
+      * `fact` -> `fact...6`
+      * `dim_1` -> `dim_1...7`
+      * `dim_2` -> `dim_2...8`
+      * `dim_3` -> `dim_3...9`
+      * `dim_4` -> `dim_4...10`
+      dm::dm(
+        fact...1,
+        dim_1...2,
+        dim_2...3,
+        dim_3...4,
+        dim_4...5,
+        fact...6,
+        dim_1...7,
+        dim_2...8,
+        dim_3...9,
+        dim_4...10,
+      ) %>%
+        dm::dm_select(fact...1, fact, dim_1_key_1, dim_1_key_2, dim_2_key, dim_3_key, dim_4_key, something) %>%
+        dm::dm_select(dim_1...2, dim_1_pk_1, dim_1_pk_2, something) %>%
+        dm::dm_select(dim_2...3, dim_2_pk, something) %>%
+        dm::dm_select(dim_3...4, dim_3_pk, something) %>%
+        dm::dm_select(dim_4...5, dim_4_pk, something) %>%
+        dm::dm_select(fact...6, fact, dim_1_key_1, dim_1_key_2, dim_2_key, dim_3_key, dim_4_key, something) %>%
+        dm::dm_select(dim_1...7, dim_1_pk_1, dim_1_pk_2, something) %>%
+        dm::dm_select(dim_2...8, dim_2_pk, something) %>%
+        dm::dm_select(dim_3...9, dim_3_pk, something) %>%
+        dm::dm_select(dim_4...10, dim_4_pk, something) %>%
+        dm::dm_add_pk(dim_1...2, c(dim_1_pk_1, dim_1_pk_2)) %>%
+        dm::dm_add_pk(dim_2...3, dim_2_pk) %>%
+        dm::dm_add_pk(dim_3...4, dim_3_pk) %>%
+        dm::dm_add_pk(dim_4...5, dim_4_pk) %>%
+        dm::dm_add_pk(dim_1...7, c(dim_1_pk_1, dim_1_pk_2)) %>%
+        dm::dm_add_pk(dim_2...8, dim_2_pk) %>%
+        dm::dm_add_pk(dim_3...9, dim_3_pk) %>%
+        dm::dm_add_pk(dim_4...10, dim_4_pk) %>%
+        dm::dm_add_fk(fact...1, c(dim_1_key_1, dim_1_key_2), dim_1...2) %>%
+        dm::dm_add_fk(fact...1, dim_2_key, dim_2...3) %>%
+        dm::dm_add_fk(fact...1, dim_3_key, dim_3...4) %>%
+        dm::dm_add_fk(fact...1, dim_4_key, dim_4...5) %>%
+        dm::dm_add_fk(fact...6, c(dim_1_key_1, dim_1_key_2), dim_1...7) %>%
+        dm::dm_add_fk(fact...6, dim_2_key, dim_2...8) %>%
+        dm::dm_add_fk(fact...6, dim_3_key, dim_3...9) %>%
+        dm::dm_add_fk(fact...6, dim_4_key, dim_4...10)
+
 # output
 
     Code

--- a/tests/testthat/_snaps/dm.md
+++ b/tests/testthat/_snaps/dm.md
@@ -39,6 +39,21 @@
       Error in `dm()`:
       ! names2(quos)[is_dm] == "" is not TRUE
 
+# errors: duplicate table names, src mismatches
+
+    Code
+      dm(dm_for_filter(), dm_for_flatten(), dm_for_filter())
+    Condition
+      Error in `dm()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "tf_1" at locations 1 and 12.
+        * "tf_2" at locations 2 and 13.
+        * "tf_3" at locations 3 and 14.
+        * "tf_4" at locations 4 and 15.
+        * "tf_5" at locations 5 and 16.
+        * ...
+
 # test error output for src mismatches
 
     Code

--- a/tests/testthat/_snaps/dm.md
+++ b/tests/testthat/_snaps/dm.md
@@ -1,3 +1,36 @@
+# dm() API
+
+    Code
+      dm(a = tibble(), a = tibble(), .name_repair = "unique")
+    Message
+      New names:
+      * `a` -> `a...1`
+      * `a` -> `a...2`
+    Output
+      -- Metadata --------------------------------------------------------------------
+      Tables: `a...1`, `a...2`
+      Columns: 0
+      Primary keys: 0
+      Foreign keys: 0
+    Code
+      dm(a = tibble(), a = tibble(), .name_repair = "unique", .quiet = TRUE)
+    Output
+      -- Metadata --------------------------------------------------------------------
+      Tables: `a...1`, `a...2`
+      Columns: 0
+      Primary keys: 0
+      Foreign keys: 0
+
+---
+
+    Code
+      dm(a = tibble(), a = tibble())
+    Condition
+      Error in `dm()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "a" at locations 1 and 2.
+
 # output
 
     Code

--- a/tests/testthat/_snaps/dm.md
+++ b/tests/testthat/_snaps/dm.md
@@ -80,8 +80,15 @@
     Code
       dm(dm_for_filter(), dm_for_flatten(), dm_for_filter())
     Condition
-      Error in `abort_need_unique_names()`:
-      ! Each new table needs to have a unique name. Duplicate new name(s): `tf_1`, `tf_2`, `tf_3`, `tf_4`, `tf_5`, `tf_6`.
+      Error in `dm()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "tf_1" at locations 1 and 12.
+        * "tf_2" at locations 2 and 13.
+        * "tf_3" at locations 3 and 14.
+        * "tf_4" at locations 4 and 15.
+        * "tf_5" at locations 5 and 16.
+        * ...
 
 ---
 

--- a/tests/testthat/_snaps/dm.md
+++ b/tests/testthat/_snaps/dm.md
@@ -37,7 +37,17 @@
       dm(a = dm())
     Condition
       Error in `dm()`:
-      ! names2(quos)[is_dm] == "" is not TRUE
+      ! All dm objects passed to `dm()` must be unnamed.
+      i Argument 1 has name `a`.
+
+---
+
+    Code
+      dm(a = tibble(), dm_zoom_to(dm_for_filter(), tf_1))
+    Condition
+      Error in `dm()`:
+      ! All dm objects passed to `dm()` must be unzoomed.
+      i Argument 2 is a zoomed dm.
 
 # dm() works for adding tables
 

--- a/tests/testthat/_snaps/dm.md
+++ b/tests/testthat/_snaps/dm.md
@@ -31,6 +31,14 @@
       x These names are duplicated:
         * "a" at locations 1 and 2.
 
+---
+
+    Code
+      dm(a = dm())
+    Condition
+      Error in `dm()`:
+      ! names2(quos)[is_dm] == "" is not TRUE
+
 # test error output for src mismatches
 
     Code
@@ -75,7 +83,7 @@
       Error in `abort_need_unique_names()`:
       ! Each new table needs to have a unique name. Duplicate new name(s): `tf_1`, `tf_2`, `tf_3`, `tf_4`, `tf_5`, `tf_6`.
 
-# output dev vctrs
+---
 
     Code
       dm(dm_for_filter(), dm_for_flatten(), dm_for_filter(), .name_repair = "unique") %>%

--- a/tests/testthat/_snaps/dm.md
+++ b/tests/testthat/_snaps/dm.md
@@ -39,6 +39,45 @@
       Error in `dm()`:
       ! names2(quos)[is_dm] == "" is not TRUE
 
+# dm() works for adding tables
+
+    Code
+      dm(dm_for_filter(), tf_1 = data_card_1(), .name_repair = "check_unique")
+    Condition
+      Error in `dm()`:
+      ! Names must be unique.
+      x These names are duplicated:
+        * "tf_1" at locations 1 and 7.
+
+# dm() for adding tables with compound keys
+
+    Code
+      dm(dm_for_flatten(), res_flat = result_from_flatten()) %>% dm_paste(options = c(
+        "select", "keys"))
+    Message
+      dm::dm(
+        fact,
+        dim_1,
+        dim_2,
+        dim_3,
+        dim_4,
+        res_flat,
+      ) %>%
+        dm::dm_select(fact, fact, dim_1_key_1, dim_1_key_2, dim_2_key, dim_3_key, dim_4_key, something) %>%
+        dm::dm_select(dim_1, dim_1_pk_1, dim_1_pk_2, something) %>%
+        dm::dm_select(dim_2, dim_2_pk, something) %>%
+        dm::dm_select(dim_3, dim_3_pk, something) %>%
+        dm::dm_select(dim_4, dim_4_pk, something) %>%
+        dm::dm_select(res_flat, fact, dim_1_key_1, dim_1_key_2, dim_2_key, dim_3_key, dim_4_key, fact.something, dim_1.something, dim_2.something, dim_3.something, dim_4.something) %>%
+        dm::dm_add_pk(dim_1, c(dim_1_pk_1, dim_1_pk_2)) %>%
+        dm::dm_add_pk(dim_2, dim_2_pk) %>%
+        dm::dm_add_pk(dim_3, dim_3_pk) %>%
+        dm::dm_add_pk(dim_4, dim_4_pk) %>%
+        dm::dm_add_fk(fact, c(dim_1_key_1, dim_1_key_2), dim_1) %>%
+        dm::dm_add_fk(fact, dim_2_key, dim_2) %>%
+        dm::dm_add_fk(fact, dim_3_key, dim_3) %>%
+        dm::dm_add_fk(fact, dim_4_key, dim_4)
+
 # errors: duplicate table names, src mismatches
 
     Code

--- a/tests/testthat/_snaps/dm.md
+++ b/tests/testthat/_snaps/dm.md
@@ -356,7 +356,7 @@
     Condition
       Warning:
       `copy_to.dm()` was deprecated in dm 0.2.0.
-      Use `copy_to(dm_get_con(dm), ...)` and `dm_add_tbl()`.
+      Use `copy_to(dm_get_con(dm), ...)` and `dm()`.
     Output
       -- Metadata --------------------------------------------------------------------
       Tables: `airlines`, `airports`, `flights`, `planes`, `weather`, `car_table`
@@ -364,7 +364,7 @@
       Primary keys: 4
       Foreign keys: 4
     Code
-      dm_add_tbl(nyc_comp(), car_table)
+      dm(nyc_comp(), car_table)
     Output
       -- Metadata --------------------------------------------------------------------
       Tables: `airlines`, `airports`, `flights`, `planes`, `weather`, `car_table`

--- a/tests/testthat/_snaps/paste.md
+++ b/tests/testthat/_snaps/paste.md
@@ -86,8 +86,8 @@
         dm::dm_add_fk(tf_5, m, tf_6, n)
     Code
       # produce `dm_select()` statements in addition to the rest
-      dm_for_filter() %>% dm_select(tf_5, k = k, m) %>% dm_select(tf_1, a) %>%
-        dm_add_tbl(x = copy_to_my_test_src(tibble(q = 1L), qq)) %>% dm_paste(options = "select")
+      dm_for_filter() %>% dm_select(tf_5, k = k, m) %>% dm_select(tf_1, a) %>% dm(x = copy_to_my_test_src(
+        tibble(q = 1L), qq)) %>% dm_paste(options = "select")
     Message
       dm::dm(
         tf_1,

--- a/tests/testthat/test-add-tbl.R
+++ b/tests/testthat/test-add-tbl.R
@@ -50,11 +50,6 @@ test_that("dm_add_tbl() works", {
     c(src_tbls_impl(dm_for_filter()), "data_card_1()", "data_card_2()")
   )
 
-  # Is an error thrown in case I try to give the new table an old table's name if `repair = "check_unique"`?
-  expect_snapshot(error = TRUE, {
-    dm_add_tbl(dm_for_filter(), tf_1 = data_card_1(), repair = "check_unique")
-  })
-
   # are in the default case (`repair = 'unique'`) the tables renamed (old table AND new table) according to "unique" default setting
   expect_identical(
     dm_add_tbl(dm_for_filter(), tf_1 = data_card_1(), quiet = TRUE) %>% src_tbls_impl(),
@@ -90,6 +85,17 @@ test_that("dm_add_tbl() works", {
   )
 })
 
+test_that("dm_add_tbl() snapshots", {
+  # Is an error thrown in case I try to give the new table an old table's name if `repair = "check_unique"`?
+  expect_snapshot(error = TRUE, {
+    dm_add_tbl(dm_for_filter(), tf_1 = data_card_1(), repair = "check_unique")
+  })
+
+  expect_snapshot({
+    dm_add_tbl(dm_for_flatten(), res_flat = result_from_flatten()) %>% dm_paste(options = c("select", "keys"))
+  })
+})
+
 test_that("dm_rm_tbl() works", {
   # removes a table
   expect_equivalent_dm(
@@ -120,11 +126,8 @@ test_that("dm_rm_tbl() works", {
     dm_rm_tbl(dm_for_disambiguate()),
     dm_for_disambiguate()
   )
-})
 
-test_that("dm_add_tbl() and dm_rm_tbl() for compound keys", {
   expect_snapshot({
-    dm_add_tbl(dm_for_flatten(), res_flat = result_from_flatten()) %>% dm_paste(options = c("select", "keys"))
     dm_rm_tbl(dm_for_flatten(), dim_1) %>% dm_paste(options = c("select", "keys"))
     dm_rm_tbl(dm_for_flatten(), fact) %>% dm_paste(options = c("select", "keys"))
   })

--- a/tests/testthat/test-add-tbl.R
+++ b/tests/testthat/test-add-tbl.R
@@ -51,10 +51,9 @@ test_that("dm_add_tbl() works", {
   )
 
   # Is an error thrown in case I try to give the new table an old table's name if `repair = "check_unique"`?
-  expect_dm_error(
-    dm_add_tbl(dm_for_filter(), tf_1 = data_card_1(), repair = "check_unique"),
-    "need_unique_names"
-  )
+  expect_snapshot(error = TRUE, {
+    dm_add_tbl(dm_for_filter(), tf_1 = data_card_1(), repair = "check_unique")
+  })
 
   # are in the default case (`repair = 'unique'`) the tables renamed (old table AND new table) according to "unique" default setting
   expect_identical(

--- a/tests/testthat/test-add-tbl.R
+++ b/tests/testthat/test-add-tbl.R
@@ -1,4 +1,6 @@
 test_that("dm_add_tbl() works", {
+  local_options(lifecycle_verbosity = "quiet")
+
   # is a table added?
   expect_identical(
     length(dm_get_tables(dm_add_tbl(dm_for_filter(), data_card_1()))),
@@ -86,6 +88,8 @@ test_that("dm_add_tbl() works", {
 })
 
 test_that("dm_add_tbl() snapshots", {
+  local_options(lifecycle_verbosity = "warning")
+
   # Is an error thrown in case I try to give the new table an old table's name if `repair = "check_unique"`?
   expect_snapshot(error = TRUE, {
     dm_add_tbl(dm_for_filter(), tf_1 = data_card_1(), repair = "check_unique")

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -37,10 +37,18 @@ test_that("are empty_dm() and empty ellipsis handled correctly?", {
 })
 
 test_that("errors: duplicate table names, src mismatches", {
+  local_options(lifecycle_verbosity = "warning")
+
+  expect_snapshot(error = TRUE, {
+    dm_bind(dm_for_filter(), dm_for_flatten(), dm_for_filter())
+  })
+})
+
+test_that("errors: src mismatches", {
   local_options(lifecycle_verbosity = "quiet")
 
-  expect_dm_error(dm_bind(dm_for_filter(), dm_for_flatten(), dm_for_filter()), "need_unique_names")
   skip_if_not_installed("dbplyr")
+  skip_if_not_installed("duckdb")
   expect_dm_error(dm_bind(dm_for_flatten(), dm_for_filter_duckdb()), "not_same_src")
 })
 

--- a/tests/testthat/test-bind.R
+++ b/tests/testthat/test-bind.R
@@ -1,4 +1,6 @@
 test_that("dm_bind() works?", {
+  local_options(lifecycle_verbosity = "quiet")
+
   expect_equivalent_dm(
     dm_bind(dm_for_filter()),
     dm_for_filter()
@@ -16,6 +18,8 @@ test_that("dm_bind() works?", {
 })
 
 test_that("are empty_dm() and empty ellipsis handled correctly?", {
+  local_options(lifecycle_verbosity = "quiet")
+
   expect_equivalent_dm(
     dm_bind(empty_dm()),
     empty_dm()
@@ -33,12 +37,16 @@ test_that("are empty_dm() and empty ellipsis handled correctly?", {
 })
 
 test_that("errors: duplicate table names, src mismatches", {
+  local_options(lifecycle_verbosity = "quiet")
+
   expect_dm_error(dm_bind(dm_for_filter(), dm_for_flatten(), dm_for_filter()), "need_unique_names")
   skip_if_not_installed("dbplyr")
   expect_dm_error(dm_bind(dm_for_flatten(), dm_for_filter_duckdb()), "not_same_src")
 })
 
 test_that("auto-renaming works", {
+  local_options(lifecycle_verbosity = "quiet")
+
   expect_equivalent_dm(
     expect_name_repair_message(
       dm_bind(dm_for_filter(), dm_for_flatten(), dm_for_filter(), repair = "unique")
@@ -75,6 +83,8 @@ test_that("auto-renaming works", {
 })
 
 test_that("test error output for src mismatches", {
+  local_options(lifecycle_verbosity = "warning")
+
   skip_if_not_installed("dbplyr")
 
   expect_snapshot({
@@ -85,6 +95,8 @@ test_that("test error output for src mismatches", {
 })
 
 test_that("output", {
+  local_options(lifecycle_verbosity = "warning")
+
   expect_snapshot({
     dm_bind()
     dm_bind(empty_dm())
@@ -94,10 +106,6 @@ test_that("output", {
       dm_bind(dm_for_filter(), dm_for_flatten(), dm_for_filter())
     )))
   })
-})
-
-test_that("output dev vctrs", {
-  skip_if_not_installed("vctrs", "0.3.8.9001")
 
   expect_snapshot({
     dm_bind(dm_for_filter(), dm_for_flatten(), dm_for_filter(), repair = "unique") %>% collect()
@@ -105,14 +113,12 @@ test_that("output dev vctrs", {
 })
 
 test_that("output for compound keys", {
+  local_options(lifecycle_verbosity = "warning")
+
   expect_snapshot({
     dm_bind(dm_for_filter(), dm_for_flatten()) %>% dm_paste(options = c("select", "keys"))
     dm_bind(dm_for_flatten(), dm_for_filter()) %>% dm_paste(options = c("select", "keys"))
   })
-})
-
-test_that("output for compound keys dev vctrs", {
-  skip_if_not_installed("vctrs", "0.3.8.9001")
 
   expect_snapshot({
     dm_bind(dm_for_flatten(), dm_for_flatten(), repair = "unique") %>% dm_paste(options = c("select", "keys"))

--- a/tests/testthat/test-dm.R
+++ b/tests/testthat/test-dm.R
@@ -8,6 +8,124 @@ test_that("dm() API", {
   })
 })
 
+test_that("dm() works for dm objects", {
+  expect_equivalent_dm(
+    dm(dm_for_filter()),
+    dm_for_filter()
+  )
+
+  expect_equivalent_dm(
+    dm(dm_for_filter(), dm_for_flatten(), dm_for_disambiguate()),
+    bind_rows(
+      dm_get_def(dm_for_filter()),
+      dm_get_def(dm_for_flatten()),
+      dm_get_def(dm_for_disambiguate())
+    ) %>%
+      new_dm3()
+  )
+})
+
+test_that("are empty_dm() and empty ellipsis handled correctly?", {
+  expect_equivalent_dm(
+    dm(empty_dm()),
+    empty_dm()
+  )
+
+  expect_equivalent_dm(
+    dm(empty_dm(), empty_dm(), empty_dm()),
+    empty_dm()
+  )
+
+  expect_equivalent_dm(
+    dm(),
+    empty_dm()
+  )
+})
+
+test_that("errors: duplicate table names, src mismatches", {
+  expect_dm_error(dm(dm_for_filter(), dm_for_flatten(), dm_for_filter()), "need_unique_names")
+  skip_if_not_installed("dbplyr")
+  expect_dm_error(dm(dm_for_flatten(), dm_for_filter_duckdb()), "not_same_src")
+})
+
+test_that("auto-renaming works", {
+  expect_equivalent_dm(
+    expect_name_repair_message(
+      dm(dm_for_filter(), dm_for_flatten(), dm_for_filter(), .name_repair = "unique")
+    ),
+    bind_rows(
+      dm_get_def(
+        dm_rename_tbl(
+          dm_for_filter(),
+          tf_1...1 = tf_1,
+          tf_2...2 = tf_2,
+          tf_3...3 = tf_3,
+          tf_4...4 = tf_4,
+          tf_5...5 = tf_5,
+          tf_6...6 = tf_6
+        )
+      ),
+      dm_get_def(dm_for_flatten()),
+      dm_get_def(dm_rename_tbl(
+        dm_for_filter(),
+        tf_1...12 = tf_1,
+        tf_2...13 = tf_2,
+        tf_3...14 = tf_3,
+        tf_4...15 = tf_4,
+        tf_5...16 = tf_5,
+        tf_6...17 = tf_6
+      ))
+    ) %>%
+      new_dm3()
+  )
+
+  expect_silent(
+    dm(dm_for_filter(), dm_for_flatten(), dm_for_filter(), .name_repair = "unique", .quiet = TRUE)
+  )
+})
+
+test_that("test error output for src mismatches", {
+  skip_if_not_installed("dbplyr")
+
+  expect_snapshot({
+    writeLines(conditionMessage(expect_error(
+      dm(dm_for_flatten(), dm_for_filter_duckdb())
+    )))
+  })
+})
+
+test_that("output for dm() with dm", {
+  expect_snapshot({
+    dm()
+    dm(empty_dm())
+    dm(dm_for_filter()) %>% collect()
+    dm(dm_for_filter(), dm_for_flatten(), dm_for_filter(), .name_repair = "unique", .quiet = TRUE) %>% collect()
+  })
+
+  expect_snapshot(error = TRUE, {
+    dm(dm_for_filter(), dm_for_flatten(), dm_for_filter())
+  })
+})
+
+test_that("output dev vctrs", {
+  skip_if_not_installed("vctrs", "0.3.8.9001")
+
+  expect_snapshot({
+    dm(dm_for_filter(), dm_for_flatten(), dm_for_filter(), .name_repair = "unique") %>% collect()
+  })
+})
+
+test_that("output dm() for dm for compound keys", {
+  expect_snapshot({
+    dm(dm_for_filter(), dm_for_flatten()) %>% dm_paste(options = c("select", "keys"))
+    dm(dm_for_flatten(), dm_for_filter()) %>% dm_paste(options = c("select", "keys"))
+  })
+
+  expect_snapshot({
+    dm(dm_for_flatten(), dm_for_flatten(), .name_repair = "unique") %>% dm_paste(options = c("select", "keys"))
+  })
+})
+
 test_that("can create dm with as_dm()", {
   expect_equivalent_dm(as_dm(dm_get_tables(dm_test_obj())), dm_test_obj())
 })

--- a/tests/testthat/test-dm.R
+++ b/tests/testthat/test-dm.R
@@ -1,3 +1,13 @@
+test_that("dm() API", {
+  expect_snapshot({
+    dm(a = tibble(), a = tibble(), .name_repair = "unique")
+    dm(a = tibble(), a = tibble(), .name_repair = "unique", .quiet = TRUE)
+  })
+  expect_snapshot(error = TRUE, {
+    dm(a = tibble(), a = tibble())
+  })
+})
+
 test_that("can create dm with as_dm()", {
   expect_equivalent_dm(as_dm(dm_get_tables(dm_test_obj())), dm_test_obj())
 })

--- a/tests/testthat/test-dm.R
+++ b/tests/testthat/test-dm.R
@@ -9,6 +9,9 @@ test_that("dm() API", {
   expect_snapshot(error = TRUE, {
     dm(a = dm())
   })
+  expect_snapshot(error = TRUE, {
+    dm(a = tibble(), dm_zoom_to(dm_for_filter(), tf_1))
+  })
 })
 
 test_that("dm() works for adding tables", {

--- a/tests/testthat/test-dm.R
+++ b/tests/testthat/test-dm.R
@@ -46,8 +46,12 @@ test_that("are empty_dm() and empty ellipsis handled correctly?", {
 })
 
 test_that("errors: duplicate table names, src mismatches", {
-  expect_dm_error(dm(dm_for_filter(), dm_for_flatten(), dm_for_filter()), "need_unique_names")
+  expect_snapshot(error = TRUE, {
+    dm(dm_for_filter(), dm_for_flatten(), dm_for_filter())
+  })
+
   skip_if_not_installed("dbplyr")
+  skip_if_not_installed("duckdb")
   expect_dm_error(dm(dm_for_flatten(), dm_for_filter_duckdb()), "not_same_src")
 })
 

--- a/tests/testthat/test-dm.R
+++ b/tests/testthat/test-dm.R
@@ -11,6 +11,104 @@ test_that("dm() API", {
   })
 })
 
+test_that("dm() works for adding tables", {
+  # is a table added?
+  expect_identical(
+    length(dm_get_tables(dm(dm_for_filter(), data_card_1()))),
+    7L
+  )
+
+  # can I retrieve the tibble under its old name?
+  expect_equivalent_tbl(
+    dm(dm_for_filter(), data_card_1())[["data_card_1()"]],
+    data_card_1()
+  )
+
+  # can I retrieve the tibble under a new name?
+  expect_equivalent_tbl(
+    dm(dm_for_filter(), test = data_card_1())[["test"]],
+    data_card_1()
+  )
+
+  # use special names with :=
+  expect_identical(
+    names(dm(dm_for_filter(), dm := data_card_1(), repair := data_card_2())),
+    c(names(dm_for_filter()), "dm", "repair")
+  )
+
+  # we accept even weird table names, as long as they are unique
+  expect_equivalent_tbl(
+    dm(dm_for_filter(), . = data_card_1())[["."]],
+    data_card_1()
+  )
+
+  # do I avoid the warning when piping the table but setting the name?
+  expect_silent(
+    expect_equivalent_tbl(
+      dm_for_filter() %>% dm(new_name = data_card_1()) %>% pull_tbl(new_name),
+      data_card_1()
+    )
+  )
+
+  # adding more than 1 table:
+  # 1. Is the resulting number of tables correct?
+  expect_identical(
+    length(dm_get_tables(dm(dm_for_filter(), data_card_1(), data_card_2()))),
+    8L
+  )
+
+  # 2. Is the resulting order of the tables correct?
+  expect_identical(
+    src_tbls_impl(dm(dm_for_filter(), data_card_1(), data_card_2())),
+    c(src_tbls_impl(dm_for_filter()), "data_card_1()", "data_card_2()")
+  )
+
+  # Is an error thrown in case I try to give the new table an old table's name if `repair = "check_unique"`?
+  expect_snapshot(error = TRUE, {
+    dm(dm_for_filter(), tf_1 = data_card_1(), .name_repair = "check_unique")
+  })
+
+  # are in the default case (`repair = 'unique'`) the tables renamed (old table AND new table) according to "unique" default setting
+  expect_identical(
+    dm(dm_for_filter(), tf_1 = data_card_1(), .name_repair = "unique", .quiet = TRUE) %>% src_tbls_impl(),
+    c("tf_1...1", "tf_2", "tf_3", "tf_4", "tf_5", "tf_6", "tf_1...7")
+  )
+
+  expect_name_repair_message(
+    expect_equivalent_dm(
+      dm(dm_for_filter(), tf_1 = data_card_1(), .name_repair = "unique"),
+      dm_for_filter() %>%
+        dm_rename_tbl(tf_1...1 = tf_1) %>%
+        dm(tf_1...7 = data_card_1())
+    )
+  )
+
+  # can I use dm_select_tbl(), selecting among others the new table?
+  expect_silent(
+    dm(dm_for_filter(), tf_7_new = tf_7()) %>% dm_select_tbl(tf_1, tf_7_new, everything())
+  )
+
+  skip_if_not_installed("dbplyr")
+
+  # error in case table srcs don't match
+  expect_dm_error(
+    dm(dm_for_filter(), data_card_1_duckdb()),
+    "not_same_src"
+  )
+
+  # adding tables to an empty `dm` works for all sources
+  expect_equivalent_tbl(
+    dm(dm(), test = data_card_1_duckdb())$test,
+    data_card_1()
+  )
+})
+
+test_that("dm() for adding tables with compound keys", {
+  expect_snapshot({
+    dm(dm_for_flatten(), res_flat = result_from_flatten()) %>% dm_paste(options = c("select", "keys"))
+  })
+})
+
 test_that("dm() works for dm objects", {
   expect_equivalent_dm(
     dm(dm_for_filter()),

--- a/tests/testthat/test-dm.R
+++ b/tests/testthat/test-dm.R
@@ -524,7 +524,7 @@ test_that("output for compound keys", {
 
   expect_snapshot({
     copy_to(nyc_comp(), mtcars, "car_table")
-    dm_add_tbl(nyc_comp(), car_table)
+    dm(nyc_comp(), car_table)
     nyc_comp() %>%
       collect()
     nyc_comp() %>%

--- a/tests/testthat/test-dm.R
+++ b/tests/testthat/test-dm.R
@@ -6,6 +6,9 @@ test_that("dm() API", {
   expect_snapshot(error = TRUE, {
     dm(a = tibble(), a = tibble())
   })
+  expect_snapshot(error = TRUE, {
+    dm(a = dm())
+  })
 })
 
 test_that("dm() works for dm objects", {
@@ -105,10 +108,6 @@ test_that("output for dm() with dm", {
   expect_snapshot(error = TRUE, {
     dm(dm_for_filter(), dm_for_flatten(), dm_for_filter())
   })
-})
-
-test_that("output dev vctrs", {
-  skip_if_not_installed("vctrs", "0.3.8.9001")
 
   expect_snapshot({
     dm(dm_for_filter(), dm_for_flatten(), dm_for_filter(), .name_repair = "unique") %>% collect()

--- a/tests/testthat/test-dplyr-src.R
+++ b/tests/testthat/test-dplyr-src.R
@@ -35,7 +35,7 @@ test_that("'copy_to.dm()' works", {
 
   expect_equivalent_dm(
     suppress_mssql_message(copy_to(dm_for_filter(), mtcars, "car_table")),
-    dm_add_tbl(dm_for_filter(), car_table)
+    dm(dm_for_filter(), car_table)
   )
 
   # FIXME: Why do we do name repair in copy_to()?
@@ -43,7 +43,7 @@ test_that("'copy_to.dm()' works", {
     suppress_mssql_message(expect_name_repair_message(
       copy_to(dm_for_filter(), mtcars, "")
     )),
-    dm_add_tbl(dm_for_filter(), ...7 = car_table)
+    dm(dm_for_filter(), ...7 = car_table)
   )
 })
 
@@ -83,12 +83,12 @@ test_that("'copy_to.dm()' works (2)", {
   # copying `tibble` from chosen src to sqlite() `dm`
   expect_equivalent_dm(
     copy_to(dm_for_filter_duckdb(), data_card_1(), "test_table"),
-    dm_add_tbl(dm_for_filter_duckdb(), test_table = data_card_1_duckdb())
+    dm(dm_for_filter_duckdb(), test_table = data_card_1_duckdb())
   )
 
   # copying sqlite() `tibble` to `dm` on src of choice
   expect_equivalent_dm(
     suppress_mssql_message(copy_to(dm_for_filter(), data_card_1_duckdb(), "test_table_1")),
-    dm_add_tbl(dm_for_filter(), test_table_1 = data_card_1())
+    dm(dm_for_filter(), test_table_1 = data_card_1())
   )
 })

--- a/tests/testthat/test-draw-dm.R
+++ b/tests/testthat/test-draw-dm.R
@@ -137,9 +137,9 @@ test_that("output", {
       # Multi-fk (#37)
       dm_insert_zoomed("planes_copy") %>%
       # Loose table
-      dm_add_tbl(loose = tibble(a = 1)) %>%
+      dm(loose = tibble(a = 1)) %>%
       # Non-default fk (#402)
-      dm_add_tbl(agency = tibble(airline_name = character())) %>%
+      dm(agency = tibble(airline_name = character())) %>%
       dm_add_fk(agency, airline_name, airlines, name) %>%
       dm_draw(),
     "nycflight-dm.svg"

--- a/tests/testthat/test-filter-dm.R
+++ b/tests/testthat/test-filter-dm.R
@@ -73,11 +73,11 @@ test_that("get_all_filtered_connected() calculates the paths correctly", {
   # Cycles in other components don't affect filtering
   expect_equivalent_dm(
     dm_for_filter_w_cycle() %>%
-      dm_add_tbl(tf_8 = tibble(r = 1)) %>%
+      dm(tf_8 = tibble(r = 1)) %>%
       dm_filter(tf_8, TRUE) %>%
       dm_apply_filters(),
     dm_for_filter_w_cycle() %>%
-      dm_add_tbl(tf_8 = tibble(r = 1))
+      dm(tf_8 = tibble(r = 1))
   )
 
   # FIXME: fails, when it could actually work (check diagram of `dm_for_filter_w_cycle()`)

--- a/tests/testthat/test-paste.R
+++ b/tests/testthat/test-paste.R
@@ -33,7 +33,7 @@ test_that("output", {
     dm_for_filter() %>%
       dm_select(tf_5, k = k, m) %>%
       dm_select(tf_1, a) %>%
-      dm_add_tbl(x = copy_to_my_test_src(tibble(q = 1L), qq)) %>%
+      dm(x = copy_to_my_test_src(tibble(q = 1L), qq)) %>%
       dm_paste(options = "select")
 
     "produce code with colors"

--- a/tests/testthat/test-zoom.R
+++ b/tests/testthat/test-zoom.R
@@ -67,7 +67,7 @@ test_that("dm_insert_zoomed() works", {
     dm_zoom_to(dm_for_filter(), tf_4) %>%
       dm_insert_zoomed("tf_4_new"),
     dm_for_filter() %>%
-      dm_add_tbl(tf_4_new = tf_4()) %>%
+      dm(tf_4_new = tf_4()) %>%
       dm_add_pk(tf_4_new, h) %>%
       dm_add_fk(tf_4_new, c(j, j1), tf_3) %>%
       dm_add_fk(tf_5, l, tf_4_new, on_delete = "cascade")
@@ -87,7 +87,7 @@ test_that("dm_insert_zoomed() works", {
       dm_insert_zoomed("tf_4", repair = "unique", quiet = TRUE),
     dm_for_filter() %>%
       dm_rename_tbl(tf_4...4 = tf_4) %>%
-      dm_add_tbl(tf_4...7 = tf_4()) %>%
+      dm(tf_4...7 = tf_4()) %>%
       dm_add_pk(tf_4...7, h) %>%
       dm_add_fk(tf_4...7, c(j, j1), tf_3) %>%
       dm_add_fk(tf_5, l, tf_4...7, on_delete = "cascade")
@@ -109,7 +109,7 @@ test_that("dm_update_tbl() works", {
     dm_update_zoomed(new_dm_for_filter),
     dm_for_filter() %>%
       dm_rm_tbl(tf_6) %>%
-      dm_add_tbl(tf_6 = tf_7())
+      dm(tf_6 = tf_7())
   )
 })
 

--- a/tests/testthat/test-zzx-deprecated.R
+++ b/tests/testthat/test-zzx-deprecated.R
@@ -7,7 +7,7 @@ test_that("cdm_add_tbl() works", {
 
   expect_equivalent_dm(
     cdm_add_tbl(dm_for_filter_simple(), cars_table = mtcars_tbl),
-    dm_add_tbl(dm_for_filter_simple(), cars_table = mtcars_tbl)
+    dm(dm_for_filter_simple(), cars_table = mtcars_tbl)
   )
 })
 

--- a/vignettes/howto-dm-db.Rmd
+++ b/vignettes/howto-dm-db.Rmd
@@ -130,13 +130,13 @@ my_dm_keys %>%
 ``````
 
 Once you have instantiated a dm object, you can continue to add tables to it.
-For tables from the original source for the dm, use `dm_add_tbl()`
+For tables from the original source for the dm, use `dm()`
 
 ``````{r }
 trans <- tbl(my_db, "trans")
 
 my_dm_keys %>%
-  dm_add_tbl(trans)
+  dm(trans)
 ``````
 
 For tables from other sources or from the local environment, `dplyr::copy_to()` is used.
@@ -151,7 +151,7 @@ my_dm_keys
 
 my_dm_trans <-
   my_dm_keys %>%
-  dm_add_tbl(trans)
+  dm(trans)
 
 my_dm_trans
 ``````

--- a/vignettes/out/howto-dm-db.md
+++ b/vignettes/out/howto-dm-db.md
@@ -145,13 +145,13 @@ my_dm_keys %>%
 ![](/home/kirill/git/R/dm/vignettes/out/howto-dm-db_files/figure-gfm/unnamed-chunk-4-1.png)<!-- -->
 
 Once you have instantiated a dm object you can continue to add tables to
-it. For tables from the original source for the dm, use `dm_add_tbl()`
+it. For tables from the original source for the dm, use `dm()`
 
 ``` r
 trans <- tbl(my_db, "trans")
 
 my_dm_keys %>%
-  dm_add_tbl(trans)
+  dm(trans)
 #> ── Table source ───────────────────────────────────────────────────────────
 #> src:  mysql  [guest@relational.fit.cvut.cz:NA/Financial_ijs]
 #> ── Metadata ───────────────────────────────────────────────────────────────
@@ -182,7 +182,7 @@ my_dm_keys
 
 my_dm_trans <-
   my_dm_keys %>%
-  dm_add_tbl(trans)
+  dm(trans)
 
 my_dm_trans
 #> ── Table source ───────────────────────────────────────────────────────────

--- a/vignettes/out/tech-dm-class.md
+++ b/vignettes/out/tech-dm-class.md
@@ -60,7 +60,7 @@ library(dm)
 empty_dm <- dm()
 empty_dm
 #> dm()
-dm_add_tbl(empty_dm, airlines, airports, flights, planes, weather)
+dm(empty_dm, airlines, airports, flights, planes, weather)
 #> ── Metadata ───────────────────────────────────────────────────────────────
 #> Tables: `airlines`, `airports`, `flights`, `planes`, `weather`
 #> Columns: 53

--- a/vignettes/tech-dm-class.Rmd
+++ b/vignettes/tech-dm-class.Rmd
@@ -64,7 +64,7 @@ library(nycflights13)
 library(dm)
 empty_dm <- dm()
 empty_dm
-dm_add_tbl(empty_dm, airlines, airports, flights, planes, weather)
+dm(empty_dm, airlines, airports, flights, planes, weather)
 ```
 
 ### Coerce a list of tables


### PR DESCRIPTION
Closes #1191.

For #676.