### PR TITLE
docs: Add information on default font size to `?dm_draw`

### DIFF
--- a/R/draw-dm.R
+++ b/R/draw-dm.R
@@ -30,9 +30,10 @@
 #' @param font_size `r lifecycle::badge("experimental")`
 #'
 #'   Font size for:
-#'     - `header`, defaults to `16`
-#'     - `column`, defaults to `16`
-#'     - `table_description`, defaults to `8`
+#'
+#'   - `header`, defaults to `16`
+#'   - `column`, defaults to `16`
+#'   - `table_description`, defaults to `8`
 #'
 #'   Can be set as a named integer vector, e.g. `c(table_headers = 18L, table_description = 6L)`.
 #'

--- a/man/dm_draw.Rd
+++ b/man/dm_draw.Rd
@@ -55,9 +55,11 @@ to display a data model but relies on the type of the return value.}
 \item{font_size}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 
 Font size for:
-- \code{header}, defaults to \code{16}
-- \code{column}, defaults to \code{16}
-- \code{table_description}, defaults to \code{8}
+\itemize{
+\item \code{header}, defaults to \code{16}
+\item \code{column}, defaults to \code{16}
+\item \code{table_description}, defaults to \code{8}
+}
 
 Can be set as a named integer vector, e.g. \code{c(table_headers = 18L, table_description = 6L)}.}
 }


### PR DESCRIPTION
list of possible elements for argument `font_size` was not properly rendered in the docs