### PR TITLE
feat: `dm_get_all_pks()` and `dm_get_all_fks()` keep order of `table` or `parent_table` argument

### DIFF
--- a/R/primary-keys.R
+++ b/R/primary-keys.R
@@ -158,12 +158,13 @@ dm_get_pk_impl <- function(dm, table_name) {
 #' Get all primary keys of a [`dm`] object
 #'
 #' @description
-#' `dm_get_all_pks()` checks the `dm` object for set primary keys and
-#' returns the tables, the respective primary key columns and their classes.
+#' `dm_get_all_pks()` checks the `dm` object for primary keys and
+#' returns the tables, the respective primary key columns, and their classes.
 #'
 #' @family primary key functions
 #' @param table One or more table names, as character vector,
 #'   to return primary key information for.
+#'   If given, primary keys are returned in that order.
 #'   The default `NULL` returns information for all tables.
 #'
 #' @inheritParams dm_add_pk
@@ -196,7 +197,11 @@ dm_get_all_pks_def_impl <- function(def, table = NULL) {
   def_sub <- def[c("table", "pks")]
 
   if (!is.null(table)) {
-    def_sub <- def_sub[def_sub$table %in% table, ]
+    idx <- match(table, def_sub$table)
+    if (anyNA(idx)) {
+      abort(paste0("Table not in dm object: ", parent_table[which(is.na(idx))[[1]]]))
+    }
+    def_sub <- def_sub[match(table, def_sub$table), ]
   }
 
   out <-

--- a/man/dm_get_all_fks.Rd
+++ b/man/dm_get_all_fks.Rd
@@ -11,6 +11,7 @@ dm_get_all_fks(dm, parent_table = NULL, ...)
 
 \item{parent_table}{One or more table names, as character vector,
 to return foreign key information for.
+If given, foreign keys are returned in that order.
 The default \code{NULL} returns information for all tables.}
 
 \item{...}{These dots are for future extensions and must be empty.}

--- a/man/dm_get_all_pks.Rd
+++ b/man/dm_get_all_pks.Rd
@@ -11,6 +11,7 @@ dm_get_all_pks(dm, table = NULL, ...)
 
 \item{table}{One or more table names, as character vector,
 to return primary key information for.
+If given, primary keys are returned in that order.
 The default \code{NULL} returns information for all tables.}
 
 \item{...}{These dots are for future extensions and must be empty.}
@@ -23,8 +24,8 @@ A tibble with the following columns:
 }
 }
 \description{
-\code{dm_get_all_pks()} checks the \code{dm} object for set primary keys and
-returns the tables, the respective primary key columns and their classes.
+\code{dm_get_all_pks()} checks the \code{dm} object for primary keys and
+returns the tables, the respective primary key columns, and their classes.
 }
 \examples{
 \dontshow{if (rlang::is_installed("nycflights13")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/tests/testthat/test-foreign-keys.R
+++ b/tests/testthat/test-foreign-keys.R
@@ -266,3 +266,21 @@ test_that("bogus arguments are rejected", {
       dm_add_fk(a, x, b, x, on_delete = letters)
   })
 })
+
+
+# all foreign keys --------------------------------------------------------------------
+
+test_that("dm_get_all_fks() and order", {
+  dm <- dm_for_filter()
+  fks_all <- dm_get_all_fks(dm)
+  fks_1 <- dm_get_all_fks(dm, "tf_1")
+  fks_3 <- dm_get_all_fks(dm, "tf_3")
+  fks_4 <- dm_get_all_fks(dm, "tf_4")
+  fks_6 <- dm_get_all_fks(dm, "tf_6")
+  fks_34 <- dm_get_all_fks(dm, c("tf_3", "tf_4"))
+  fks_43 <- dm_get_all_fks(dm, c("tf_4", "tf_3"))
+
+  expect_equal(fks_all, bind_rows(fks_1, fks_3, fks_4, fks_6))
+  expect_equal(fks_34, bind_rows(fks_3, fks_4))
+  expect_equal(fks_43, bind_rows(fks_4, fks_3))
+})

--- a/tests/testthat/test-primary-keys.R
+++ b/tests/testthat/test-primary-keys.R
@@ -177,6 +177,19 @@ test_that("output", {
 })
 
 
+# all primary keys --------------------------------------------------------------------
+
+test_that("dm_get_all_pks() and order", {
+  dm <- nyc_comp()
+  pks_all <- dm_get_all_pks(dm)
+  pks_12 <- dm_get_all_pks(dm, names(dm)[1:2])
+  pks_21 <- dm_get_all_pks(dm, names(dm)[2:1])
+
+  expect_equal(pks_all[1:2, ], pks_12)
+  expect_equal(pks_all[2:1, ], pks_21)
+})
+
+
 # tests for compound keys -------------------------------------------------
 
 test_that("dm_get_all_pks() with compound keys", {


### PR DESCRIPTION
For #1698.