### PR TITLE
docs: Fix column names in `?dm_get_all_pks`

### DIFF
--- a/R/primary-keys.R
+++ b/R/primary-keys.R
@@ -160,7 +160,7 @@ dm_get_pk_impl <- function(dm, table_name) {
 #' @return A tibble with the following columns:
 #'   \describe{
 #'     \item{`table`}{table name,}
-#'     \item{`pk_cols`}{column name(s) of primary key, as list of character vectors.}
+#'     \item{`pk_col`}{column name(s) of primary key, as list of character vectors.}
 #'   }
 #'
 #' @export

--- a/man/dm_get_all_pks.Rd
+++ b/man/dm_get_all_pks.Rd
@@ -19,7 +19,7 @@ The default \code{NULL} returns information for all tables.}
 A tibble with the following columns:
 \describe{
 \item{\code{table}}{table name,}
-\item{\code{pk_cols}}{column name(s) of primary key, as list of character vectors.}
+\item{\code{pk_col}}{column name(s) of primary key, as list of character vectors.}
 }
 }
 \description{


### PR DESCRIPTION
man page says the output tibble contains a column `pk_cols`, but currently it's `pk_col`.

I didn't update the snapshots, since my package setup differs slightly from what is needed to produce the "correct" snapshots, so tests will fail initially.