### PR TITLE
docs: Deprecate `copy_dm_to(copy_to = )` argument

### DIFF
--- a/R/db-interface.R
+++ b/R/db-interface.R
@@ -62,14 +62,7 @@
 #'
 #'   Use qualified names corresponding to your database's syntax
 #'   to specify e.g. database and schema for your tables.
-#' @param copy_to By default, [dplyr::copy_to()] is called to upload the
-#'   individual tables to the target data source.
-#'   This argument allows overriding the standard behavior in cases
-#'   when the default does not work as expected, such as spatial data frames
-#'   or other tables with special data types.
-#'   If not `NULL`, this argument is processed with [rlang::as_function()].
-#' @param ... Passed on to [dplyr::copy_to()] or to the function specified
-#'   by the `copy_to` argument.
+#' @param copy_to,... Deprecated.
 #'
 #' @family DB interaction functions
 #'
@@ -137,6 +130,20 @@ copy_dm_to <- function(dest, dm, ...,
     if (is.null(table_names) && temporary && !unique_table_names) {
       table_names <- identity
     }
+  }
+
+  if (!is.null(copy_to)) {
+    deprecate_soft(
+      "1.0.0", "dm::copy_dm_to(copy_to = )",
+      details = "Use `dm_ddl()` for more control over the schema creation process."
+    )
+  }
+
+  if (dots_n(...) > 0) {
+    deprecate_soft(
+      "1.0.0", "dm::copy_dm_to(... = )",
+      details = "Use `dm_ddl()` for more control over the schema creation process."
+    )
   }
 
   dest <- src_from_src_or_con(dest)

--- a/man/copy_dm_to.Rd
+++ b/man/copy_dm_to.Rd
@@ -26,9 +26,6 @@ copy_dm_to(
 
 \item{dm}{A \code{dm} object.}
 
-\item{...}{Passed on to \code{\link[dplyr:copy_to]{dplyr::copy_to()}} or to the function specified
-by the \code{copy_to} argument.}
-
 \item{overwrite, types, indexes, unique_indexes}{Must remain \code{NULL}.}
 
 \item{set_key_constraints}{If \code{TRUE} will mirror \code{dm} primary and foreign key constraints on a database
@@ -83,12 +80,7 @@ Not all DBMS are supported.}
 hide in non-interactive mode, show in interactive mode. Requires the
 'progress' package.}
 
-\item{copy_to}{By default, \code{\link[dplyr:copy_to]{dplyr::copy_to()}} is called to upload the
-individual tables to the target data source.
-This argument allows overriding the standard behavior in cases
-when the default does not work as expected, such as spatial data frames
-or other tables with special data types.
-If not \code{NULL}, this argument is processed with \code{\link[rlang:as_function]{rlang::as_function()}}.}
+\item{copy_to, ...}{Deprecated.}
 }
 \value{
 A \code{dm} object on the given \code{src} with the same table names


### PR DESCRIPTION
.