### PR TITLE
fix: Always use `get_src_tbl_names()` to fetch tbl `Id`s within `dm_from_con()`

### DIFF
--- a/R/dm_from_con.R
+++ b/R/dm_from_con.R
@@ -93,18 +93,14 @@ dm_from_con <- function(con = NULL, table_names = NULL, learn_keys = NULL,
     )
   }
 
-  if (is_null(table_names)) {
-    src_tbl_names <- get_src_tbl_names(src, ..., names = .names)
-  } else {
-    src_tbl_names <- table_names
+  tbl_ids <- get_src_tbl_names(src, ..., names = .names)
+
+  # Fetch only the tbls which were specifically requested
+  if (!is.null(table_names)) {
+    tbl_ids <- tbl_ids[table_names]
   }
 
-  nms <- purrr::map_chr(src_tbl_names, ~ .x@name[["table"]])
-
-  tbls <-
-    set_names(src_tbl_names, nms) %>%
-    quote_ids(con) %>%
-    map(possibly(tbl, NULL), src = src)
+  tbls <- map(tbl_ids, possibly(tbl, NULL), src = src)
 
   bad <- map_lgl(tbls, is_null)
   if (any(bad)) {

--- a/R/dm_from_con.R
+++ b/R/dm_from_con.R
@@ -97,7 +97,13 @@ dm_from_con <- function(con = NULL, table_names = NULL, learn_keys = NULL,
 
   # Fetch only the tbls which were specifically requested
   if (!is.null(table_names)) {
-    tbl_ids <- tbl_ids[table_names]
+    not_found <- setdiff(table_names, names(tbl_ids))
+
+    if (length(not_found) > 0) {
+      cli::cli_warn("Could not find table{?s}: {not_found}")
+    }
+
+    tbl_ids <- tbl_ids[intersect(table_names, names(tbl_ids))]
   }
 
   tbls <- map(tbl_ids, possibly(tbl, NULL), src = src)


### PR DESCRIPTION
According to the docs of `dm_from_con()`, the `table_names` parameter allows the user to include only specific tables in the returned `dm` object:

    #' @param table_names
    #'   A character vector of the names of the tables to include.

Currently, we use two different methods to fetch tbls:
* If `table_names` was not provided, use `dm:::get_src_tbl_names()` to fetch tbl `Id`s, which are later passed to `tbl()`
* If `table_names` _was_ provided, pass the character-type names directly to `tbl()`

But the second method does not work with non-default schema names, or with multiple schemas; and we also create additional problems when we try to set names for the list of tbls (#1933).

I think we can actually use the first method in all cases, i.e. use `get_src_tbl_names()` to return a named list of tbl `Id`s.

Then we can use `table_names` to take a subset from that list, before passing to `tbl()`.

---

Fixes #1933.