### PR TITLE
Harmonize vignette titles and entries

### DIFF
--- a/vignettes/dm.Rmd
+++ b/vignettes/dm.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Getting started with dm"
+title: "First read: Getting started with dm"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >

--- a/vignettes/howto-dm-copy.Rmd
+++ b/vignettes/howto-dm-copy.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Copy tables to and from a database"
+title: "How to: Copy data to and from a database"
 date: "`r Sys.Date()`"
 author: James Wondrasek, Kirill Müller
 output: rmarkdown::html_vignette

--- a/vignettes/howto-dm-db.Rmd
+++ b/vignettes/howto-dm-db.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Create a dm object from a database"
+title: "How to: Create a dm object from a database"
 date: "`r Sys.Date()`"
 author: James Wondrasek, Kirill Müller
 output:

--- a/vignettes/howto-dm-df.Rmd
+++ b/vignettes/howto-dm-df.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Create a dm object from data frames"
+title: "How to: Create a dm object from data frames"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >

--- a/vignettes/howto-dm-rows.Rmd
+++ b/vignettes/howto-dm-rows.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Insert, update, or remove rows in a database"
+title: "How to: Insert, update or remove rows in a database"
 date: "`r Sys.Date()`"
 author: James Wondrasek
 output: rmarkdown::html_vignette

--- a/vignettes/tech-dm-cdm.Rmd
+++ b/vignettes/tech-dm-cdm.Rmd
@@ -1,10 +1,10 @@
 ---
-title: "Migration guide: 'cdm' -> 'dm'"
+title: "Technical: Migration guide: 'cdm' -> 'dm'"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Technical: Migration guide: 'cdm' -> 'dm'}
   %\VignetteEncoding{UTF-8}
+  %\VignetteIndexEntry{Technical: Migration guide: 'cdm' -> 'dm'}
   %\VignetteEngine{knitr::rmarkdown}
 editor_options:
   chunk_output_type: console

--- a/vignettes/tech-dm-class.Rmd
+++ b/vignettes/tech-dm-class.Rmd
@@ -1,10 +1,10 @@
 ---
-title: "Class dm and basic operations"
+title: "Technical: Class dm and basic operations"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Technical: Class dm and basic operations}
   %\VignetteEncoding{UTF-8}
+  %\VignetteIndexEntry{Technical: Class dm and basic operations}
   %\VignetteEngine{knitr::rmarkdown}
 editor_options:
   chunk_output_type: console

--- a/vignettes/tech-dm-draw.Rmd
+++ b/vignettes/tech-dm-draw.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Visualizing dm objects"
+title: "Techincal: Visualizing dm objects"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >

--- a/vignettes/tech-dm-filter.Rmd
+++ b/vignettes/tech-dm-filter.Rmd
@@ -1,10 +1,10 @@
 ---
-title: "Filtering in relational data models"
+title: "Technical: Filtering in relational data models"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Technical: Filtering in relational data models}
   %\VignetteEncoding{UTF-8}
+  %\VignetteIndexEntry{Technical: Filtering in relational data models}
   %\VignetteEngine{knitr::rmarkdown}
 editor_options:
   chunk_output_type: console

--- a/vignettes/tech-dm-join.Rmd
+++ b/vignettes/tech-dm-join.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Joining in relational data models"
+title: "Technical: Joining in relational data models"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >

--- a/vignettes/tech-dm-keyed.Rmd
+++ b/vignettes/tech-dm-keyed.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Manipulating individual tables"
+title: "Technical: Manipulating individual tables"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Technical: Manipulating individual tables}

--- a/vignettes/tech-dm-low-level.Rmd
+++ b/vignettes/tech-dm-low-level.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Model verification - keys, constraints and normalization"
+title: "Technical: Model verification - keys, constraints and normalization"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >

--- a/vignettes/tech-dm-naming.Rmd
+++ b/vignettes/tech-dm-naming.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Function naming logic"
+title: "Technical: Function naming logic"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteEncoding{UTF-8}

--- a/vignettes/tech-dm-zoom.Rmd
+++ b/vignettes/tech-dm-zoom.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Zooming and manipulating tables"
+title: "Technical: Zooming and manipulating tables"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Technical: Zooming and manipulating tables}


### PR DESCRIPTION
To avoid warnings while building vignettes:

```r
Warning: Warning: The vignette title specified in \VignetteIndexEntry{} is different from the title in the YAML metadata. The former is "First read: Getting started with dm", and the latter is "Getting started with dm". If that is intentional, you may set options(rmarkdown.html_vignette.check_title = FALSE) to suppress this check.

Warning: Warning: The vignette title specified in \VignetteIndexEntry{} is different from the title in the YAML metadata. The former is "How to: Create a dm object from a database", and the latter is "Create a dm object from a database". If that is intentional, you may set options(rmarkdown.html_vignette.check_title = FALSE) to suppress this check.

...
```

The other option is to build vignettes with the following option: `options(rmarkdown.html_vignette.check_title = FALSE)`.

Not sure which one we should prefer. I personally prefer having the same, detailed titles on the pkgdown website as on CRAN.