### PR TITLE
chore: Use correct option to control verbosity of lifecycle messages in unit tests

### DIFF
--- a/tests/testthat/helper-testthat.R
+++ b/tests/testthat/helper-testthat.R
@@ -1,3 +1,2 @@
-options(testthat.progress.verbose_skips = FALSE)
 options(Ncpus = min(parallel::detectCores(), 4))
 options(lifecycle_verbosity = "warning")

--- a/tests/testthat/helper-testthat.R
+++ b/tests/testthat/helper-testthat.R
@@ -1,3 +1,3 @@
 options(testthat.progress.verbose_skips = FALSE)
 options(Ncpus = min(parallel::detectCores(), 4))
-options(tidyselect_verbosity = "verbose")
+options(lifecycle_verbosity = "warning")


### PR DESCRIPTION
- Old option deprecated in https://tidyselect.r-lib.org/news/index.html#tidyselect-120
- New option documented in https://lifecycle.r-lib.org/reference/verbosity.html