### PR TITLE
perf: Replace superseded `dplyr::recode()`

### DIFF
--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -711,12 +711,12 @@ prepare_join <- function(x, y, by, selected, suffix, copy, disambiguate = TRUE) 
 
     if (has_length(x_renames)) {
       x_tbl <- x_tbl %>% rename(!!!x_renames[[1]])
-      names(by) <- recode(names2(by), !!!prep_recode(x_renames[[1]]))
-      names(new_col_names) <- recode(names(new_col_names), !!!prep_recode(x_renames[[1]]))
+      names(by) <- recode_compat(names2(by), prep_recode(x_renames[[1]]))
+      names(new_col_names) <- recode_compat(names(new_col_names), prep_recode(x_renames[[1]]))
     }
 
     if (has_length(y_renames)) {
-      names(selected_wo_by) <- recode(names(selected_wo_by), !!!prep_recode(y_renames[[1]]))
+      names(selected_wo_by) <- recode_compat(names(selected_wo_by), prep_recode(y_renames[[1]]))
     }
   }
 
@@ -737,7 +737,7 @@ prepare_join <- function(x, y, by, selected, suffix, copy, disambiguate = TRUE) 
   y_tbl <- select(y_tbl, !!!selected_repaired)
 
   # the `by` argument needs to be updated: LHS stays, RHS needs to be replaced with new names
-  repaired_by <- set_names(recode(by, !!!prep_recode(by_rhs_rename)), names(by))
+  repaired_by <- set_names(recode_compat(by, prep_recode(by_rhs_rename)), names(by))
 
   # in case key columns of x_tbl have the same name as selected columns of y_tbl
   # the column names of x will be adapted (not for `semi_join()` and `anti_join()`)

--- a/R/select-tbl.R
+++ b/R/select-tbl.R
@@ -74,14 +74,14 @@ filter_recode_table_def <- function(data, selected) {
   idx <- match(selected, data$table, nomatch = 0L)
 
   data[idx, ] %>%
-    mutate(table = recode(table, !!!prep_recode(selected)))
+    mutate(table = recode_compat(table, prep_recode(selected)))
 }
 
 filter_recode_fks_of_table <- function(data, selected) {
   # data$table can have multiple entries, we don't care about the order
   idx <- data$table %in% selected
   out <- data[idx, ]
-  out$table <- recode(out$table, !!!prep_recode(selected))
+  out$table <- recode_compat(out$table, prep_recode(selected))
   out
 }
 
@@ -99,6 +99,6 @@ recode2 <- function(x, new) {
   if (is_empty(recipe)) {
     x
   } else {
-    recode(x, !!!recipe)
+    recode_compat(x, recipe)
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -31,3 +31,9 @@ tail.dm_zoomed <- function(x, n = 6L, ...) {
   # dm method provided by utils
   replace_zoomed_tbl(x, tail(tbl_zoomed(x), n, ...))
 }
+
+recode_compat <- function(x, y) {
+  x <- unname(x)
+  idx <- vctrs::vec_match(names(y), x)
+  vctrs::vec_assign(x, idx, y)
+}


### PR DESCRIPTION
Using superseded functions harms the performance quite a bit.
I noticed this when removing tables via `dm::dm_select_tbl(dm, -any_of(tables_to_remove))`.

```r
data <- nycflights_subset()
flights <- data$flights
weather <- data$weather
airlines <- data$airlines
airports <- data$airports
planes <- data$planes

dm <- dm(airlines, airports, flights, planes, weather)

remove_tables <- function() {
  dm %>% 
    dm_select_tbl(-airlines) %>% 
    dm_select_tbl(-airports) %>% 
    dm_select_tbl(-flights) %>% 
    dm_select_tbl(-planes) %>% 
    dm_select_tbl(-weather)
}

bench::mark(
  remove_tables()
)

# Before
# # A tibble: 1 × 13
#   expression     min median `itr/sec` mem_alloc `gc/sec` n_itr
#   <bch:expr>  <bch:> <bch:>     <dbl> <bch:byt>    <dbl> <int>
# 1 remove_tab… 52.5ms 58.2ms      16.7    1.35MB     13.4     5

# After
# # A tibble: 1 × 13
#   expression     min median `itr/sec` mem_alloc `gc/sec` n_itr
#   <bch:expr>  <bch:> <bch:>     <dbl> <bch:byt>    <dbl> <int>
# 1 remove_tab… 15.8ms 17.3ms      55.2    55.3KB     12.6    22
```