### PR TITLE
feat!: `dm_get_all_pks()`, `dm_get_all_fks()`, and `dm_get_all_uks()` require unquoted table names as input, for consistency with other parts of the API

### DIFF
--- a/R/build_copy_queries.R
+++ b/R/build_copy_queries.R
@@ -25,7 +25,7 @@ build_copy_queries <- function(dest, dm, set_key_constraints = TRUE, temporary =
     # to be a scalar
     pk_col <-
       dm %>%
-      dm_get_all_pks(x) %>%
+      dm_get_all_pks(!!x) %>%
       filter(autoincrement) %>%
       pull(pk_col)
 

--- a/R/foreign-keys.R
+++ b/R/foreign-keys.R
@@ -247,13 +247,13 @@ dm_get_fk2_impl <- function(dm, table_name, ref_table_name) {
 dm_get_all_fks <- function(dm, parent_table = NULL, ...) {
   check_dots_empty()
   check_not_zoomed(dm)
-  table_expr <- enexpr(parent_table) %||% src_tbls_impl(dm)
-  table_names <- eval_select_table(table_expr, set_names(src_tbls_impl(dm)))
+  table_expr <- enexpr(parent_table) %||% src_tbls_impl(dm, quiet = TRUE)
+  table_names <- eval_select_table(table_expr, set_names(src_tbls_impl(dm, quiet = TRUE)))
   dm_get_all_fks_impl(dm, table_names)
 }
 
 dm_get_all_fks_impl <- function(dm, parent_table = NULL, ignore_on_delete = FALSE, id = FALSE) {
-  def <- dm_get_def(dm)
+  def <- dm_get_def(dm, quiet = TRUE)
 
   dm_get_all_fks_def_impl(def = def, parent_table = parent_table, ignore_on_delete = ignore_on_delete, id = id)
 }

--- a/R/foreign-keys.R
+++ b/R/foreign-keys.R
@@ -253,7 +253,7 @@ dm_get_all_fks <- function(dm, parent_table = NULL, ...) {
 }
 
 dm_get_all_fks_impl <- function(dm, parent_table = NULL, ignore_on_delete = FALSE, id = FALSE) {
-  def <- dm_get_def(dm, quiet = TRUE)
+  def <- dm_get_def(dm)
 
   dm_get_all_fks_def_impl(def = def, parent_table = parent_table, ignore_on_delete = ignore_on_delete, id = id)
 }

--- a/R/foreign-keys.R
+++ b/R/foreign-keys.R
@@ -233,7 +233,7 @@ dm_get_fk2_impl <- function(dm, table_name, ref_table_name) {
 #'   }
 #'
 #' @inheritParams dm_has_fk
-#' @param parent_table One or more table names, as character vector,
+#' @param parent_table One or more table names, unquoted,
 #'   to return foreign key information for.
 #'   If given, foreign keys are returned in that order.
 #'   The default `NULL` returns information for all tables.

--- a/R/foreign-keys.R
+++ b/R/foreign-keys.R
@@ -247,7 +247,9 @@ dm_get_fk2_impl <- function(dm, table_name, ref_table_name) {
 dm_get_all_fks <- function(dm, parent_table = NULL, ...) {
   check_dots_empty()
   check_not_zoomed(dm)
-  dm_get_all_fks_impl(dm, parent_table)
+  table_expr <- enexpr(parent_table) %||% src_tbls_impl(dm)
+  table_names <- eval_select_table(table_expr, set_names(src_tbls_impl(dm)))
+  dm_get_all_fks_impl(dm, table_names)
 }
 
 dm_get_all_fks_impl <- function(dm, parent_table = NULL, ignore_on_delete = FALSE, id = FALSE) {

--- a/R/primary-keys.R
+++ b/R/primary-keys.R
@@ -193,7 +193,7 @@ dm_get_all_pks <- function(dm, table = NULL, ...) {
 
 dm_get_all_pks_impl <- function(dm, table = NULL) {
   dm %>%
-    dm_get_def(quiet = TRUE) %>%
+    dm_get_def() %>%
     dm_get_all_pks_def_impl(table)
 }
 

--- a/R/primary-keys.R
+++ b/R/primary-keys.R
@@ -186,14 +186,14 @@ dm_get_pk_impl <- function(dm, table_name) {
 dm_get_all_pks <- function(dm, table = NULL, ...) {
   check_dots_empty()
   check_not_zoomed(dm)
-  table_expr <- enexpr(table) %||% src_tbls_impl(dm)
-  table_names <- eval_select_table(table_expr, set_names(src_tbls_impl(dm)))
+  table_expr <- enexpr(table) %||% src_tbls_impl(dm, quiet = TRUE)
+  table_names <- eval_select_table(table_expr, set_names(src_tbls_impl(dm, quiet = TRUE)))
   dm_get_all_pks_impl(dm, table_names)
 }
 
 dm_get_all_pks_impl <- function(dm, table = NULL) {
   dm %>%
-    dm_get_def() %>%
+    dm_get_def(quiet = TRUE) %>%
     dm_get_all_pks_def_impl(table)
 }
 

--- a/R/primary-keys.R
+++ b/R/primary-keys.R
@@ -166,7 +166,7 @@ dm_get_pk_impl <- function(dm, table_name) {
 #' returns the tables and the respective primary key columns.
 #'
 #' @family primary key functions
-#' @param table One or more table names, as character vector,
+#' @param table One or more table names, unquoted,
 #'   to return primary key information for.
 #'   If given, primary keys are returned in that order.
 #'   The default `NULL` returns information for all tables.

--- a/R/primary-keys.R
+++ b/R/primary-keys.R
@@ -186,7 +186,9 @@ dm_get_pk_impl <- function(dm, table_name) {
 dm_get_all_pks <- function(dm, table = NULL, ...) {
   check_dots_empty()
   check_not_zoomed(dm)
-  dm_get_all_pks_impl(dm, table)
+  table_expr <- enexpr(table) %||% src_tbls_impl(dm)
+  table_names <- eval_select_table(table_expr, set_names(src_tbls_impl(dm)))
+  dm_get_all_pks_impl(dm, table_names)
 }
 
 dm_get_all_pks_impl <- function(dm, table = NULL) {
@@ -202,9 +204,6 @@ dm_get_all_pks_def_impl <- function(def, table = NULL) {
 
   if (!is.null(table)) {
     idx <- match(table, def_sub$table)
-    if (anyNA(idx)) {
-      abort_table_not_in_dm(table[which(is.na(idx))], def$table)
-    }
     def_sub <- def_sub[match(table, def_sub$table), ]
   }
 

--- a/R/rows-dm.R
+++ b/R/rows-dm.R
@@ -410,7 +410,7 @@ dm_patch_tbl <- function(dm, ...) {
 }
 
 get_autoinc_col <- function(x, table, cols) {
-  my_pk <- dm_get_all_pks(x, table)
+  my_pk <- dm_get_all_pks_impl(x, table)
   stopifnot(nrow(my_pk) %in% 0:1)
 
   if (!isTRUE(my_pk$autoincrement)) {
@@ -426,7 +426,7 @@ get_autoinc_col <- function(x, table, cols) {
 }
 
 align_autoinc_fks <- function(tbls, target_dm, table, returning_rows) {
-  fks <- dm_get_all_fks(target_dm, table)
+  fks <- dm_get_all_fks_impl(target_dm, table)
   fks_target <- fks[fks$child_table %in% names(tbls), ]
 
   all_target_tables <- dm_get_tables(target_dm)[fks_target$child_table]

--- a/R/unique-keys.R
+++ b/R/unique-keys.R
@@ -118,7 +118,9 @@ dm_add_uk_impl <- function(dm, table, column) {
 dm_get_all_uks <- function(dm, table = NULL, ...) {
   check_dots_empty()
   check_not_zoomed(dm)
-  dm_get_all_uks_impl(dm, table)
+  table_expr <- enexpr(table) %||% src_tbls_impl(dm)
+  table_names <- eval_select_table(table_expr, set_names(src_tbls_impl(dm)))
+  dm_get_all_uks_impl(dm, table_names)
 }
 
 dm_get_all_uks_impl <- function(dm, table = NULL) {
@@ -127,9 +129,6 @@ dm_get_all_uks_impl <- function(dm, table = NULL) {
 
   if (!is.null(table)) {
     idx <- match(table, def$table)
-    if (anyNA(idx)) {
-      abort_table_not_in_dm(table[which(is.na(idx))], def$table)
-    }
     def <- def[match(table, def$table), ]
   }
 

--- a/R/unique-keys.R
+++ b/R/unique-keys.R
@@ -93,7 +93,7 @@ dm_add_uk_impl <- function(dm, table, column) {
 #' the respective unique key columns.
 #'
 #' @family primary key functions
-#' @param table One or more table names, as character vector,
+#' @param table One or more table names, unquoted,
 #'   to return unique key information for.
 #'   The default `NULL` returns information for all tables.
 #'

--- a/R/unique-keys.R
+++ b/R/unique-keys.R
@@ -119,7 +119,7 @@ dm_get_all_uks <- function(dm, table = NULL, ...) {
   check_dots_empty()
   check_not_zoomed(dm)
   table_expr <- enexpr(table) %||% src_tbls_impl(dm, quiet = TRUE)
-  table_names <- eval_select_table(table_expr, set_names(src_tbls_impl(dm)))
+  table_names <- eval_select_table(table_expr, set_names(src_tbls_impl(dm, quiet = TRUE)))
   dm_get_all_uks_impl(dm, table_names)
 }
 

--- a/R/unique-keys.R
+++ b/R/unique-keys.R
@@ -118,14 +118,14 @@ dm_add_uk_impl <- function(dm, table, column) {
 dm_get_all_uks <- function(dm, table = NULL, ...) {
   check_dots_empty()
   check_not_zoomed(dm)
-  table_expr <- enexpr(table) %||% src_tbls_impl(dm)
+  table_expr <- enexpr(table) %||% src_tbls_impl(dm, quiet = TRUE)
   table_names <- eval_select_table(table_expr, set_names(src_tbls_impl(dm)))
   dm_get_all_uks_impl(dm, table_names)
 }
 
 dm_get_all_uks_impl <- function(dm, table = NULL) {
   def <- dm %>%
-    dm_get_def()
+    dm_get_def(quiet = TRUE)
 
   if (!is.null(table)) {
     idx <- match(table, def$table)

--- a/R/unique-keys.R
+++ b/R/unique-keys.R
@@ -125,7 +125,7 @@ dm_get_all_uks <- function(dm, table = NULL, ...) {
 
 dm_get_all_uks_impl <- function(dm, table = NULL) {
   def <- dm %>%
-    dm_get_def(quiet = TRUE)
+    dm_get_def()
 
   if (!is.null(table)) {
     idx <- match(table, def$table)

--- a/man/dm_get_all_fks.Rd
+++ b/man/dm_get_all_fks.Rd
@@ -9,7 +9,7 @@ dm_get_all_fks(dm, parent_table = NULL, ...)
 \arguments{
 \item{dm}{A \code{dm} object.}
 
-\item{parent_table}{One or more table names, as character vector,
+\item{parent_table}{One or more table names, unquoted,
 to return foreign key information for.
 If given, foreign keys are returned in that order.
 The default \code{NULL} returns information for all tables.}

--- a/man/dm_get_all_pks.Rd
+++ b/man/dm_get_all_pks.Rd
@@ -9,7 +9,7 @@ dm_get_all_pks(dm, table = NULL, ...)
 \arguments{
 \item{dm}{A \code{dm} object.}
 
-\item{table}{One or more table names, as character vector,
+\item{table}{One or more table names, unquoted,
 to return primary key information for.
 If given, primary keys are returned in that order.
 The default \code{NULL} returns information for all tables.}

--- a/man/dm_get_all_uks.Rd
+++ b/man/dm_get_all_uks.Rd
@@ -9,7 +9,7 @@ dm_get_all_uks(dm, table = NULL, ...)
 \arguments{
 \item{dm}{A \code{dm} object.}
 
-\item{table}{One or more table names, as character vector,
+\item{table}{One or more table names, unquoted,
 to return unique key information for.
 The default \code{NULL} returns information for all tables.}
 

--- a/tests/testthat/_snaps/foreign-keys.md
+++ b/tests/testthat/_snaps/foreign-keys.md
@@ -232,7 +232,7 @@
 # dm_get_all_fks() with parent_table arg
 
     Code
-      nyc_comp() %>% dm_get_all_fks("weather")
+      nyc_comp() %>% dm_get_all_fks(weather)
     Output
       # A tibble: 1 x 5
         child_table child_fk_cols     parent_table parent_key_cols   on_delete
@@ -249,5 +249,6 @@
 
 # dm_get_all_fks() with parent_table arg fails nicely
 
-    Table `timetable`, `tabletime` not in `dm` object. Available table names: `airlines`, `airports`, `flights`, `planes`, `weather`.
+    Can't subset tables that don't exist.
+    x Table `timetable` doesn't exist.
 

--- a/tests/testthat/_snaps/foreign-keys.md
+++ b/tests/testthat/_snaps/foreign-keys.md
@@ -246,6 +246,23 @@
         <chr>       <keys>            <chr>        <keys>            <chr>    
       1 flights     carrier           airlines     carrier           no_action
       2 flights     origin, time_hour weather      origin, time_hour no_action
+    Code
+      nyc_comp() %>% dm_get_all_fks(ends_with("ports"))
+    Output
+      # A tibble: 1 x 5
+        child_table child_fk_cols parent_table parent_key_cols on_delete
+        <chr>       <keys>        <chr>        <keys>          <chr>    
+      1 flights     dest          airports     faa             no_action
+    Code
+      nyc_comp() %>% dm_get_all_fks(everything())
+    Output
+      # A tibble: 4 x 5
+        child_table child_fk_cols     parent_table parent_key_cols   on_delete
+        <chr>       <keys>            <chr>        <keys>            <chr>    
+      1 flights     carrier           airlines     carrier           no_action
+      2 flights     dest              airports     faa               no_action
+      3 flights     tailnum           planes       tailnum           no_action
+      4 flights     origin, time_hour weather      origin, time_hour no_action
 
 # dm_get_all_fks() with parent_table arg fails nicely
 

--- a/tests/testthat/_snaps/primary-keys.md
+++ b/tests/testthat/_snaps/primary-keys.md
@@ -236,7 +236,7 @@
         <chr>   <keys>            <lgl>        
       1 weather origin, time_hour FALSE        
     Code
-      nyc_comp() %>% dm_get_all_pks(c("airlines", "weather"))
+      nyc_comp() %>% dm_get_all_pks(c(airlines, weather))
     Output
       # A tibble: 2 x 3
         table    pk_col            autoincrement
@@ -246,7 +246,8 @@
 
 # dm_get_all_pks() with table arg fails nicely
 
-    Table `timetable`, `tabletime` not in `dm` object. Available table names: `airlines`, `airports`, `flights`, `planes`, `weather`.
+    Can't subset tables that don't exist.
+    x Table `timetable` doesn't exist.
 
 # dm_get_all_pks() with compound keys
 

--- a/tests/testthat/_snaps/primary-keys.md
+++ b/tests/testthat/_snaps/primary-keys.md
@@ -243,6 +243,21 @@
         <chr>    <keys>            <lgl>        
       1 airlines carrier           FALSE        
       2 weather  origin, time_hour FALSE        
+    Code
+      nyc_comp() %>% dm_get_all_pks(starts_with("weat"))
+    Output
+      # A tibble: 1 x 3
+        table   pk_col            autoincrement
+        <chr>   <keys>            <lgl>        
+      1 weather origin, time_hour FALSE        
+    Code
+      nyc_comp() %>% dm_get_all_pks(matches("^a.*s$"))
+    Output
+      # A tibble: 2 x 3
+        table    pk_col  autoincrement
+        <chr>    <keys>  <lgl>        
+      1 airlines carrier FALSE        
+      2 airports faa     FALSE        
 
 # dm_get_all_pks() with table arg fails nicely
 

--- a/tests/testthat/_snaps/unique-keys.md
+++ b/tests/testthat/_snaps/unique-keys.md
@@ -191,7 +191,7 @@
       3 tf_4        j, j1         tf_3         f, f1           no_action
       4 tf_5        l             tf_4         h               cascade  
     Code
-      nyc_1_uk %>% dm_get_all_uks("flights")
+      nyc_1_uk %>% dm_get_all_uks(flights)
     Output
       # A tibble: 1 x 3
         table   uk_col                      kind       
@@ -205,7 +205,7 @@
         <chr>    <keys> <chr>
       1 airports faa    PK   
     Code
-      nyc_1_uk %>% dm_get_all_uks(c("airports", "weather", "flights", "airlines"))
+      nyc_1_uk %>% dm_get_all_uks(c(airports, weather, flights, airlines))
     Output
       # A tibble: 3 x 3
         table    uk_col                      kind       
@@ -224,11 +224,13 @@
 
 ---
 
-    Table `timetable` not in `dm` object. Available table names: `airlines`, `airports`, `flights`, `planes`, `weather`.
+    Can't subset tables that don't exist.
+    x Table `timetable` doesn't exist.
 
 ---
 
-    Table `timetable`, `tabletime` not in `dm` object. Available table names: `airlines`, `airports`, `flights`, `planes`, `weather`.
+    Can't subset tables that don't exist.
+    x Table `timetable` doesn't exist.
 
 ---
 

--- a/tests/testthat/_snaps/unique-keys.md
+++ b/tests/testthat/_snaps/unique-keys.md
@@ -213,6 +213,24 @@
       1 airports faa                         PK         
       2 airlines carrier                     PK         
       3 flights  year, month, ... (19 total) explicit UK
+    Code
+      nyc_1_uk %>% dm_get_all_uks(starts_with("a"))
+    Output
+      # A tibble: 2 x 3
+        table    uk_col  kind 
+        <chr>    <keys>  <chr>
+      1 airlines carrier PK   
+      2 airports faa     PK   
+    Code
+      nyc_1_uk %>% dm_get_all_uks(everything())
+    Output
+      # A tibble: 4 x 3
+        table    uk_col                      kind       
+        <chr>    <keys>                      <chr>      
+      1 airlines carrier                     PK         
+      2 airports faa                         PK         
+      3 planes   tailnum                     PK         
+      4 flights  year, month, ... (19 total) explicit UK
 
 ---
 

--- a/tests/testthat/_snaps/upgrade.md
+++ b/tests/testthat/_snaps/upgrade.md
@@ -102,6 +102,35 @@
       5 tf_5  k      PK         
       6 tf_6  o      PK         
       7 tf_6  n      implicit UK
+    Code
+      dm_get_all_pks(dm_v3)
+    Message
+      Upgrading dm object created with dm <= 0.3.0.
+      Upgrading dm object created with dm <= 1.0.3.
+    Output
+      # A tibble: 6 x 3
+        table pk_col autoincrement
+        <chr> <keys> <lgl>        
+      1 tf_1  a      FALSE        
+      2 tf_2  c      FALSE        
+      3 tf_3  f, f1  FALSE        
+      4 tf_4  h      FALSE        
+      5 tf_5  k      FALSE        
+      6 tf_6  o      FALSE        
+    Code
+      dm_get_all_fks(dm_v3)
+    Message
+      Upgrading dm object created with dm <= 0.3.0.
+      Upgrading dm object created with dm <= 1.0.3.
+    Output
+      # A tibble: 5 x 5
+        child_table child_fk_cols parent_table parent_key_cols on_delete
+        <chr>       <keys>        <chr>        <keys>          <chr>    
+      1 tf_2        d             tf_1         a               no_action
+      2 tf_2        e, e1         tf_3         f, f1           no_action
+      3 tf_4        j, j1         tf_3         f, f1           no_action
+      4 tf_5        l             tf_4         h               cascade  
+      5 tf_5        m             tf_6         n               no_action
 
 # can upgrade zoomed from v3
 
@@ -146,6 +175,33 @@
       5 tf_5  k      PK         
       6 tf_6  o      PK         
       7 tf_6  n      implicit UK
+    Code
+      dm_get_all_pks(dm_v4)
+    Message
+      Upgrading dm object created with dm <= 1.0.3.
+    Output
+      # A tibble: 6 x 3
+        table pk_col autoincrement
+        <chr> <keys> <lgl>        
+      1 tf_1  a      FALSE        
+      2 tf_2  c      FALSE        
+      3 tf_3  f, f1  FALSE        
+      4 tf_4  h      FALSE        
+      5 tf_5  k      FALSE        
+      6 tf_6  o      FALSE        
+    Code
+      dm_get_all_fks(dm_v4)
+    Message
+      Upgrading dm object created with dm <= 1.0.3.
+    Output
+      # A tibble: 5 x 5
+        child_table child_fk_cols parent_table parent_key_cols on_delete
+        <chr>       <keys>        <chr>        <keys>          <chr>    
+      1 tf_2        d             tf_1         a               no_action
+      2 tf_2        e, e1         tf_3         f, f1           no_action
+      3 tf_4        j, j1         tf_3         f, f1           no_action
+      4 tf_5        l             tf_4         h               cascade  
+      5 tf_5        m             tf_6         n               no_action
 
 # can upgrade zoomed to v4
 

--- a/tests/testthat/test-foreign-keys.R
+++ b/tests/testthat/test-foreign-keys.R
@@ -274,11 +274,11 @@ test_that("dm_get_all_fks() and order", {
   dm <- dm_for_filter()
   fks_all <- dm_get_all_fks(dm)
   fks_1 <- dm_get_all_fks(dm, "tf_1")
-  fks_3 <- dm_get_all_fks(dm, "tf_3")
+  fks_3 <- dm_get_all_fks(dm, tf_3)
   fks_4 <- dm_get_all_fks(dm, "tf_4")
   fks_6 <- dm_get_all_fks(dm, "tf_6")
-  fks_34 <- dm_get_all_fks(dm, c("tf_3", "tf_4"))
-  fks_43 <- dm_get_all_fks(dm, c("tf_4", "tf_3"))
+  fks_34 <- dm_get_all_fks(dm, c(tf_3, tf_4))
+  fks_43 <- dm_get_all_fks(dm, c(tf_4, tf_3))
 
   expect_equal(fks_all, bind_rows(fks_1, fks_3, fks_4, fks_6))
   expect_equal(fks_34, bind_rows(fks_3, fks_4))
@@ -288,7 +288,7 @@ test_that("dm_get_all_fks() and order", {
 test_that("dm_get_all_fks() with parent_table arg", {
   expect_snapshot({
     nyc_comp() %>%
-      dm_get_all_fks("weather")
+      dm_get_all_fks(weather)
 
     nyc_comp() %>%
       dm_get_all_fks(c("airlines", "weather"))
@@ -298,6 +298,6 @@ test_that("dm_get_all_fks() with parent_table arg", {
 test_that("dm_get_all_fks() with parent_table arg fails nicely", {
   expect_snapshot_error({
     nyc_comp() %>%
-      dm_get_all_fks(c("airlines", "weather", "timetable", "tabletime"))
+      dm_get_all_fks(c(airlines, weather, timetable, tabletime))
   })
 })

--- a/tests/testthat/test-foreign-keys.R
+++ b/tests/testthat/test-foreign-keys.R
@@ -292,6 +292,13 @@ test_that("dm_get_all_fks() with parent_table arg", {
 
     nyc_comp() %>%
       dm_get_all_fks(c("airlines", "weather"))
+
+    # test tidyselect functions for parent_table arg
+    nyc_comp() %>%
+      dm_get_all_fks(ends_with("ports"))
+
+    nyc_comp() %>%
+      dm_get_all_fks(everything())
   })
 })
 

--- a/tests/testthat/test-primary-keys.R
+++ b/tests/testthat/test-primary-keys.R
@@ -187,8 +187,8 @@ test_that("output", {
 test_that("dm_get_all_pks() and order", {
   dm <- nyc_comp()
   pks_all <- dm_get_all_pks(dm)
-  pks_12 <- dm_get_all_pks(dm, names(dm)[1:2])
-  pks_21 <- dm_get_all_pks(dm, names(dm)[2:1])
+  pks_12 <- dm_get_all_pks(dm, !!names(dm)[1:2])
+  pks_21 <- dm_get_all_pks(dm, !!names(dm)[2:1])
 
   expect_equal(pks_all[1:2, ], pks_12)
   expect_equal(pks_all[2:1, ], pks_21)
@@ -200,14 +200,14 @@ test_that("dm_get_all_pks() with table arg", {
       dm_get_all_pks("weather")
 
     nyc_comp() %>%
-      dm_get_all_pks(c("airlines", "weather"))
+      dm_get_all_pks(c(airlines, weather))
   })
 })
 
 test_that("dm_get_all_pks() with table arg fails nicely", {
   expect_snapshot_error({
     nyc_comp() %>%
-      dm_get_all_pks(c("airlines", "weather", "timetable", "tabletime"))
+      dm_get_all_pks(c(airlines, weather, timetable, tabletime))
   })
 })
 

--- a/tests/testthat/test-primary-keys.R
+++ b/tests/testthat/test-primary-keys.R
@@ -201,6 +201,13 @@ test_that("dm_get_all_pks() with table arg", {
 
     nyc_comp() %>%
       dm_get_all_pks(c(airlines, weather))
+
+    # test tidyselect functions for parent_table arg
+    nyc_comp() %>%
+      dm_get_all_pks(starts_with("weat"))
+
+    nyc_comp() %>%
+      dm_get_all_pks(matches("^a.*s$"))
   })
 })
 

--- a/tests/testthat/test-unique-keys.R
+++ b/tests/testthat/test-unique-keys.R
@@ -123,13 +123,13 @@ test_that("unique keys", {
 
     # test table arg for dm_get_all_uks()
     nyc_1_uk %>%
-      dm_get_all_uks("flights")
+      dm_get_all_uks(flights)
 
     nyc_1_uk %>%
       dm_get_all_uks("airports")
 
     nyc_1_uk %>%
-      dm_get_all_uks(c("airports", "weather", "flights", "airlines"))
+      dm_get_all_uks(c(airports, weather, flights, airlines))
   })
 
   expect_snapshot_error(
@@ -156,15 +156,13 @@ test_that("unique keys", {
   expect_snapshot_error(
     # trying to request a table not part of the dm
     nyc_1_uk %>%
-      dm_get_all_uks("timetable"),
-    class = dm_error("table_not_in_dm")
+      dm_get_all_uks(timetable)
   )
 
   expect_snapshot_error(
     # trying to request 2 tables that are not part of the dm and a few others
     nyc_1_uk %>%
-      dm_get_all_uks(c("timetable", "weather", "flights", "tabletime")),
-    class = dm_error("table_not_in_dm")
+      dm_get_all_uks(c(timetable, weather, flights, tabletime))
   )
 
   expect_snapshot_error(

--- a/tests/testthat/test-unique-keys.R
+++ b/tests/testthat/test-unique-keys.R
@@ -130,6 +130,13 @@ test_that("unique keys", {
 
     nyc_1_uk %>%
       dm_get_all_uks(c(airports, weather, flights, airlines))
+
+    # test tidyselect functions
+    nyc_1_uk %>%
+      dm_get_all_uks(starts_with("a"))
+
+    nyc_1_uk %>%
+      dm_get_all_uks(everything())
   })
 
   expect_snapshot_error(

--- a/tests/testthat/test-upgrade.R
+++ b/tests/testthat/test-upgrade.R
@@ -76,6 +76,8 @@ test_that("can upgrade from v3", {
     dm_validate(dm)
     is_zoomed(dm)
     dm_get_all_uks(dm_v3)
+    dm_get_all_pks(dm_v3)
+    dm_get_all_fks(dm_v3)
   })
 })
 
@@ -104,6 +106,8 @@ test_that("can upgrade to v4", {
     dm_validate(dm)
     is_zoomed(dm)
     dm_get_all_uks(dm_v4)
+    dm_get_all_pks(dm_v4)
+    dm_get_all_fks(dm_v4)
   })
 })
 

--- a/vignettes/tech-dm-class.Rmd
+++ b/vignettes/tech-dm-class.Rmd
@@ -250,16 +250,16 @@ Remove foreign key relations with `dm_rm_fk()` (parameter `columns = NULL` means
 try(
   flights_dm_with_fk %>%
     dm_rm_fk(table = flights, column = dest, ref_table = airports) %>%
-    dm_get_all_fks(c("flights", "airports"))
+    dm_get_all_fks(c(flights, airports))
 )
 
 flights_dm_with_fk %>%
   dm_rm_fk(flights, origin, airports) %>%
-  dm_get_all_fks(c("flights", "airports"))
+  dm_get_all_fks(c(flights, airports))
 
 flights_dm_with_fk %>%
   dm_rm_fk(flights, columns = NULL, airports) %>%
-  dm_get_all_fks(c("flights", "airports"))
+  dm_get_all_fks(c(flights, airports))
 ```
 
 Since the primary keys are defined in the `dm` object, you do not usually need to provide the referenced column name of `ref_table`.


### PR DESCRIPTION
in order to be more in line with the rest of the package's functions