### PR TITLE
chore: Minimal patch to fix multiple match updates

### DIFF
--- a/tests/testthat/test-flatten.R
+++ b/tests/testthat/test-flatten.R
@@ -300,25 +300,12 @@ test_that("tests with 'bad_dm' work", {
   skip_if_src("postgres")
 
   # flatten bad_dm() (no referential integrity)
-  #
-  # Warning, because since dplyr 1.1.0 dm_flatten_to_tbl()
-  # issues warnings, when there are multiple rows in `y` to match rows in `x`
-  # This means here, that the PK in the parent table is violating key constraints
-  if (is_db(my_test_src())) {
+  if (is_db(my_test_src()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
     expect_equivalent_tbl(
       dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3),
       tbl_1() %>%
         left_join(tbl_2(), by = c("a" = "id", "x")) %>%
         left_join(tbl_3(), by = c("b" = "id"))
-    )
-  } else {
-    expect_warning(
-      expect_equivalent_tbl(
-        dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3),
-        tbl_1() %>%
-          left_join(tbl_2(), by = c("a" = "id", "x")) %>%
-          left_join(tbl_3(), by = c("b" = "id"), multiple = "all")
-      )
     )
   }
 
@@ -361,21 +348,12 @@ test_that("tests with 'bad_dm' work (2)", {
   bad_filtered_dm <- dm_filter(bad_dm(), tbl_1 = (a != 4))
 
   # flatten bad_dm() (no referential integrity)
-  if (is_db(my_test_src())) {
+  if (is_db(my_test_src()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
     expect_equivalent_tbl(
       dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3, .join = full_join),
       tbl_1() %>%
         full_join(tbl_2(), by = c("a" = "id", "x")) %>%
         full_join(tbl_3(), by = c("b" = "id"))
-    )
-  } else {
-    expect_warning(
-      expect_equivalent_tbl(
-        dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3, .join = full_join),
-        tbl_1() %>%
-          full_join(tbl_2(), by = c("a" = "id", "x")) %>%
-          full_join(tbl_3(), by = c("b" = "id"), multiple = "all")
-      )
     )
   }
 })
@@ -390,39 +368,23 @@ test_that("tests with 'bad_dm' work (3)", {
   bad_filtered_dm <- dm_filter(bad_dm(), tbl_1 = (a != 4))
 
   # flatten bad_dm() (no referential integrity)
-  if (is_db(my_test_src())) {
+  if (is_db(my_test_src()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
     expect_equivalent_tbl(
       dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3, .join = right_join),
       tbl_1() %>%
         right_join(tbl_2(), by = c("a" = "id", "x")) %>%
         right_join(tbl_3(), by = c("b" = "id"))
     )
-  } else {
-    expect_equivalent_tbl(
-      dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3, .join = right_join),
-      tbl_1() %>%
-        right_join(tbl_2(), by = c("a" = "id", "x")) %>%
-        right_join(tbl_3(), by = c("b" = "id"), multiple = "all")
-    )
   }
 
 
   # flatten bad_dm() (no referential integrity); different order
-  if (is_db(my_test_src())) {
+  if (is_db(my_test_src()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
     expect_equivalent_tbl(
       dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_3, tbl_2, .join = right_join),
       tbl_1() %>%
         right_join(tbl_3(), by = c("b" = "id")) %>%
         right_join(tbl_2(), by = c("a" = "id", "x"))
-    )
-  } else {
-    expect_warning(
-      expect_equivalent_tbl(
-        dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_3, tbl_2, .join = right_join),
-        tbl_1() %>%
-          right_join(tbl_3(), by = c("b" = "id"), multiple = "all") %>%
-          right_join(tbl_2(), by = c("a" = "id", "x"))
-      )
     )
   }
 })


### PR DESCRIPTION
We are preparing to release dplyr 1.1.1 and dm popped up in the revdep checks.

We realized that we didn't get the `multiple` argument quite right the first time around 😞 . It was too aggressive since it warned on both one-to-many and many-to-many joins. In 1.1.1 we've made two improvements:
- `multiple` now defaults to `"all"`. The options of `NULL`, `"error"`, and `"warning"` are deprecated.
- `relationship` is a new argument to add known constraints onto the join procedure, such as `"many-to-one"`, which replaces `multiple = "error"`.

The default of `relationship` checks to see if there is a `many-to-many` relationship between the keys of `x` and `y` and will warn if one is present. This should be _much_ rarer than what we checked for before, and targets the most dangerous case that we were trying to warn the user about.

You can read all about `relationship` here https://github.com/tidyverse/dplyr/pull/6753, along with the issues linked there.

Unfortunately it does affect dm by breaking some tests. I've done the minimal amount of work to get the tests working again, but I think you may need to do a full review of `multiple = "all"` usage. I think most of the time you will just be able to remove it, as I doubt you do many many-to-many joins here. The annoying part is ensuring the tests pass on CRAN and dev dplyr, so maybe it is worth leaving the other `multiple = "all"` calls in there until dplyr 1.1.1 is out and you can depend on it.

We plan to submit dplyr 1.1.1 in 2-3 weeks.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!