### PR TITLE
perf: Speed up `dm()`, `new_dm()`, `as_dm()` and `dm_validate()`. `dm()` and `as_dm()` no longer call `dm_validate()`

### DIFF
--- a/R/globals.R
+++ b/R/globals.R
@@ -34,9 +34,6 @@ utils::globalVariables(c(
   "new_table", # <dm_disentangle>
   "fks", # <dm_disentangle>
   "uks", # <dm_disentangle>
-  "pks", # <new_dm_def>
-  "uks", # <new_dm_def>
-  "fks", # <new_dm_def>
   "pks", # <str.dm>
   "fks", # <str.dm>
   "filters", # <str.dm>

--- a/R/validate.R
+++ b/R/validate.R
@@ -1,3 +1,6 @@
+# Run at installation time
+boilerplate <- new_dm_def()
+
 #' Validator
 #'
 #' `dm_validate()` checks the internal consistency of a `dm` object.
@@ -26,8 +29,6 @@ dm_validate <- function(x) {
   }
 
   def <- dm_get_def(x)
-
-  boilerplate <- new_dm_def()
 
   table_names <- def$table
   if (any(table_names == "")) abort_dm_invalid("Not all tables are named.")


### PR DESCRIPTION
.