### PR TITLE
chore: Improve handling of suggested packages, add link in doc

### DIFF
--- a/R/check_suggested.R
+++ b/R/check_suggested.R
@@ -42,13 +42,17 @@ check_suggested <- function(packages,
   # If TRUE, fail if package is not installed
   for (pkg in packages) {
     if (!is_installed(pkg)) {
-      if (is.null(message)) {
-        message <- glue("`{top_level_fun}()` needs the '{pkg}' package. Do you need `install.packages(\"{pkg}\")` ?")
-      }
       if (is_testing()) {
+        if (is.null(message)) {
+          message <- glue("`{top_level_fun}()` needs the '{pkg}' package.")
+        }
         testthat::skip(message)
       } else {
-        abort(message)
+        if (is.null(message)) {
+          message <- glue("to use `{top_level_fun}()`.")
+        }
+        # Could use the version argument too.
+        rlang::check_installed(packages, message)
       }
     }
   }

--- a/R/nycflights13.R
+++ b/R/nycflights13.R
@@ -3,8 +3,8 @@
 #' @description
 #' Creates an example [`dm`] object from the tables in \pkg{nycflights13},
 #' along with the references.
-#' See [nycflights13::flights] for a description of the data.
-#' As described in [nycflights13::planes], the relationship
+#' See [`nycflights13::flights`] for a description of the data.
+#' As described in [`nycflights13::planes`], the relationship
 #' between the `flights` table and the `planes` tables is "weak", it does not satisfy
 #' data integrity constraints.
 #'
@@ -26,6 +26,7 @@
 #' @return A `dm` object consisting of {nycflights13} tables, complete with primary and foreign keys and optionally colored.
 #'
 #' @export
+#' @seealso `vignette("howto-dm-df")`
 #' @examplesIf rlang::is_installed("DiagrammeR")
 #' dm_nycflights13() %>%
 #'   dm_draw()

--- a/man/dm_nycflights13.Rd
+++ b/man/dm_nycflights13.Rd
@@ -40,8 +40,8 @@ A \code{dm} object consisting of {nycflights13} tables, complete with primary an
 \description{
 Creates an example \code{\link{dm}} object from the tables in \pkg{nycflights13},
 along with the references.
-See \link[nycflights13:flights]{nycflights13::flights} for a description of the data.
-As described in \link[nycflights13:planes]{nycflights13::planes}, the relationship
+See \code{\link[nycflights13:flights]{nycflights13::flights}} for a description of the data.
+As described in \code{\link[nycflights13:planes]{nycflights13::planes}}, the relationship
 between the \code{flights} table and the \code{planes} tables is "weak", it does not satisfy
 data integrity constraints.
 }
@@ -50,4 +50,7 @@ data integrity constraints.
 dm_nycflights13() \%>\%
   dm_draw()
 \dontshow{\}) # examplesIf}
+}
+\seealso{
+\code{vignette("howto-dm-df")}
 }

--- a/tests/testthat/_snaps/check_suggested.md
+++ b/tests/testthat/_snaps/check_suggested.md
@@ -35,10 +35,10 @@
       check_suggested("iurtnkjvmomweicopbt", TRUE, top_level_fun = "foo")
     Condition
       Error:
-      ! `foo()` needs the 'iurtnkjvmomweicopbt' package. Do you need `install.packages("iurtnkjvmomweicopbt")` ?
+      ! The package "iurtnkjvmomweicopbt" is required to use `foo()`.
     Code
       check_suggested("iurtnkjvmomweicopbt", TRUE, message = "not installed!")
     Condition
       Error:
-      ! not installed!
+      ! The package "iurtnkjvmomweicopbt" is required not installed!
 

--- a/tests/testthat/test-check_suggested.R
+++ b/tests/testthat/test-check_suggested.R
@@ -1,4 +1,5 @@
 test_that("`check_suggested()` works", {
+  withr::local_envvar("TESTTHAT" = "")
   expect_snapshot({
     check_suggested("rlang", TRUE, top_level_fun = "foo")
 
@@ -13,6 +14,7 @@ test_that("`check_suggested()` works", {
 })
 
 test_that("`check_suggested()` works for error messages", {
+  withr::local_envvar("TESTTHAT" = "")
   expect_snapshot(error = TRUE, {
     check_suggested("iurtnkjvmomweicopbt", TRUE, top_level_fun = "foo")
     check_suggested("iurtnkjvmomweicopbt", TRUE, message = "not installed!")


### PR DESCRIPTION
Addresses #1735, closes #2035.

Briefly, it uses `check_installed()` in the check_suggested function to make it easier to install DiagrammeR. I guess `check_suggests()` could be simplified further. (and get the function by chaining rather than naming.

Mind the small tweak in tests to avoid skipping the test. We have to make it believe that we are not testing to avoid skipping the test. and actually record the message.

Note that check_installed()` errors in non-interactive sessions.

In an unrelated way, I added a link to the data frame vignette in the dm_nyc13 flights as I had issues to get started and this vignette helped me.

