### PR TITLE
fix: `copy_dm_to()` creates string columns of necessary lengths for MariaDB and SQL Server. This worked before for SQL Server in dm 1.0.5, now also works on MariaDB

### DIFF
--- a/R/build_copy_queries.R
+++ b/R/build_copy_queries.R
@@ -62,7 +62,16 @@ build_copy_queries <- function(dest, dm, set_key_constraints = TRUE, temporary =
 
     # database-specific type conversions
     if (is_mariadb(dest)) {
-      types[types == "TEXT"] <- "VARCHAR(255)"
+      if (nrow(tbl) == 0) {
+        types[types == "TEXT"] <- "VARCHAR(255)"
+      } else {
+        for (i in which(types == "TEXT")) {
+          chars <- max(nchar(tbl[[i]], type = "bytes", keepNA = FALSE))
+          if (chars <= 255) {
+            types[[i]] <- paste0("VARCHAR(255)")
+          }
+        }
+      }
     }
     if (is_sqlite(dest)) {
       types[types == "INT"] <- "INTEGER"

--- a/R/build_copy_queries.R
+++ b/R/build_copy_queries.R
@@ -1,5 +1,7 @@
 #' @autoglobal
 build_copy_queries <- function(dest, dm, set_key_constraints = TRUE, temporary = TRUE, table_names = set_names(names(dm))) {
+  stopifnot(!is_src_db(dm))
+
   ## Reorder queries according to topological sort so pks are created before associated fks
   graph <- create_graph_from_dm(dm, directed = TRUE)
   topo <- names(igraph::topo_sort(graph, mode = "in"))
@@ -7,9 +9,6 @@ build_copy_queries <- function(dest, dm, set_key_constraints = TRUE, temporary =
   if (length(topo) == length(dm)) {
     dm <- dm[topo]
   }
-
-  ## use 0-rows object
-  ptype_dm <- collect(dm_ptype(dm))
 
   con <- con_from_src_or_con(dest)
 
@@ -35,8 +34,8 @@ build_copy_queries <- function(dest, dm, set_key_constraints = TRUE, temporary =
   }
 
   ## fetch types, keys and uniques
-  pks <- dm_get_all_pks_impl(ptype_dm) %>% rename(name = table)
-  fks <- dm_get_all_fks_impl(ptype_dm)
+  pks <- dm_get_all_pks_impl(dm) %>% rename(name = table)
+  fks <- dm_get_all_fks_impl(dm)
 
   # if a that doesn't match a pk, this non-pk col should be unique
   uniques <-
@@ -52,12 +51,12 @@ build_copy_queries <- function(dest, dm, set_key_constraints = TRUE, temporary =
     # autoincrementing is not possible for composite keys, so `pk_col` is guaranteed
     # to be a scalar
     pk_col <-
-      ptype_dm %>%
+      dm %>%
       dm_get_all_pks(!!x) %>%
       filter(autoincrement) %>%
       pull(pk_col)
 
-    tbl <- tbl_impl(ptype_dm, x)
+    tbl <- tbl_impl(dm, x)
     types <- DBI::dbDataType(con, tbl)
     autoincrement_attribute <- ""
 
@@ -117,10 +116,10 @@ build_copy_queries <- function(dest, dm, set_key_constraints = TRUE, temporary =
     df_col_types
   }
 
-  tbl_defs <- tibble(name = names(ptype_dm))
+  tbl_defs <- tibble(name = names(dm))
 
   col_defs <-
-    ptype_dm %>%
+    dm %>%
     src_tbls_impl() %>%
     set_names() %>%
     map_dfr(get_sql_col_types, .id = "name") %>%

--- a/R/db-interface.R
+++ b/R/db-interface.R
@@ -264,7 +264,7 @@ db_append_table <- function(con, remote_table, table, progress, top_level_fun = 
     walk(seq_len(n_chunks), ticker(~ {
       end <- .x * chunk_size
       idx <- seq2(end - (chunk_size - 1), min(end, nrow(table)))
-      values <- map(table[idx, ], mssql_escape, con = con)
+      values <- map(table[idx, , drop = FALSE], mssql_escape, con = con)
       # Can't use dbAppendTable(): https://github.com/r-dbi/odbc/issues/480
       sql <- DBI::sqlAppendTable(con, remote_table_id, values, row.names = FALSE)
       if (length(autoinc) > 1L) abort("more than one autoincrement key in one table")

--- a/R/db-interface.R
+++ b/R/db-interface.R
@@ -173,6 +173,9 @@ copy_dm_to <- function(
     return(dm)
   }
 
+  # Must be done here because table types may depend on string length, #2066
+  dm <- collect(dm, progress = progress)
+
   queries <- build_copy_queries(dest_con, dm, set_key_constraints, temporary, table_names_out)
 
   ticker_create <- new_ticker(
@@ -240,7 +243,7 @@ check_naming <- function(table_names, dm_table_names) {
 }
 
 db_append_table <- function(con, remote_table, table, progress, top_level_fun = "copy_dm_to", autoinc = logical(0)) {
-  table <- collect(table)
+  stopifnot(is.data.frame(table))
   if (nrow(table) == 0 || ncol(table) == 0) {
     return(invisible())
   }

--- a/R/dm_sql.R
+++ b/R/dm_sql.R
@@ -316,7 +316,16 @@ ddl_get_col_defs <- function(tables, con, table_names, pks) {
     # database-specific type conversions
     if (is_mariadb(con)) {
       # FIXME: This is wrong in general, only needed for index columns
-      types[types == "TEXT"] <- "VARCHAR(255)"
+      if (nrow(tbl) == 0) {
+        types[types == "TEXT"] <- "VARCHAR(255)"
+      } else {
+        for (i in which(types == "TEXT")) {
+          chars <- max(nchar(tbl[[i]], type = "bytes", keepNA = FALSE))
+          if (chars <= 255) {
+            types[[i]] <- paste0("VARCHAR(255)")
+          }
+        }
+      }
     }
     if (is_sqlite(con)) {
       types[types == "INT"] <- "INTEGER"

--- a/tests/testthat/_snaps/df/build_copy_queries.md
+++ b/tests/testthat/_snaps/df/build_copy_queries.md
@@ -111,7 +111,7 @@
 # build_copy_queries snapshot test for dm_for_filter()
 
     Code
-      dm_for_filter() %>% build_copy_queries(src_db, .) %>% as.list()
+      dm_for_filter() %>% collect() %>% build_copy_queries(src_db, .) %>% as.list()
     Message
       `on_delete = "cascade"` not supported for duckdb
     Output

--- a/tests/testthat/_snaps/duckdb/build_copy_queries.md
+++ b/tests/testthat/_snaps/duckdb/build_copy_queries.md
@@ -111,7 +111,7 @@
 # build_copy_queries snapshot test for dm_for_filter()
 
     Code
-      dm_for_filter() %>% build_copy_queries(src_db, .) %>% as.list()
+      dm_for_filter() %>% collect() %>% build_copy_queries(src_db, .) %>% as.list()
     Message
       `on_delete = "cascade"` not supported for duckdb
     Output

--- a/tests/testthat/_snaps/maria.md
+++ b/tests/testthat/_snaps/maria.md
@@ -241,7 +241,7 @@
       $pre
       $pre$x
       <SQL> CREATE TEMPORARY TABLE `x` (
-        `a` VARCHAR(255)
+        `a` TEXT
       )
       
       
@@ -279,7 +279,7 @@
       $pre
       $pre$x
       <SQL> CREATE TEMPORARY TABLE `x` (
-        `a` VARCHAR(255)
+        `a` TEXT
       )
       
       

--- a/tests/testthat/_snaps/maria/build_copy_queries.md
+++ b/tests/testthat/_snaps/maria/build_copy_queries.md
@@ -107,7 +107,7 @@
 # build_copy_queries snapshot test for dm_for_filter()
 
     Code
-      dm_for_filter() %>% build_copy_queries(src_db, .) %>% as.list()
+      dm_for_filter() %>% collect() %>% build_copy_queries(src_db, .) %>% as.list()
     Output
       $name
       [1] "tf_1" "tf_3" "tf_6" "tf_2" "tf_4" "tf_5"

--- a/tests/testthat/_snaps/mssql/build_copy_queries.md
+++ b/tests/testthat/_snaps/mssql/build_copy_queries.md
@@ -111,7 +111,7 @@
 # build_copy_queries snapshot test for dm_for_filter()
 
     Code
-      dm_for_filter() %>% build_copy_queries(src_db, .) %>% as.list()
+      dm_for_filter() %>% collect() %>% build_copy_queries(src_db, .) %>% as.list()
     Output
       $name
       [1] "tf_1" "tf_3" "tf_6" "tf_2" "tf_4" "tf_5"

--- a/tests/testthat/_snaps/postgres/build_copy_queries.md
+++ b/tests/testthat/_snaps/postgres/build_copy_queries.md
@@ -111,7 +111,7 @@
 # build_copy_queries snapshot test for dm_for_filter()
 
     Code
-      dm_for_filter() %>% build_copy_queries(src_db, .) %>% as.list()
+      dm_for_filter() %>% collect() %>% build_copy_queries(src_db, .) %>% as.list()
     Output
       $name
       [1] "tf_1" "tf_3" "tf_6" "tf_2" "tf_4" "tf_5"

--- a/tests/testthat/_snaps/sqlite/build_copy_queries.md
+++ b/tests/testthat/_snaps/sqlite/build_copy_queries.md
@@ -111,7 +111,7 @@
 # build_copy_queries snapshot test for dm_for_filter()
 
     Code
-      dm_for_filter() %>% build_copy_queries(src_db, .) %>% as.list()
+      dm_for_filter() %>% collect() %>% build_copy_queries(src_db, .) %>% as.list()
     Output
       $name
       [1] "tf_1" "tf_3" "tf_6" "tf_2" "tf_4" "tf_5"

--- a/tests/testthat/test-build_copy_queries.R
+++ b/tests/testthat/test-build_copy_queries.R
@@ -34,6 +34,7 @@ test_that("build_copy_queries snapshot test for dm_for_filter()", {
     variant = my_test_src_name,
     {
       dm_for_filter() %>%
+        collect() %>%
         build_copy_queries(
           src_db,
           .

--- a/tests/testthat/test-duckdb.R
+++ b/tests/testthat/test-duckdb.R
@@ -26,3 +26,20 @@ test_that("dm_sql()", {
       dm_sql(my_test_con())
   })
 })
+
+test_that("long text columns with copy_dm_to()", {
+  # Need skip in every test block, unfortunately
+  skip_if_src_not("duckdb")
+
+  dm <- dm(x = data.frame(a = strrep("x", 300)))
+  dm_out <- copy_dm_to(my_test_con(), dm)
+  expect_equal(collect(dm_out$x)$a, dm$x$a)
+  dm_out_out <- copy_dm_to(my_test_con(), dm_out)
+  expect_equal(collect(dm_out_out$x)$a, dm$x$a)
+
+  dm <- dm(x = data.frame(a = strrep("x", 10000)))
+  dm_out <- copy_dm_to(my_test_con(), dm)
+  expect_equal(collect(dm_out$x)$a, dm$x$a)
+  dm_out_out <- copy_dm_to(my_test_con(), dm_out)
+  expect_equal(collect(dm_out_out$x)$a, dm$x$a)
+})

--- a/tests/testthat/test-maria.R
+++ b/tests/testthat/test-maria.R
@@ -26,3 +26,20 @@ test_that("dm_sql()", {
       dm_sql(my_test_con())
   })
 })
+
+test_that("long text columns with copy_dm_to()", {
+  # Need skip in every test block, unfortunately
+  skip_if_src_not("maria")
+
+  dm <- dm(x = data.frame(a = strrep("x", 300)))
+  dm_out <- copy_dm_to(my_test_con(), dm)
+  expect_equal(collect(dm_out$x)$a, dm$x$a)
+  dm_out_out <- copy_dm_to(my_test_con(), dm_out)
+  expect_equal(collect(dm_out_out$x)$a, dm$x$a)
+
+  dm <- dm(x = data.frame(a = strrep("x", 10000)))
+  dm_out <- copy_dm_to(my_test_con(), dm)
+  expect_equal(collect(dm_out$x)$a, dm$x$a)
+  dm_out_out <- copy_dm_to(my_test_con(), dm_out)
+  expect_equal(collect(dm_out_out$x)$a, dm$x$a)
+})

--- a/tests/testthat/test-mssql.R
+++ b/tests/testthat/test-mssql.R
@@ -26,3 +26,20 @@ test_that("dm_sql()", {
       dm_sql(my_test_con())
   })
 })
+
+test_that("long text columns with copy_dm_to()", {
+  # Need skip in every test block, unfortunately
+  skip_if_src_not("mssql")
+
+  dm <- dm(x = data.frame(a = strrep("x", 300)))
+  dm_out <- copy_dm_to(my_test_con(), dm)
+  expect_equal(collect(dm_out$x)$a, dm$x$a)
+  dm_out_out <- copy_dm_to(my_test_con(), dm_out)
+  expect_equal(collect(dm_out_out$x)$a, dm$x$a)
+
+  dm <- dm(x = data.frame(a = strrep("x", 10000)))
+  dm_out <- copy_dm_to(my_test_con(), dm)
+  expect_equal(collect(dm_out$x)$a, dm$x$a)
+  dm_out_out <- copy_dm_to(my_test_con(), dm_out)
+  expect_equal(collect(dm_out_out$x)$a, dm$x$a)
+})

--- a/tests/testthat/test-postgres.R
+++ b/tests/testthat/test-postgres.R
@@ -26,3 +26,20 @@ test_that("dm_sql()", {
       dm_sql(my_test_con())
   })
 })
+
+test_that("long text columns with copy_dm_to()", {
+  # Need skip in every test block, unfortunately
+  skip_if_src_not("postgres")
+
+  dm <- dm(x = data.frame(a = strrep("x", 300)))
+  dm_out <- copy_dm_to(my_test_con(), dm)
+  expect_equal(collect(dm_out$x)$a, dm$x$a)
+  dm_out_out <- copy_dm_to(my_test_con(), dm_out)
+  expect_equal(collect(dm_out_out$x)$a, dm$x$a)
+
+  dm <- dm(x = data.frame(a = strrep("x", 10000)))
+  dm_out <- copy_dm_to(my_test_con(), dm)
+  expect_equal(collect(dm_out$x)$a, dm$x$a)
+  dm_out_out <- copy_dm_to(my_test_con(), dm_out)
+  expect_equal(collect(dm_out_out$x)$a, dm$x$a)
+})

--- a/tests/testthat/test-sqlite.R
+++ b/tests/testthat/test-sqlite.R
@@ -26,3 +26,20 @@ test_that("dm_sql()", {
       dm_sql(my_test_con())
   })
 })
+
+test_that("long text columns with copy_dm_to()", {
+  # Need skip in every test block, unfortunately
+  skip_if_src_not("sqlite")
+
+  dm <- dm(x = data.frame(a = strrep("x", 300)))
+  dm_out <- copy_dm_to(my_test_con(), dm)
+  expect_equal(collect(dm_out$x)$a, dm$x$a)
+  dm_out_out <- copy_dm_to(my_test_con(), dm_out)
+  expect_equal(collect(dm_out_out$x)$a, dm$x$a)
+
+  dm <- dm(x = data.frame(a = strrep("x", 10000)))
+  dm_out <- copy_dm_to(my_test_con(), dm)
+  expect_equal(collect(dm_out$x)$a, dm$x$a)
+  dm_out_out <- copy_dm_to(my_test_con(), dm_out)
+  expect_equal(collect(dm_out_out$x)$a, dm$x$a)
+})


### PR DESCRIPTION
Closes #2066.

Closes #311.