### PR TITLE
Handle name collisions when wrapping (no suffix)

### DIFF
--- a/R/dm_nest_tbl.R
+++ b/R/dm_nest_tbl.R
@@ -150,8 +150,18 @@ dm_pack_tbl <- function(dm, parent_table, into = NULL) {
   def <- dm_get_def(dm, quiet = TRUE)
   table_data <- def$data[def$table == table_name][[1]]
   child_data <- def$data[def$table == child_name][[1]]
-  packed_data <- pack_join(child_data, table_data, by = set_names(parent_fk, child_fk), name = table_name)
-  class(packed_data[[table_name]]) <- c("packed", class(packed_data[[table_name]]))
+  #packed_data <- pack_join(child_data, table_data, by = set_names(parent_fk, child_fk), name = table_name)
+  #class(packed_data[[table_name]]) <- c("packed", class(packed_data[[table_name]]))
+  parent_fk_suffixed <- paste0(parent_fk, "=", child_fk)
+  # FIXME: fail if weird names exist already
+  table_data <- rename(table_data, !!! set_names(parent_fk, parent_fk_suffixed))
+  packed_data <- pack_join(
+    child_data,
+    table_data,
+    by = set_names(parent_fk_suffixed, child_fk),
+    name = paste0(table_name, "<"),
+    keep = TRUE
+  )
 
   # update def and rebuild dm
   def$data[def$table == child_name] <- list(packed_data)

--- a/R/dm_nest_tbl.R
+++ b/R/dm_nest_tbl.R
@@ -152,13 +152,18 @@ dm_pack_tbl <- function(dm, parent_table, into = NULL) {
   child_data <- def$data[def$table == child_name][[1]]
   #packed_data <- pack_join(child_data, table_data, by = set_names(parent_fk, child_fk), name = table_name)
   #class(packed_data[[table_name]]) <- c("packed", class(packed_data[[table_name]]))
-  parent_fk_suffixed <- paste0(parent_fk, "=", child_fk)
+  new_names <- names(table_data)
+  fk_lgl <- new_names %in% parent_fk
+  pk_lgl <- new_names %in% parent_pk
+  new_names[fk_lgl] <- paste0(parent_fk, "=", child_fk)
+  new_names[pk_lgl] <- paste0(new_names[pk_lgl], "*")
+  new_parent_fk <- new_names[fk_lgl]
   # FIXME: fail if weird names exist already
-  table_data <- rename(table_data, !!! set_names(parent_fk, parent_fk_suffixed))
+  table_data <- set_names(table_data, new_names)
   packed_data <- pack_join(
     child_data,
     table_data,
-    by = set_names(parent_fk_suffixed, child_fk),
+    by = set_names(new_parent_fk, child_fk),
     name = paste0(table_name, "<"),
     keep = TRUE
   )

--- a/R/dm_nest_tbl.R
+++ b/R/dm_nest_tbl.R
@@ -55,23 +55,11 @@ dm_nest_tbl <- function(dm, child_table, into = NULL) {
   def <- dm_get_def(dm, quiet = TRUE)
   table_data <- def$data[def$table == table_name][[1]]
   parent_data <- def$data[def$table == parent_name][[1]]
-  #nested_data <- nest_join(parent_data, table_data, by = set_names(child_fk, parent_fk), name = table_name)
-  #class(nested_data[[table_name]]) <- c("nested", class(nested_data[[table_name]]))
-
-  # FIXME: fail if weird names exist already
-  new_names <- names(table_data)
-  fk_lgl <- new_names %in% child_fk
-  pk_lgl <- new_names %in% child_pk
-  new_names[fk_lgl] <- paste0(child_fk, "=", parent_fk)
-  new_names[pk_lgl] <- paste0(new_names[pk_lgl], "*")
-  new_parent_fk <- new_names[fk_lgl]
-
-  table_data <- set_names(table_data, new_names)
 
   nested_data <- nest_join(
     parent_data,
     table_data,
-    by = set_names(new_parent_fk, parent_fk),
+    by = set_names(child_fk, parent_fk),
     name = table_name,
     keep = TRUE
   )

--- a/R/dm_nest_tbl.R
+++ b/R/dm_nest_tbl.R
@@ -172,20 +172,11 @@ dm_pack_tbl <- function(dm, parent_table, into = NULL) {
   def <- dm_get_def(dm, quiet = TRUE)
   table_data <- def$data[def$table == table_name][[1]]
   child_data <- def$data[def$table == child_name][[1]]
-  #packed_data <- pack_join(child_data, table_data, by = set_names(parent_fk, child_fk), name = table_name)
-  #class(packed_data[[table_name]]) <- c("packed", class(packed_data[[table_name]]))
-  new_names <- names(table_data)
-  fk_lgl <- new_names %in% parent_fk
-  pk_lgl <- new_names %in% parent_pk
-  new_names[fk_lgl] <- paste0(parent_fk, "=", child_fk)
-  new_names[pk_lgl] <- paste0(new_names[pk_lgl], "*")
-  new_parent_fk <- new_names[fk_lgl]
-  # FIXME: fail if weird names exist already
-  table_data <- set_names(table_data, new_names)
+
   packed_data <- pack_join(
     child_data,
     table_data,
-    by = set_names(new_parent_fk, child_fk),
+    by = set_names(parent_fk, child_fk),
     name = table_name,
     keep = TRUE
   )

--- a/R/dm_nest_tbl.R
+++ b/R/dm_nest_tbl.R
@@ -72,7 +72,7 @@ dm_nest_tbl <- function(dm, child_table, into = NULL) {
     parent_data,
     table_data,
     by = set_names(new_parent_fk, parent_fk),
-    name = paste0(table_name, ">"),
+    name = table_name,
     keep = TRUE
   )
 
@@ -186,7 +186,7 @@ dm_pack_tbl <- function(dm, parent_table, into = NULL) {
     child_data,
     table_data,
     by = set_names(new_parent_fk, child_fk),
-    name = paste0(table_name, "<"),
+    name = table_name,
     keep = TRUE
   )
 

--- a/R/dm_unnest_tbl.R
+++ b/R/dm_unnest_tbl.R
@@ -38,47 +38,32 @@
 dm_unnest_tbl <- function(dm, parent_table, col, ptype) {
   # process args and build names
   parent_table_name <- dm_tbl_name(dm, {{ parent_table }})
-  table <- dm[[parent_table_name]]
+  table <- dm_get_tables_impl(dm)[[parent_table_name]]
   col_expr <- enexpr(col)
   nested_col_name <- names(eval_select_indices(col_expr, colnames(table)))
-  new_child_table_name <- sub(">$", "", nested_col_name)
 
-  # child_pk_names <-
-  #   dm_get_all_pks(ptype) %>%
-  #   filter(table == new_child_table_name) %>%
-  #   pull(pk_col) %>%
-  #   unlist()
-
-  # fk <-
-  #   dm_get_all_fks(ptype) %>%
-  #   filter(child_table == new_child_table_name, parent_table == parent_table_name)
-
-  new_table <- vctrs::vec_c(!!!table[[nested_col_name]])
-  raw_names <- names(new_table)
-
-  pattern <- "^([^*=]+?)(=([^*=]+?))?\\*?$"
-  clean_names <- sub(pattern, "\\1", raw_names)
-  child_pk_lgl <- grepl("\\*$", raw_names)
-  child_pk_names <- clean_names[child_pk_lgl]
-  keys <- grep("=", raw_names, value = TRUE)
-  child_fk_names <- sub(pattern, "\\1", keys)
-  parent_fk_names <- sub(pattern, "\\3", keys)
+  parent_pk_names <-
+    dm_get_all_pks(dm) %>%
+    filter(table == parent_table_name) %>%
+    pull(pk_col) %>%
+    unlist()
 
   # extract nested table
-  new_table <-
-    new_table %>%
-    rename(!!!set_names(raw_names, clean_names)) %>%
+  new_table <- vctrs::vec_c(!!!table[[nested_col_name]]) %>%
     distinct()
+  raw_names <- names(new_table)
+
+  child_fk_names <- guess_fks(table, new_table, parent_pk_names)
+  child_pk_names <- guess_pk(new_table)
 
   # update the dm by adding new table, removing nested col and setting keys
-  dm <- dm(dm, !!new_child_table_name := new_table)
+  dm <- dm(dm, !!nested_col_name := new_table)
   dm <- dm_select(dm, !!parent_table_name, -all_of(nested_col_name))
-  if (length(parent_fk_names)) {
-    dm <- dm_add_fk(dm, !!new_child_table_name, !!child_fk_names, !!parent_table_name, !!parent_fk_names)
+  if (length(parent_pk_names)) {
+    dm <- dm_add_fk(dm, !!nested_col_name, !!child_fk_names, !!parent_table_name, !!parent_pk_names)
   }
-
   if (length(child_pk_names)) {
-    dm <- dm_add_pk(dm, !!new_child_table_name, !!child_pk_names)
+    dm <- dm_add_pk(dm, !!nested_col_name, !!child_pk_names)
   }
 
   dm
@@ -182,3 +167,39 @@ dm_unpack_tbl <- function(dm, child_table, col, ptype) {
 
   dm
 }
+
+guess_fks <- function(parent_table, child_table, parent_pk_names) {
+  names_by_type <-
+    child_table %>%
+    map_chr(type_of) %>%
+    split.default(child_table, .) %>%
+    map(names)
+  pk1_candidates <- names_by_type[[typeof(parent_table[[parent_pk_names[1]]])]]
+  combos_df <- reduce(parent_pk_names[-1], .init = tibble(pk1_candidates), function(acc, nxt) {
+    new_candidates <- names_by_type[[typeof(parent_table[[nxt]])]]
+    tidyr::expand_grid(acc, new_candidates) %>%
+      rowwise() %>%
+      filter(n_distinct(c_across()) == ncol(.)) %>%
+      ungroup()
+  })
+  for (i in seq_len(nrow(combos_df))) {
+    combo <- unname(unlist(combos_df[i, ]))
+    combo_is_subset <-
+      nrow(child_table) ==
+        child_table[combo] %>%
+          set_names(parent_pk_names) %>%
+          semi_join(parent_table[parent_pk_names], by = parent_pk_names) %>%
+          nrow()
+    if (combo_is_subset) break
+  }
+  combo
+}
+
+guess_pk <- function(table) {
+  for (i in seq_len(ncol(table))) {
+    if (!anyDuplicated(table[1:i])) {
+      child_pk_names <- names(table)[1:i]
+      break
+    }
+  }
+  child_pk_names

--- a/R/dm_wrap.R
+++ b/R/dm_wrap.R
@@ -156,8 +156,9 @@ dm_unwrap_tbl <- function(dm, ptype, progress = NA) {
 dm_unwrap_tbl_plan <- function(table, table_name) {
   nms <- names(table)
 
-  children <- nms[map_lgl(table, inherits, "nested")]
-  parents <- nms[map_lgl(table, inherits, "packed")]
+  # detect parent and children tables
+  children <- nms[map_lgl(table, is_bare_list)]
+  parents <- nms[map_lgl(table, is.data.frame)]
 
   unnest_plan <-
     tibble(

--- a/tests/testthat/_snaps/dm_nest_tbl.md
+++ b/tests/testthat/_snaps/dm_nest_tbl.md
@@ -19,7 +19,7 @@
       Primary keys: 4
       Foreign keys: 3
     Code
-      dm_packed_nested_unnested <- dm_unnest_tbl(dm_packed_nested, tf_3, tf_2, ptype = dm_for_filter())
+      dm_packed_nested_unnested <- dm_unnest_tbl(dm_packed_nested, tf_3, tf_2)
       dm_packed_nested_unnested
     Output
       -- Metadata --------------------------------------------------------------------
@@ -29,7 +29,7 @@
       Foreign keys: 4
     Code
       dm_packed_nested_unnested_unpacked <- dm_unpack_tbl(dm_packed_nested_unnested,
-        tf_2, tf_1, ptype = dm_for_filter())
+        tf_2, tf_1)
       dm_packed_nested_unnested_unpacked
     Output
       -- Metadata --------------------------------------------------------------------

--- a/tests/testthat/_snaps/dm_nest_tbl.md
+++ b/tests/testthat/_snaps/dm_nest_tbl.md
@@ -20,6 +20,21 @@
       Foreign keys: 3
     Code
       dm_packed_nested_unnested <- dm_unnest_tbl(dm_packed_nested, tf_3, tf_2)
+    Condition
+      Warning:
+      `type_of()` is deprecated as of rlang 0.4.0.
+      Please use `typeof()` or your own version instead.
+      This warning is displayed once every 8 hours.
+      Warning:
+      There were 4 warnings in `filter()`.
+      The first warning was:
+      i In argument: `n_distinct(c_across()) == ncol(.)`.
+      i In row 1.
+      Caused by warning:
+      ! Using `c_across()` without supplying `cols` was deprecated in dplyr 1.1.0.
+      i Please supply `cols` instead.
+      i Run `dplyr::last_dplyr_warnings()` to see the 3 remaining warnings.
+    Code
       dm_packed_nested_unnested
     Output
       -- Metadata --------------------------------------------------------------------

--- a/tests/testthat/_snaps/dm_wrap.md
+++ b/tests/testthat/_snaps/dm_wrap.md
@@ -13,28 +13,28 @@
       wrapped$tf_4
     Output
       # A tibble: 5 x 6
-        h     i     j        j1 tf_3$g $tf_2            tf_5            
-        <chr> <chr> <chr> <int> <chr>  <nested>         <nested>        
-      1 a     three C         3 two    <tibble [0 x 3]> <tibble [0 x 4]>
-      2 b     four  D         4 three  <tibble [1 x 3]> <tibble [1 x 4]>
-      3 c     five  E         5 four   <tibble [2 x 3]> <tibble [1 x 4]>
-      4 d     six   F         6 five   <tibble [2 x 3]> <tibble [1 x 4]>
-      5 e     seven F         6 five   <tibble [2 x 3]> <tibble [1 x 4]>
+        h     i     j        j1 tf_3$g $tf_2            $`f=j*` $`f1=j1*` tf_5    
+        <chr> <chr> <chr> <int> <chr>  <list>           <chr>       <int> <list>  
+      1 a     three C         3 two    <tibble [0 x 5]> C               3 <tibble>
+      2 b     four  D         4 three  <tibble [1 x 5]> D               4 <tibble>
+      3 c     five  E         5 four   <tibble [2 x 5]> E               5 <tibble>
+      4 d     six   F         6 five   <tibble [2 x 5]> F               6 <tibble>
+      5 e     seven F         6 five   <tibble [2 x 5]> F               6 <tibble>
     Code
       wrapped$tf_4$tf_3$tf_2[[3]]
     Output
-      # A tibble: 2 x 3
-        c         d tf_1$b
-        <chr> <int> <chr> 
-      1 lion      3 C     
-      2 dog       6 F     
+      # A tibble: 2 x 5
+        `c*`      d `e=f` `e1=f1` tf_1$b $`a=d*`
+        <chr> <int> <chr>   <int> <chr>    <int>
+      1 lion      3 E           5 C            3
+      2 dog       6 E           5 F            6
     Code
       wrapped$tf_4$tf_5[[2]]
     Output
-      # A tibble: 1 x 4
-           ww     k m     tf_6$zz $o   
-        <int> <int> <chr>   <int> <chr>
-      1     2     1 house       1 e    
+      # A tibble: 1 x 5
+           ww  `k*` `l=h` m     tf_6$zz $`o*` $`n=m`
+        <int> <int> <chr> <chr>   <int> <chr> <chr> 
+      1     2     1 b     house       1 e     house 
 
 ---
 
@@ -62,22 +62,22 @@
       unwrapped$tf_1
     Output
       # A tibble: 5 x 2
-            a b    
-        <int> <chr>
-      1     2 B    
-      2     3 C    
-      3     6 F    
-      4     4 D    
-      5     7 G    
+        b         a
+        <chr> <int>
+      1 B         2
+      2 C         3
+      3 F         6
+      4 D         4
+      5 G         7
     Code
       unwrapped$tf_6
     Output
       # A tibble: 3 x 3
-        n             zz o    
-        <chr>      <int> <chr>
-      1 house          1 e    
-      2 tree           1 f    
-      3 streetlamp     1 h    
+           zz o     n         
+        <int> <chr> <chr>     
+      1     1 e     house     
+      2     1 f     tree      
+      3     1 h     streetlamp
 
 # `node_type_from_graph()` works
 

--- a/tests/testthat/_snaps/dm_wrap.md
+++ b/tests/testthat/_snaps/dm_wrap.md
@@ -13,28 +13,28 @@
       wrapped$tf_4
     Output
       # A tibble: 5 x 6
-        h     i     j        j1 tf_3$g $tf_2            $`f=j*` $`f1=j1*` tf_5    
-        <chr> <chr> <chr> <int> <chr>  <list>           <chr>       <int> <list>  
-      1 a     three C         3 two    <tibble [0 x 5]> C               3 <tibble>
-      2 b     four  D         4 three  <tibble [1 x 5]> D               4 <tibble>
-      3 c     five  E         5 four   <tibble [2 x 5]> E               5 <tibble>
-      4 d     six   F         6 five   <tibble [2 x 5]> F               6 <tibble>
-      5 e     seven F         6 five   <tibble [2 x 5]> F               6 <tibble>
+        h     i     j        j1 tf_3$f   $f1 $g    $tf_2            tf_5            
+        <chr> <chr> <chr> <int> <chr>  <int> <chr> <list>           <list>          
+      1 a     three C         3 C          3 two   <tibble [0 x 5]> <tibble [0 x 5]>
+      2 b     four  D         4 D          4 three <tibble [1 x 5]> <tibble [1 x 5]>
+      3 c     five  E         5 E          5 four  <tibble [2 x 5]> <tibble [1 x 5]>
+      4 d     six   F         6 F          6 five  <tibble [2 x 5]> <tibble [1 x 5]>
+      5 e     seven F         6 F          6 five  <tibble [2 x 5]> <tibble [1 x 5]>
     Code
       wrapped$tf_4$tf_3$tf_2[[3]]
     Output
       # A tibble: 2 x 5
-        `c*`      d `e=f` `e1=f1` tf_1$b $`a=d*`
-        <chr> <int> <chr>   <int> <chr>    <int>
-      1 lion      3 E           5 C            3
-      2 dog       6 E           5 F            6
+        c         d e        e1 tf_1$a $b   
+        <chr> <int> <chr> <int>  <int> <chr>
+      1 lion      3 E         5      3 C    
+      2 dog       6 E         5      6 F    
     Code
       wrapped$tf_4$tf_5[[2]]
     Output
       # A tibble: 1 x 5
-           ww  `k*` `l=h` m     tf_6$zz $`o*` $`n=m`
-        <int> <int> <chr> <chr>   <int> <chr> <chr> 
-      1     2     1 b     house       1 e     house 
+           ww     k l     m     tf_6$zz $n    $o   
+        <int> <int> <chr> <chr>   <int> <chr> <chr>
+      1     2     1 b     house       1 house e    
 
 ---
 
@@ -62,22 +62,22 @@
       unwrapped$tf_1
     Output
       # A tibble: 5 x 2
-        b         a
-        <chr> <int>
-      1 B         2
-      2 C         3
-      3 F         6
-      4 D         4
-      5 G         7
+            a b    
+        <int> <chr>
+      1     2 B    
+      2     3 C    
+      3     6 F    
+      4     4 D    
+      5     7 G    
     Code
       unwrapped$tf_6
     Output
       # A tibble: 3 x 3
-           zz o     n         
-        <int> <chr> <chr>     
-      1     1 e     house     
-      2     1 f     tree      
-      3     1 h     streetlamp
+           zz n          o    
+        <int> <chr>      <chr>
+      1     1 house      e    
+      2     1 tree       f    
+      3     1 streetlamp h    
 
 # `node_type_from_graph()` works
 

--- a/tests/testthat/_snaps/dm_wrap.md
+++ b/tests/testthat/_snaps/dm_wrap.md
@@ -40,6 +40,17 @@
 
     Code
       unwrapped <- dm_unwrap_tbl(dm_wrap_tbl(dm_for_filter(), tf_4), dm_for_filter())
+    Condition
+      Warning:
+      There were 4 warnings in `filter()`.
+      The first warning was:
+      i In argument: `n_distinct(c_across()) == ncol(.)`.
+      i In row 1.
+      Caused by warning:
+      ! Using `c_across()` without supplying `cols` was deprecated in dplyr 1.1.0.
+      i Please supply `cols` instead.
+      i Run `dplyr::last_dplyr_warnings()` to see the 3 remaining warnings.
+    Code
       unwrapped
     Output
       -- Metadata --------------------------------------------------------------------

--- a/tests/testthat/test-dm_nest_tbl.R
+++ b/tests/testthat/test-dm_nest_tbl.R
@@ -22,11 +22,11 @@ test_that("`dm_pack_tbl()`, `dm_unpack_tbl()`, `dm_nest_tbl()`, `dm_unnest_tbl()
     dm_packed_nested
 
     #dm_packed_nested_unnested <- dm_unnest_tbl(dm_packed_nested, tf_3, tf_2, ptype = dm_for_filter())
-    dm_packed_nested_unnested <- dm_unnest_tbl(dm_packed_nested, tf_3, `tf_2>`)
+    dm_packed_nested_unnested <- dm_unnest_tbl(dm_packed_nested, tf_3, tf_2)
     dm_packed_nested_unnested
 
     #dm_packed_nested_unnested_unpacked <- dm_unpack_tbl(dm_packed_nested_unnested, tf_2, tf_1, ptype = dm_for_filter())
-    dm_packed_nested_unnested_unpacked <- dm_unpack_tbl(dm_packed_nested_unnested, tf_2, `tf_1<`)
+    dm_packed_nested_unnested_unpacked <- dm_unpack_tbl(dm_packed_nested_unnested, tf_2, tf_1)
     dm_packed_nested_unnested_unpacked
   })
 })

--- a/tests/testthat/test-dm_nest_tbl.R
+++ b/tests/testthat/test-dm_nest_tbl.R
@@ -21,10 +21,12 @@ test_that("`dm_pack_tbl()`, `dm_unpack_tbl()`, `dm_nest_tbl()`, `dm_unnest_tbl()
     dm_packed_nested <- dm_nest_tbl(dm_packed, tf_2)
     dm_packed_nested
 
-    dm_packed_nested_unnested <- dm_unnest_tbl(dm_packed_nested, tf_3, tf_2, ptype = dm_for_filter())
+    #dm_packed_nested_unnested <- dm_unnest_tbl(dm_packed_nested, tf_3, tf_2, ptype = dm_for_filter())
+    dm_packed_nested_unnested <- dm_unnest_tbl(dm_packed_nested, tf_3, `tf_2>`)
     dm_packed_nested_unnested
 
-    dm_packed_nested_unnested_unpacked <- dm_unpack_tbl(dm_packed_nested_unnested, tf_2, tf_1, ptype = dm_for_filter())
+    #dm_packed_nested_unnested_unpacked <- dm_unpack_tbl(dm_packed_nested_unnested, tf_2, tf_1, ptype = dm_for_filter())
+    dm_packed_nested_unnested_unpacked <- dm_unpack_tbl(dm_packed_nested_unnested, tf_2, `tf_1<`)
     dm_packed_nested_unnested_unpacked
   })
 })

--- a/tests/testthat/test-dm_nest_tbl.R
+++ b/tests/testthat/test-dm_nest_tbl.R
@@ -21,11 +21,11 @@ test_that("`dm_pack_tbl()`, `dm_unpack_tbl()`, `dm_nest_tbl()`, `dm_unnest_tbl()
     dm_packed_nested <- dm_nest_tbl(dm_packed, tf_2)
     dm_packed_nested
 
-    #dm_packed_nested_unnested <- dm_unnest_tbl(dm_packed_nested, tf_3, tf_2, ptype = dm_for_filter())
+    # dm_packed_nested_unnested <- dm_unnest_tbl(dm_packed_nested, tf_3, tf_2, ptype = dm_for_filter())
     dm_packed_nested_unnested <- dm_unnest_tbl(dm_packed_nested, tf_3, tf_2)
     dm_packed_nested_unnested
 
-    #dm_packed_nested_unnested_unpacked <- dm_unpack_tbl(dm_packed_nested_unnested, tf_2, tf_1, ptype = dm_for_filter())
+    # dm_packed_nested_unnested_unpacked <- dm_unpack_tbl(dm_packed_nested_unnested, tf_2, tf_1, ptype = dm_for_filter())
     dm_packed_nested_unnested_unpacked <- dm_unpack_tbl(dm_packed_nested_unnested, tf_2, tf_1)
     dm_packed_nested_unnested_unpacked
   })


### PR DESCRIPTION
Towards #867.

After discussion in #1453 we propose unwrapping without using nesting/packing cols nor nested/packed cols to store constraints metadata.

When unnesting :
* we know the PK of the parent but we lost the FK relationship and the PK of the child
* The parent key in the nesting parent is assumed to be its PK
* The foreign key in the nested child is the first found combination of columns of compatible types which contains a subset of the parent key 
* The pk of the child to unnest is found by testing if the nth leftmost columns form a unique key, iterating from 1 to the number of cols.

When unpacking :
* We know nothing about the constraints relevant to the unpacking operation
* The pk of the parent to unpack is found by testing if the nth leftmost columns form a unique key, iterating from 1 to the number of cols.
* The parent key is assumed to be the parent's pk
* The FK in the packing child is the first found combination of columns of compatible types which contains a subset of the parent key 

See below the original `dm_for_filter()` followed by its wrapped then unwrapped counterpart.

``` r
dm1 <- dm_for_filter()
dm_draw(dm1, view_type = "all")
```

![](https://i.imgur.com/lQIB4Un.png)

``` r
dm_wrapped <- dm_wrap_tbl(dm1, tf_4)
dm_unwrapped <- dm_unwrap_tbl(dm_wrapped, dm1)
dm_draw(dm_unwrapped, view_type = "all")
```

![](https://i.imgur.com/ODbcpNv.png)


We see a lot of constraints got mixed up but we get the right diagram shape.

Next steps as I see them if we pursue in this direction:
* More efficient detection of constraints, even on the flights dm this runs forever because of expand_grid() + rowwise(). I think that for each new candidate we need to test if the n first candidates are a subset of the n first parent keys. Right now we compute every type compatible combination first and it goes into the millions.
* Add the key information to the unwrap plan arguments
* update `dm_unnest_tbl()` and `dm_unpack_tbl()` with arguments to set the keys.
  * `dm_unnest_tbl(dm, parent_table, col, ptype)` might become `dm_unnest_tbl(dm, parent_table, col, parent_key, child_fk, child_pk)`
  *  `dm_unpack_tbl(dm, child_table, col, ptype)` might become `dm_unnest_tbl(dm, child_table, col, child_fk , parent_key, parent_pk)`
  * OR instead of `parent_key` and `child_fk` args we use a {dplyr} join like syntax (as in the by arg), 
  * Print calls built from plan so user can adjust the keys.

