### PR TITLE
use normal dev version of fledge

### DIFF
--- a/.github/workflows/fledge.yaml
+++ b/.github/workflows/fledge.yaml
@@ -5,6 +5,8 @@ on:
   workflow_dispatch:
   # for debugging
   push:
+    branches:
+      - "main"
   # daily run
   schedule:
   - cron: "30 0 * * *"

--- a/.github/workflows/fledge.yaml
+++ b/.github/workflows/fledge.yaml
@@ -45,7 +45,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           install-r: false
           cache-version: fledge-1
-          packages: cynkra/fledge@cran-watching
+          packages: cynkra/fledge
 
       - name: Bump version
         run: |


### PR DESCRIPTION
poking a bit in the dark here, but -- seeing the error messages in the action -- does this make sense, @krlmlr?

1. fledge@cran-watching: https://github.com/cynkra/dm/actions/runs/4551073535/jobs/8024728595
2. run only on main: https://github.com/cynkra/dm/actions/runs/4553712072/jobs/8030620020
