### PR TITLE
fix: Correct error message if nonexisting table is passed to `dm_get_all_pks()`

### DIFF
--- a/R/foreign-keys.R
+++ b/R/foreign-keys.R
@@ -250,7 +250,7 @@ dm_get_all_fks_impl <- function(dm, parent_table = NULL, ignore_on_delete = FALS
   if (!is.null(parent_table)) {
     idx <- match(parent_table, def_sub$parent_table)
     if (anyNA(idx)) {
-      abort_table_not_in_dm(parent_table[which(is.na(idx))[[1]]], def$parent_table)
+      abort_table_not_in_dm(parent_table[which(is.na(idx))], def$table)
     }
     def_sub <- def_sub[idx, ]
   }

--- a/R/foreign-keys.R
+++ b/R/foreign-keys.R
@@ -250,7 +250,7 @@ dm_get_all_fks_impl <- function(dm, parent_table = NULL, ignore_on_delete = FALS
   if (!is.null(parent_table)) {
     idx <- match(parent_table, def_sub$parent_table)
     if (anyNA(idx)) {
-      abort(paste0("Table not in dm object: ", parent_table[which(is.na(idx))[[1]]]))
+      abort_table_not_in_dm(parent_table[which(is.na(idx))[[1]]], def$parent_table)
     }
     def_sub <- def_sub[idx, ]
   }

--- a/R/primary-keys.R
+++ b/R/primary-keys.R
@@ -199,7 +199,7 @@ dm_get_all_pks_def_impl <- function(def, table = NULL) {
   if (!is.null(table)) {
     idx <- match(table, def_sub$table)
     if (anyNA(idx)) {
-      abort(paste0("Table not in dm object: ", parent_table[which(is.na(idx))[[1]]]))
+      abort_table_not_in_dm(table[which(is.na(idx))], def$table)
     }
     def_sub <- def_sub[match(table, def_sub$table), ]
   }

--- a/tests/testthat/_snaps/foreign-keys.md
+++ b/tests/testthat/_snaps/foreign-keys.md
@@ -229,3 +229,25 @@
       Error in `dm_add_fk()`:
       ! `on_delete` must be one of "no_action" or "cascade", not "a".
 
+# dm_get_all_fks() with parent_table arg
+
+    Code
+      nyc_comp() %>% dm_get_all_fks("weather")
+    Output
+      # A tibble: 1 x 5
+        child_table child_fk_cols     parent_table parent_key_cols   on_delete
+        <chr>       <keys>            <chr>        <keys>            <chr>    
+      1 flights     origin, time_hour weather      origin, time_hour no_action
+    Code
+      nyc_comp() %>% dm_get_all_fks(c("airlines", "weather"))
+    Output
+      # A tibble: 2 x 5
+        child_table child_fk_cols     parent_table parent_key_cols   on_delete
+        <chr>       <keys>            <chr>        <keys>            <chr>    
+      1 flights     carrier           airlines     carrier           no_action
+      2 flights     origin, time_hour weather      origin, time_hour no_action
+
+# dm_get_all_fks() with parent_table arg fails nicely
+
+    Table `timetable`, `tabletime` not in `dm` object. Available table names: `airlines`, `airports`, `flights`, `planes`, `weather`.
+

--- a/tests/testthat/_snaps/primary-keys.md
+++ b/tests/testthat/_snaps/primary-keys.md
@@ -224,6 +224,28 @@
       Error in `abort_not_unique_key()`:
       ! (`a`) not a unique key of `x`.
 
+# dm_get_all_pks() with table arg
+
+    Code
+      nyc_comp() %>% dm_get_all_pks("weather")
+    Output
+      # A tibble: 1 x 3
+        table   pk_col            autoincrement
+        <chr>   <keys>            <lgl>        
+      1 weather origin, time_hour FALSE        
+    Code
+      nyc_comp() %>% dm_get_all_pks(c("airlines", "weather"))
+    Output
+      # A tibble: 2 x 3
+        table    pk_col            autoincrement
+        <chr>    <keys>            <lgl>        
+      1 airlines carrier           FALSE        
+      2 weather  origin, time_hour FALSE        
+
+# dm_get_all_pks() with table arg fails nicely
+
+    Table `timetable`, `tabletime` not in `dm` object. Available table names: `airlines`, `airports`, `flights`, `planes`, `weather`.
+
 # dm_get_all_pks() with compound keys
 
     Code

--- a/tests/testthat/test-foreign-keys.R
+++ b/tests/testthat/test-foreign-keys.R
@@ -284,3 +284,20 @@ test_that("dm_get_all_fks() and order", {
   expect_equal(fks_34, bind_rows(fks_3, fks_4))
   expect_equal(fks_43, bind_rows(fks_4, fks_3))
 })
+
+test_that("dm_get_all_fks() with parent_table arg", {
+  expect_snapshot({
+    nyc_comp() %>%
+      dm_get_all_fks("weather")
+
+    nyc_comp() %>%
+      dm_get_all_fks(c("airlines", "weather"))
+  })
+})
+
+test_that("dm_get_all_fks() with parent_table arg fails nicely", {
+  expect_snapshot_error({
+    nyc_comp() %>%
+      dm_get_all_fks(c("airlines", "weather", "timetable", "tabletime"))
+  })
+})

--- a/tests/testthat/test-primary-keys.R
+++ b/tests/testthat/test-primary-keys.R
@@ -189,6 +189,22 @@ test_that("dm_get_all_pks() and order", {
   expect_equal(pks_all[2:1, ], pks_21)
 })
 
+test_that("dm_get_all_pks() with table arg", {
+  expect_snapshot({
+    nyc_comp() %>%
+      dm_get_all_pks("weather")
+
+    nyc_comp() %>%
+      dm_get_all_pks(c("airlines", "weather"))
+  })
+})
+
+test_that("dm_get_all_pks() with table arg fails nicely", {
+  expect_snapshot_error({
+    nyc_comp() %>%
+      dm_get_all_pks(c("airlines", "weather", "timetable", "tabletime"))
+  })
+})
 
 # tests for compound keys -------------------------------------------------
 


### PR DESCRIPTION
...and produce a nicer error for `dm_get_all_fks(parent_table = "<something_wrong>")`

currently:

``` r
suppressMessages(devtools::load_all("~/git/cynkra/dm"))

dm_nycflights13() %>% 
  dm_get_all_pks("timetable")
#> Error in paste0("Table not in dm object: ", parent_table[which(is.na(idx))[[1]]]): object 'parent_table' not found
```

<sup>Created on 2023-01-10 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>