### PR TITLE
feat: `is_unique_key()`uses `vctrs::vec_count()` on local data frames for speed

### DIFF
--- a/R/key-helpers.R
+++ b/R/key-helpers.R
@@ -75,12 +75,25 @@ is_unique_key_se <- function(.data, colname) {
   col_syms <- syms(colname)
   names(col_syms) <- val_names
 
-  # FIXME: Build expression instead of paste() + parse()
-  any_value_na_expr <- parse(text = paste0("is.na(", val_names, ")", collapse = " | "))[[1]]
+  any_value_na_expr <- 
+    syms(val_names) %>% 
+    map(call2, .fn = quote(is.na)) %>% 
+    reduce(call2, .fn = quote(`|`))
 
-  res_tbl <-
-    .data %>%
-    safe_count(!!!col_syms) %>%
+  if (inherits(.data, "data.frame")) {
+    count_tbl <-
+      .data %>% 
+      select(!!!col_syms) %>% 
+      vctrs::vec_count() %>% 
+      unpack(key) %>% 
+      rename(n = count)
+  } else {
+    count_tbl <-
+      .data %>%
+      safe_count(!!!col_syms)
+  }
+  res_tbl <- 
+    count_tbl %>% 
     mutate(any_na = if_else(!!any_value_na_expr, 1L, 0L)) %>%
     filter(n != 1 | any_na != 0L) %>%
     arrange(desc(n), !!!syms(val_names)) %>%


### PR DESCRIPTION
It looks like you can use `vctrs::vec_count()` to get the same output as `safe_count()` for local data frames much faster. This speeds up `enum_pk_candidates()`

``` r
library(bench)
suppressMessages(library(dm))
#> Warning: package 'dm' was built under R version 4.1.2
suppressMessages(devtools::load_all('~/Documents/GitHub/dm')) # loaded as dm_pr

set.seed(1)
n <- 1e6
sample_out_of <- 4e11

df <- replicate(4, sample(sample_out_of, n, TRUE), simplify = FALSE) %>%
  setNames(letters[seq_along(.)]) %>%
  tibble::as_tibble() %>%
  mutate(a = replace(a, 1:4, NA))

dm_pr::enum_pk_candidates(df)
#> # A tibble: 4 × 3
#>   columns candidate why                                                         
#>   <keys>  <lgl>     <chr>                                                       
#> 1 d       TRUE      ""                                                          
#> 2 a       FALSE     "has 4 missing values, and duplicate values: 80825382988 (2…
#> 3 b       FALSE     "has duplicate values: 3.652e+11 (2)"                       
#> 4 c       FALSE     "has duplicate values: 302837742564 (2), 357345693764 (2)"
mark(epkc_main = dm::enum_pk_candidates(df),
     epkc_pr = dm_pr::enum_pk_candidates(df))
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 epkc_main     44.4s    44.4s    0.0225     968MB     5.45
#> 2 epkc_pr     623.7ms  623.7ms    1.60       496MB     9.62
```

<sup>Created on 2022-07-12 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>