### PR TITLE
feat: `pack_join(keep = TRUE)` preserves order of packed columns

### DIFF
--- a/R/pack_join.R
+++ b/R/pack_join.R
@@ -48,6 +48,8 @@ pack_join.data.frame <- function(x, y, by = NULL, ..., copy = FALSE, keep = FALS
   y_packed <- tidyr::pack(y_local, !!name_var_unique := -all_of(y_keys))
   if (keep) {
     y_packed[[name_var_unique]][y_keys] <- y_packed[y_keys]
+    # sort packed cols in original order
+    y_packed[[name_var_unique]] <- y_packed[[name_var_unique]][(names(y_local))]
   }
   joined <- left_join(x, y_packed, by = by, copy = copy, keep = FALSE)
   # overwrite existing column silently in x if collision, not very safe but consistent with dplyr::nest_join


### PR DESCRIPTION
Sort packed columns in original order. 
Closes #1513 