### PR TITLE
feat: Explicitly fail on `compute(temporary = TRUE)`, which never worked correctly

### DIFF
--- a/R/dm.R
+++ b/R/dm.R
@@ -661,15 +661,19 @@ src_tbls_impl <- function(dm, quiet = FALSE) {
 #' Materialize
 #'
 #' @description
-#' `compute()` materializes all tables in a `dm` to new (temporary or permanent)
+#' `compute()` materializes all tables in a `dm` to new temporary
 #' tables on the database.
 #'
 #' @details
 #' Called on a `dm` object, these methods create a copy of all tables in the `dm`.
 #' Depending on the size of your data this may take a long time.
 #'
+#' To create permament tables, first create the database schema using [copy_dm_to()]
+#' or [dm_sql()], and then use [dm_rows_append()].
+#'
 #' @inheritParams dm_get_tables
 #' @param ... Passed on to [compute()].
+#' @param temporary Must remain `TRUE`.
 #' @return A `dm` object of the same structure as the input.
 #' @name materialize
 #' @export
@@ -691,7 +695,11 @@ src_tbls_impl <- function(dm, quiet = FALSE) {
 #'   collect() %>%
 #'   pull_tbl(districts) %>%
 #'   class()
-compute.dm <- function(x, ...) {
+compute.dm <- function(x, ..., temporary = TRUE) {
+  if (!isTRUE(temporary)) {
+    abort("`compute.dm()` does not support `temporary = FALSE`.")
+  }
+
   # for both dm and dm_zoomed
   x %>%
     dm_apply_filters_impl() %>%

--- a/man/materialize.Rd
+++ b/man/materialize.Rd
@@ -6,7 +6,7 @@
 \alias{collect.dm}
 \title{Materialize}
 \usage{
-\method{compute}{dm}(x, ...)
+\method{compute}{dm}(x, ..., temporary = TRUE)
 
 \method{collect}{dm}(x, ..., progress = NA)
 }
@@ -14,6 +14,8 @@
 \item{x}{A \code{dm} object.}
 
 \item{...}{Passed on to \code{\link[=compute]{compute()}}.}
+
+\item{temporary}{Must remain \code{TRUE}.}
 
 \item{progress}{Whether to display a progress bar, if \code{NA} (the default)
 hide in non-interactive mode, show in interactive mode. Requires the
@@ -23,7 +25,7 @@ hide in non-interactive mode, show in interactive mode. Requires the
 A \code{dm} object of the same structure as the input.
 }
 \description{
-\code{compute()} materializes all tables in a \code{dm} to new (temporary or permanent)
+\code{compute()} materializes all tables in a \code{dm} to new temporary
 tables on the database.
 
 \code{collect()} downloads the tables in a \code{dm} object as local \link{tibble}s.
@@ -31,6 +33,9 @@ tables on the database.
 \details{
 Called on a \code{dm} object, these methods create a copy of all tables in the \code{dm}.
 Depending on the size of your data this may take a long time.
+
+To create permament tables, first create the database schema using \code{\link[=copy_dm_to]{copy_dm_to()}}
+or \code{\link[=dm_sql]{dm_sql()}}, and then use \code{\link[=dm_rows_append]{dm_rows_append()}}.
 }
 \examples{
 \dontshow{if (dm:::dm_has_financial() && rlang::is_installed("RSQLite")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/tests/testthat/_snaps/dm.md
+++ b/tests/testthat/_snaps/dm.md
@@ -333,6 +333,14 @@
         dm::dm_add_fk(fact...6, dim_3_key, dim_3...9) %>%
         dm::dm_add_fk(fact...6, dim_4_key, dim_4...10)
 
+# 'compute.dm()' fails with `temporary = FALSE` (#2059)
+
+    Code
+      dm_for_filter_duckdb() %>% compute(temporary = FALSE)
+    Condition
+      Error in `compute()`:
+      ! `compute.dm()` does not support `temporary = FALSE`.
+
 # output
 
     Code

--- a/tests/testthat/test-dm.R
+++ b/tests/testthat/test-dm.R
@@ -270,8 +270,6 @@ test_that("'collect.dm_zoomed()' collects tables, with message", {
 })
 
 test_that("'compute.dm()' computes tables on DB", {
-  skip("Needs https://github.com/tidyverse/dbplyr/pull/649")
-
   def <-
     dm_for_filter_duckdb() %>%
     dm_filter(tf_1 = a > 3) %>%
@@ -285,8 +283,6 @@ test_that("'compute.dm()' computes tables on DB", {
 })
 
 test_that("'compute.dm_zoomed()' computes tables on DB", {
-  skip("Needs https://github.com/tidyverse/dbplyr/pull/649")
-
   dm_zoomed_for_compute <-
     dm_for_filter_duckdb() %>%
     dm_zoom_to(tf_1) %>%

--- a/tests/testthat/test-dm.R
+++ b/tests/testthat/test-dm.R
@@ -311,6 +311,13 @@ test_that("'compute.dm_zoomed()' computes tables on DB", {
   expect_equal(lengths(remote_names), rep_along(remote_names, 1))
 })
 
+test_that("'compute.dm()' fails with `temporary = FALSE` (#2059)", {
+  expect_snapshot(error = TRUE, {
+    dm_for_filter_duckdb() %>%
+      compute(temporary = FALSE)
+  })
+})
+
 test_that("some methods/functions for `dm_zoomed` work", {
   expect_identical(
     colnames(dm_zoom_to(dm_for_filter(), tf_1)),


### PR DESCRIPTION
Documented workflow for persistent tables.

Closes #2059.