### PR TITLE
perf: Replace `tibble()` by `fast_tibble()`

### DIFF
--- a/R/dm.R
+++ b/R/dm.R
@@ -218,12 +218,12 @@ dm_get_def <- function(x, quiet = FALSE) {
 
 new_pk <- function(column = list(), autoincrement = logical(length(column))) {
   stopifnot(is.list(column), is.logical(autoincrement))
-  tibble(column = column, autoincrement = autoincrement)
+  fast_tibble(column = column, autoincrement = autoincrement)
 }
 
 new_uk <- function(column = list()) {
   stopifnot(is.list(column))
-  tibble(column = column)
+  fast_tibble(column = column)
 }
 
 new_fk <- function(ref_column = list(),
@@ -238,11 +238,16 @@ new_fk <- function(ref_column = list(),
     length(on_delete) %in% c(1L, length(table))
   )
 
-  tibble(ref_column, table, column, on_delete)
+  fast_tibble(
+    ref_column = ref_column,
+    table = table,
+    column = column,
+    on_delete = on_delete
+  )
 }
 
 new_filter <- function(quos = list(), zoomed = logical()) {
-  tibble(filter_expr = unclass(quos), zoomed = zoomed)
+  fast_tibble(filter_expr = unclass(quos), zoomed = zoomed)
 }
 
 # Legacy!

--- a/R/utils.R
+++ b/R/utils.R
@@ -32,6 +32,11 @@ tail.dm_zoomed <- function(x, n = 6L, ...) {
   replace_zoomed_tbl(x, tail(tbl_zoomed(x), n, ...))
 }
 
+fast_tibble <- function(...) {
+  out <- vctrs::df_list(...)
+  tibble::new_tibble(out)
+}
+
 recode_compat <- function(x, y) {
   x <- unname(x)
   idx <- vctrs::vec_match(names(y), x)


### PR DESCRIPTION
There are other places where `tibble()` is used. It might be worth looking into them as well.

```r
data <- nycflights_subset()
flights <- data$flights
weather <- data$weather
airlines <- data$airlines
airports <- data$airports
planes <- data$planes

dm <- dm(airlines, airports, flights, planes, weather)

add_keys <- function() {
  dm %>% 
    dm_add_pk(planes, tailnum) %>%
    dm_add_pk(airlines, carrier) %>%
    dm_add_pk(airports, faa) %>%
    dm_add_fk(flights, tailnum, planes) %>%
    dm_add_fk(flights, carrier, airlines) %>%
    dm_add_fk(flights, origin, airports)
}

for (i in 1:100) {
  dm_nycflights13()
}

bench::mark(
  add_keys()
)

# before
# # A tibble: 1 × 13
#   expression     min median `itr/sec` mem_alloc `gc/sec` n_itr
#   <bch:expr> <bch:t> <bch:>     <dbl> <bch:byt>    <dbl> <int>
# 1 add_keys()  9.69ms 10.4ms      90.1    35.1KB     13.7    33

# after
# # A tibble: 1 × 13
#   expression     min median `itr/sec` mem_alloc `gc/sec` n_itr
#   <bch:expr> <bch:t> <bch:>     <dbl> <bch:byt>    <dbl> <int>
# 1 add_keys()  5.31ms 7.31ms      133.     700KB     8.89    60
```