### PR TITLE
Chore: accept dm tables that are tbl_sql but not tbl_dbi

### DIFF
--- a/R/validate.R
+++ b/R/validate.R
@@ -33,7 +33,7 @@ dm_validate <- function(x) {
 
   check_df_structure(def, boilerplate, "dm definition")
 
-  if (!all(map_lgl(def$data, ~ inherits(., "data.frame") || inherits(., "tbl_dbi")))) {
+  if (!all(map_lgl(def$data, ~ inherits(., "data.frame") || inherits(., "tbl_sql")))) {
     abort_dm_invalid(
       "Not all entries in `def$data` are of class `data.frame` or `tbl_dbi`. Check `dm_get_tables()`."
     )

--- a/tests/testthat/test-validate.R
+++ b/tests/testthat/test-validate.R
@@ -198,3 +198,16 @@ test_that("validator speaks up (sqlite())", {
     "dm_invalid"
   )
 })
+
+test_that("validator accepts tbl_sql which is not tbl_dbi (from copy_inline())", {
+  skip_if_not_installed("dbplyr")
+  skip_if_src("df")
+
+  con <- my_test_con()
+  withr::defer(DBI::dbDisconnect(con))
+  test_table <- dbplyr::copy_inline(con, tibble(a = 1:3))
+  # as of dbplyr v2.2.1, `copy_inline()` creates on object that's `tbl_sql`, but not `tbl_dbi`
+  testthat::expect_false(inherits(test_table, "tbl_dbi"))
+  expect_silent(dm_validate(dm(test_table)))
+
+})

--- a/tests/testthat/test-validate.R
+++ b/tests/testthat/test-validate.R
@@ -209,5 +209,4 @@ test_that("validator accepts tbl_sql which is not tbl_dbi (from copy_inline())",
   # as of dbplyr v2.2.1, `copy_inline()` creates on object that's `tbl_sql`, but not `tbl_dbi`
   testthat::expect_false(inherits(test_table, "tbl_dbi"))
   expect_silent(dm_validate(dm(test_table)))
-
 })

--- a/tests/testthat/test-validate.R
+++ b/tests/testthat/test-validate.R
@@ -199,14 +199,13 @@ test_that("validator speaks up (sqlite())", {
   )
 })
 
-# test_that("validator accepts tbl_sql which is not tbl_dbi (from copy_inline())", {
-#   skip_if_not_installed("dbplyr")
-#   skip_if_src("df")
-#
-#   con <- my_test_con()
-#   withr::defer(DBI::dbDisconnect(con))
-#   test_table <- dbplyr::copy_inline(con, tibble(a = 1:3))
-#   # as of dbplyr v2.2.1, `copy_inline()` creates on object that's `tbl_sql`, but not `tbl_dbi`
-#   testthat::expect_false(inherits(test_table, "tbl_dbi"))
-#   expect_silent(dm_validate(dm(test_table)))
-# })
+test_that("validator accepts tbl_sql which is not tbl_dbi (from copy_inline())", {
+  skip_if_not_installed("dbplyr")
+  skip_if_src("df")
+
+  con <- my_test_con()
+  test_table <- dbplyr::copy_inline(con, tibble(a = 1:3))
+  # as of dbplyr v2.2.1, `copy_inline()` creates an object that's `tbl_sql`, but not `tbl_dbi`
+  testthat::expect_false(inherits(test_table, "tbl_dbi"))
+  expect_silent(dm_validate(dm(test_table)))
+})

--- a/tests/testthat/test-validate.R
+++ b/tests/testthat/test-validate.R
@@ -199,14 +199,14 @@ test_that("validator speaks up (sqlite())", {
   )
 })
 
-test_that("validator accepts tbl_sql which is not tbl_dbi (from copy_inline())", {
-  skip_if_not_installed("dbplyr")
-  skip_if_src("df")
-
-  con <- my_test_con()
-  withr::defer(DBI::dbDisconnect(con))
-  test_table <- dbplyr::copy_inline(con, tibble(a = 1:3))
-  # as of dbplyr v2.2.1, `copy_inline()` creates on object that's `tbl_sql`, but not `tbl_dbi`
-  testthat::expect_false(inherits(test_table, "tbl_dbi"))
-  expect_silent(dm_validate(dm(test_table)))
-})
+# test_that("validator accepts tbl_sql which is not tbl_dbi (from copy_inline())", {
+#   skip_if_not_installed("dbplyr")
+#   skip_if_src("df")
+#
+#   con <- my_test_con()
+#   withr::defer(DBI::dbDisconnect(con))
+#   test_table <- dbplyr::copy_inline(con, tibble(a = 1:3))
+#   # as of dbplyr v2.2.1, `copy_inline()` creates on object that's `tbl_sql`, but not `tbl_dbi`
+#   testthat::expect_false(inherits(test_table, "tbl_dbi"))
+#   expect_silent(dm_validate(dm(test_table)))
+# })


### PR DESCRIPTION
since dbplyr::copy_inline() produces such tables.

closes #1695 