### PR TITLE
chore: Establish compatibility with dbplyr 2.3.3 and 2.4.0

### DIFF
--- a/R/rows-dm.R
+++ b/R/rows-dm.R
@@ -285,7 +285,19 @@ do_rows_append <- function(x, y, by = NULL, ..., in_place = FALSE, autoinc_col =
   source_rows <- map(key_values, ~ select(filter(y, !!returning == !!.x), -!!returning))
 
   con <- dbplyr::remote_con(x)
-  if (utils::packageVersion("dbplyr") >= "2.3.2.9000") {
+  # FIXME can be removed after depending on dbplyr >= 2.4.0
+  sql_query_append <- dbplyr::sql_query_append
+  append_args <- rlang::fn_fmls_names(dbplyr::sql_query_append)
+  old_interface <- identical(append_args, c("con", "x_name", "y", "...", "returning_cols"))
+  if (old_interface) {
+    target_name <- remote_name_qual(x)
+    insert_queries <- map(source_rows, ~ dbplyr::sql_query_append(
+      con,
+      target_name,
+      .x,
+      returning_cols = autoinc_col
+    ))
+  } else {
     dbplyr_ns <- asNamespace("dbplyr")
     remote_table <- mget("remote_table", dbplyr_ns, mode = "function", ifnotfound = list(NULL))[[1]]
 
@@ -294,14 +306,6 @@ do_rows_append <- function(x, y, by = NULL, ..., in_place = FALSE, autoinc_col =
       remote_table(x),
       from = dbplyr::sql_render(.x, con),
       insert_cols = colnames(.x),
-      returning_cols = autoinc_col
-    ))
-  } else {
-    target_name <- remote_name_qual(x)
-    insert_queries <- map(source_rows, ~ dbplyr::sql_query_append(
-      con,
-      target_name,
-      .x,
       returning_cols = autoinc_col
     ))
   }

--- a/R/rows-dm.R
+++ b/R/rows-dm.R
@@ -297,6 +297,7 @@ do_rows_append <- function(x, y, by = NULL, ..., in_place = FALSE, autoinc_col =
       returning_cols = autoinc_col
     ))
   } else {
+    # FIXME: dbplyr::remote_table() private in dbplyr 2.3.3, public in dbplyr 2.4.0
     dbplyr_ns <- asNamespace("dbplyr")
     remote_table <- mget("remote_table", dbplyr_ns, mode = "function", ifnotfound = list(NULL))[[1]]
 

--- a/R/rows-dm.R
+++ b/R/rows-dm.R
@@ -286,7 +286,6 @@ do_rows_append <- function(x, y, by = NULL, ..., in_place = FALSE, autoinc_col =
 
   con <- dbplyr::remote_con(x)
   # FIXME can be removed after depending on dbplyr >= 2.4.0
-  sql_query_append <- dbplyr::sql_query_append
   append_args <- rlang::fn_fmls_names(dbplyr::sql_query_append)
   old_interface <- identical(append_args, c("con", "x_name", "y", "...", "returning_cols"))
   if (old_interface) {


### PR DESCRIPTION
After dbplyr needed a hot patch release, the check on the package version didn't work anymore.
This now checks the interface instead of the package version.