### PR TITLE
fix: Fix the behaviour of the message 'use collect(pull_tbl())'

### DIFF
--- a/R/dm.R
+++ b/R/dm.R
@@ -708,7 +708,9 @@ collect.dm <- function(x, ..., progress = NA) {
 
 #' @export
 collect.dm_zoomed <- function(x, ...) {
-  message("Detaching table from dm, use `collect(pull_tbl())` instead to silence this message.")
+  if (all(!grepl("pull_tbl()", match.call()))) {
+    message("Detaching table from dm, use `collect(pull_tbl())` instead to silence this message.")
+  }
 
   collect(pull_tbl(x))
 }


### PR DESCRIPTION
Fixes #1929.
In [collect.dm_zoomed()](https://github.com/cynkra/dm/blob/4e845473aacb1891a1fc387a81c2aeda910cfb17/R/dm.R#L710), check that `pull_tbl()` is specified. If not, write the message.