### PR TITLE
feat: support AI PKs for dm_copy_to() for empty tables (ptype)

### DIFF
--- a/R/build_copy_queries.R
+++ b/R/build_copy_queries.R
@@ -32,7 +32,7 @@ build_copy_queries <- function(dest, dm, set_key_constraints = TRUE, temporary =
 
     tbl <- tbl_impl(dm, x)
     types <- DBI::dbDataType(con, tbl)
-    autoincrement_attribute <- " "
+    autoincrement_attribute <- ""
 
     # database-specific type conversions
     if (is_mariadb(dest)) {
@@ -73,18 +73,14 @@ build_copy_queries <- function(dest, dm, set_key_constraints = TRUE, temporary =
       # necessary to use the `AUTOINCREMENT` keyword. So nothing we need to do here.
       # Ref: https://www.sqlite.org/autoinc.html
     }
-
     df_col_types <-
       enframe(types, "col", "type") %>%
-      mutate(autoincrement_attribute = " ")
+      mutate(autoincrement_attribute = "")
 
     if (length(pk_col) > 0L) {
       df_col_types <-
         df_col_types %>%
-        mutate(autoincrement_attribute = case_when(
-          col == pk_col ~ autoincrement_attribute,
-          TRUE ~ autoincrement_attribute
-        ))
+        mutate(autoincrement_attribute = autoincrement_attribute)
     }
 
     df_col_types

--- a/R/build_copy_queries.R
+++ b/R/build_copy_queries.R
@@ -80,7 +80,12 @@ build_copy_queries <- function(dest, dm, set_key_constraints = TRUE, temporary =
     if (length(pk_col) > 0L) {
       df_col_types <-
         df_col_types %>%
-        mutate(autoincrement_attribute = autoincrement_attribute)
+        mutate(autoincrement_attribute = if_else(
+          col == pk_col,
+          !!autoincrement_attribute,
+          autoincrement_attribute
+        )
+      )
     }
 
     df_col_types

--- a/R/db-helpers.R
+++ b/R/db-helpers.R
@@ -51,6 +51,10 @@ is_duckdb <- function(dest) {
   inherits(dest, c("duckdb_connection", "src_duckdb_connection"))
 }
 
+is_sqlite <- function(dest) {
+  inherits(dest, "SQLiteConnection")
+}
+
 is_mssql <- function(dest) {
   inherits(dest, c(
     "Microsoft SQL Server", "src_Microsoft SQL Server", "dblogConnection-Microsoft SQL Server", "src_dblogConnection-Microsoft SQL Server"

--- a/tests/testthat/_snaps/autoincrement.md
+++ b/tests/testthat/_snaps/autoincrement.md
@@ -9,3 +9,34 @@
       Primary keys: 2
       Foreign keys: 1
 
+# autoincrement produces valid SQL queries and R code - RSQLite
+
+    Code
+      df$sql_table
+    Output
+      <SQL> CREATE TEMPORARY TABLE x (
+        `x_id` INTEGER,
+        `x_data` TEXT,
+        PRIMARY KEY (`x_id`)
+      )
+      <SQL> CREATE TEMPORARY TABLE y (
+        `y_id` INTEGER,
+        `x_id` INTEGER,
+        `y_data` TEXT,
+        PRIMARY KEY (`y_id`),
+        FOREIGN KEY (`x_id`) REFERENCES x (`x_id`)
+      )
+
+---
+
+    Code
+      dm_paste(dm)
+    Message
+      dm::dm(
+        x,
+        y,
+      ) %>%
+        dm::dm_add_pk(x, x_id, autoincrement = TRUE) %>%
+        dm::dm_add_pk(y, y_id) %>%
+        dm::dm_add_fk(y, x_id, x)
+

--- a/tests/testthat/helper-src.R
+++ b/tests/testthat/helper-src.R
@@ -700,6 +700,15 @@ nyc_comp %<--% {
 dm_zoomed <- function() dm_zoom_to(dm_for_filter(), tf_2)
 dm_zoomed_2 <- function() dm_zoom_to(dm_for_filter(), tf_3)
 
+dm_for_autoinc_1 %<-% {
+  dm(
+    t1 = tibble(a = 5:7, b = letters[1:3]),
+    t2 = tibble(c = 10:8, d = 7:5),
+    t3 = tibble(e = c(6L, 5L, 7L), f = letters[1:3]),
+    t4 = tibble(g = 1:3, h = 8:10)
+  )
+}
+
 # FIXME: regarding PR #313: everything below this line needs to be at least reconsidered if not just dumped.
 
 # for database tests -------------------------------------------------

--- a/tests/testthat/test-autoincrement.R
+++ b/tests/testthat/test-autoincrement.R
@@ -16,3 +16,11 @@ dm <- dm(x, y) %>%
 test_that("autoincrement produces valid R code", {
   expect_snapshot(dm)
 })
+
+test_that("autoincrement produces valid SQL queries and R code - RSQLite", {
+  con <- DBI::dbConnect(RSQLite::SQLite())
+  df <- dm:::build_copy_queries(con, dm)
+
+  expect_snapshot(df$sql_table)
+  expect_snapshot(dm_paste(dm))
+})

--- a/tests/testthat/test-db-interface.R
+++ b/tests/testthat/test-db-interface.R
@@ -254,7 +254,7 @@ test_that("build_copy_queries avoids duplicate indexes", {
   )
 })
 
-test_that("copy_dm_to() works with autoincrement PKs and FKS for Postgres", {
+test_that("copy_dm_to() works with autoincrement PKs and FKS on selected DBs", {
   skip_if_src_not(c("postgres", "sqlite", "mssql"))
 
   con_db <- my_test_con()

--- a/tests/testthat/test-db-interface.R
+++ b/tests/testthat/test-db-interface.R
@@ -255,7 +255,7 @@ test_that("build_copy_queries avoids duplicate indexes", {
 })
 
 test_that("copy_dm_to() works with autoincrement PKs and FKS on selected DBs", {
-  skip_if_src_not(c("postgres", "sqlite", "mssql"))
+  skip_if_src_not(c("postgres", "sqlite", "mssql", "maria"))
 
   con_db <- my_test_con()
   local_dm_ptype <- dm_for_autoinc_1() %>%

--- a/tests/testthat/test-db-interface.R
+++ b/tests/testthat/test-db-interface.R
@@ -271,7 +271,7 @@ test_that("copy_dm_to() works with autoincrement PKs and FKS on selected DBs", {
     order_of_deletion <- c("t4", "t2", "t3", "t1")
     walk(
       dm_get_tables_impl(remote_dm)[order_of_deletion],
-      ~ try(dbExecute(src_db$con, paste0("DROP TABLE ", dbplyr::remote_name(.x))))
+      ~ try(dbExecute(con_db, paste0("DROP TABLE ", dbplyr::remote_name(.x))))
     )
   })
 

--- a/tests/testthat/test-db-interface.R
+++ b/tests/testthat/test-db-interface.R
@@ -253,3 +253,42 @@ test_that("build_copy_queries avoids duplicate indexes", {
     }
   )
 })
+
+test_that("copy_dm_to() works with autoincrement PKs and FKS for Postgres", {
+  skip_if_src_not(c("postgres", "sqlite", "mssql"))
+
+  con_db <- my_test_con()
+  local_dm_ptype <- dm_for_autoinc_1() %>%
+    collect() %>%
+    dm_add_pk(t1, a, autoincrement = TRUE) %>%
+    dm_add_pk(t2, c, autoincrement = TRUE) %>%
+    dm_add_fk(t2, d, t1) %>%
+    dm_add_fk(t3, e, t1) %>%
+    dm_add_fk(t4, h, t2) %>%
+    dm_ptype()
+
+  withr::defer({
+    order_of_deletion <- c("t4", "t2", "t3", "t1")
+    walk(
+      dm_get_tables_impl(remote_dm)[order_of_deletion],
+      ~ try(dbExecute(src_db$con, paste0("DROP TABLE ", dbplyr::remote_name(.x))))
+    )
+  })
+
+  # FIXME: how to check if autoincrement is actually set on DB?
+  expect_silent(
+    remote_dm <- copy_dm_to(
+      con_db,
+      local_dm_ptype,
+      temporary = FALSE
+    )
+  )
+
+  collected_dm <- remote_dm %>%
+    collect()
+
+  expect_equivalent_dm(
+    local_dm_ptype,
+    collected_dm
+  )
+})


### PR DESCRIPTION
on SQLite, SQL Server, Postgres

code mostly taken from https://github.com/cynkra/dm/pull/1654