### PR TITLE
chore: Use correctly typed missing value for lists

### DIFF
--- a/R/gui-gui_global.R
+++ b/R/gui-gui_global.R
@@ -75,17 +75,17 @@ reactable_column <- function(data, table_name) {
               dplyr::if_else(
                 data$is_pk[index],
                 list(htmltools::span(style = "margin-right: 10px;", title = "Primary key", shiny::icon(verify_fa = FALSE, "key"))),
-                NULL
+                list(NULL)
               ),
               dplyr::if_else(
                 data$is_child_fk[index],
                 list(htmltools::span(style = "margin-right: 10px;", title = "Child in foreign key", shiny::icon(verify_fa = FALSE, "angle-double-right"))),
-                NULL
+                list(NULL)
               ),
               dplyr::if_else(
                 data$is_parent_key[index],
                 list(htmltools::span(style = "margin-right: 10px;", title = "Parent key", shiny::icon(verify_fa = FALSE, "angle-double-left"))),
-                NULL
+                list(NULL)
               ),
               shiny::span(class = "tag", style = "color: #999; border-color: #999;", title = paste0("Data type: ", data$type[index]), data$type[index])
             )

--- a/tests/testthat/test-validate.R
+++ b/tests/testthat/test-validate.R
@@ -75,7 +75,7 @@ test_that("validator speaks up when something's wrong", {
     dm_for_filter() %>%
       dm_zoom_to(tf_1) %>%
       dm_get_def() %>%
-      mutate(zoom = if_else(table == "tf_1", list(1), NULL)) %>%
+      mutate(zoom = if_else(table == "tf_1", list(1), list(NULL))) %>%
       new_dm3(zoomed = TRUE) %>%
       dm_validate(),
     "dm_invalid"

--- a/tests/testthat/test-zoom.R
+++ b/tests/testthat/test-zoom.R
@@ -99,8 +99,8 @@ test_that("dm_update_tbl() works", {
   new_dm_for_filter <-
     dm_get_def(dm_for_filter()) %>%
     mutate(
-      zoom = if_else(table == "tf_6", list(tf_7()), NULL),
-      col_tracker_zoom = if_else(table == "tf_6", list(character()), NULL),
+      zoom = if_else(table == "tf_6", list(tf_7()), list(NULL)),
+      col_tracker_zoom = if_else(table == "tf_6", list(character()), list(NULL)),
     ) %>%
     new_dm3(zoomed = TRUE)
 


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

- `if_else()` now uses vctrs, which generally makes it more permissive when there are varying types, but it also means that the inputs must always be vectors. In dm's case, `NULL` was being used as the missing type for lists, when really `list(NULL)` needs to be used for vctrs

In dev dplyr, you could also just use `NA` now but that won't work with CRAN dplyr.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package in ahead of time! Thanks!

---

Also, I think if you try and check this against dev dplyr right now then you'll see an additional failure related to `left_join()` and unused arguments. I think we are going to fix that in dplyr so it should go away.

There are also some local failures related to join snapshots changing because of the `multiple = "all"` warning that is now thrown when a join results in multiple matches. When 1.1.0 is released you can just update the snapshots or set `multiple = "all"` explicitly