### PR TITLE
chore: `dm_unpack_tbl()` sets PK before FK

### DIFF
--- a/R/dm_unnest_tbl.R
+++ b/R/dm_unnest_tbl.R
@@ -136,6 +136,9 @@ dm_unpack_tbl <- function(dm, child_table, col, ptype) {
   # update the dm by adding new table, removing packed col and setting keys
   dm <- dm(dm, !!new_parent_table_name := new_table)
   dm <- dm_select(dm, !!child_table_name, -all_of(new_parent_table_name))
+  if (length(parent_pk_names)) {
+    dm <- dm_add_pk(dm, !!new_parent_table_name, !!parent_pk_names)
+  }
   if (length(child_fk_names)) {
     dm <- dm_add_fk(
       dm,
@@ -144,9 +147,6 @@ dm_unpack_tbl <- function(dm, child_table, col, ptype) {
       !!new_parent_table_name,
       !!parent_fk_names
     )
-  }
-  if (length(parent_pk_names)) {
-    dm <- dm_add_pk(dm, !!new_parent_table_name, !!parent_pk_names)
   }
 
   dm


### PR DESCRIPTION
Otherwise in the future, there will be an additional unique key, which is the same as the then added PK.