### PR TITLE
feat: `check_key()` uses `vctrs::vec_duplicate_any()` on local data frames for speed

### DIFF
--- a/R/key-helpers.R
+++ b/R/key-helpers.R
@@ -49,15 +49,20 @@ check_key_impl0 <- function(x, x_label) {
   orig_names <- colnames(x)
   cols_chosen <- syms(set_names(orig_names, glue("...{seq_along(orig_names)}")))
 
-  duplicate_rows <-
-    x %>%
-    safe_count(!!!cols_chosen) %>%
-    select(n) %>%
-    filter(n > 1) %>%
-    head(1) %>%
-    collect()
+  if (inherits(x, "data.frame")) {
+    any_duplicate_rows <- vctrs::vec_duplicate_any(x)
+  } else {
+    duplicate_rows <-
+      x %>%
+      safe_count(!!!cols_chosen) %>%
+      select(n) %>%
+      filter(n > 1) %>%
+      head(1) %>%
+      collect()
+    any_duplicate_rows <- nrow(duplicate_rows) != 0
+  }
 
-  if (nrow(duplicate_rows) != 0) {
+  if (any_duplicate_rows) {
     abort_not_unique_key(x_label, orig_names)
   }
 }


### PR DESCRIPTION
closes #1151
Using `vctrs::vec_duplicate_any()` when `.data` is a local data frame makes `check_key()` much faster.

``` r
library(bench)
suppressMessages(library(dm))
#> Warning: package 'dm' was built under R version 4.1.2

set.seed(1)
n <- 1e6

df <- replicate(4, sample(n*.9, n, TRUE), simplify = FALSE) %>%
  setNames(letters[seq_along(.)]) %>%
  tibble::as_tibble()

check_key(df, a, b)
#> Error in `abort_not_unique_key()`:
#> ! (`a`, `b`) not a unique key of `df`.
mark(ck = try(check_key(df, a, b), silent = TRUE))
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 ck            10.2s    10.2s    0.0984     268MB     6.88

suppressMessages(devtools::load_all('~/Documents/GitHub/dm'))

check_key(df, a, b)
#> Error in `abort_not_unique_key()` at dm/R/key-helpers.R:66:4:
#> ! (`a`, `b`) not a unique key of `df`.
mark(ck = try(check_key(df, a, b), silent = TRUE))
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 ck             21ms   22.8ms      40.9    11.9MB     7.22
```

<sup>Created on 2022-07-10 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>