### PR TITLE
feat: add support for Redshift connections

### DIFF
--- a/R/build_copy_queries.R
+++ b/R/build_copy_queries.R
@@ -83,7 +83,7 @@ build_copy_queries <- function(dest, dm, set_key_constraints = TRUE, temporary =
       pk_col <- pk_col[[1]]
 
       # Postgres:
-      if (is_postgres(dest)) {
+      if (is_postgres(dest) || is_redshift(dest)) {
         types[pk_col] <- "SERIAL"
       }
 

--- a/R/db-interface.R
+++ b/R/db-interface.R
@@ -6,7 +6,7 @@
 #' The latter is copied to the former.
 #' The default is to create temporary tables, set `temporary = FALSE` to create permanent tables.
 #' Unless `set_key_constraints` is `FALSE`, primary key constraints are set on all databases,
-#' and in addition foreign key constraints are set on MSSQL and Postgres databases.
+#' and in addition foreign key constraints are set on MSSQL and Postgres/Redshift databases.
 #'
 #' @inheritParams dm_examine_constraints
 #'
@@ -280,7 +280,7 @@ db_append_table <- function(con, remote_table, table, progress, top_level_fun = 
       }
       DBI::dbExecute(con, sql, immediate = TRUE)
     }))
-  } else if (is_postgres(con)) {
+  } else if (is_postgres(con) || is_redshift(con)) {
     # https://github.com/r-dbi/RPostgres/issues/384
     table <- as.data.frame(table)
     # https://github.com/r-dbi/RPostgres/issues/382

--- a/R/dm_from_con.R
+++ b/R/dm_from_con.R
@@ -3,7 +3,7 @@
 #' @description
 #' `dm_from_con()` creates a [dm] from some or all tables in a [src]
 #' (a database or an environment) or which are accessible via a DBI-Connection.
-#' For Postgres and SQL Server databases, primary and foreign keys
+#' For Postgres/Redshift and SQL Server databases, primary and foreign keys
 #' are imported from the database.
 #'
 #' @param con A [`DBI::DBIConnection-class`] or a `Pool` object.
@@ -14,13 +14,13 @@
 #'
 #'   Set to `TRUE` to query the definition of primary and
 #'   foreign keys from the database.
-#'   Currently works only for Postgres and SQL Server databases.
+#'   Currently works only for Postgres/Redshift and SQL Server databases.
 #'   The default attempts to query and issues an informative message.
 #' @param .names
 #'   `r lifecycle::badge("experimental")`
 #'
 #'   A glue specification that describes how to name the tables
-#'   within the output, currently only for MSSQL, Postgres and MySQL/MariaDB.
+#'   within the output, currently only for MSSQL, Postgres/Redshift and MySQL/MariaDB.
 #'   This can use `{.table}` to stand for the table name, and
 #'   `{.schema}` to stand for the name of the schema which the table lives
 #'   within. The default (`NULL`) is equivalent to `"{.table}"` when a single
@@ -30,11 +30,11 @@
 #'
 #'   Additional parameters for the schema learning query.
 #'
-#'   - `schema`: supported for MSSQL (default: `"dbo"`), Postgres (default: `"public"`), and MariaDB/MySQL
+#'   - `schema`: supported for MSSQL (default: `"dbo"`), Postgres/Redshift (default: `"public"`), and MariaDB/MySQL
 #'     (default: current database). Learn the tables in a specific schema (or database for MariaDB/MySQL).
 #'   - `dbname`: supported for MSSQL. Access different databases on the connected MSSQL-server;
 #'     default: active database.
-#'   - `table_type`: supported for Postgres (default: `"BASE TABLE"`). Specify the table type. Options are:
+#'   - `table_type`: supported for Postgres/Redshift (default: `"BASE TABLE"`). Specify the table type. Options are:
 #'     1. `"BASE TABLE"` for a persistent table (normal table type)
 #'     2. `"VIEW"` for a view
 #'     3. `"FOREIGN TABLE"` for a foreign table

--- a/R/dm_sql.R
+++ b/R/dm_sql.R
@@ -348,8 +348,8 @@ ddl_get_col_defs <- function(tables, con, table_names, pks) {
       # extract column name representing primary key
       pk_col_name <- pk_col$pk_col[[1]]
 
-      # Postgres:
-      if (is_postgres(con)) {
+      # Postgres/Redshift:
+      if (is_postgres(con) || is_redshift(con)) {
         types[pk_col_name] <- "SERIAL"
       }
 

--- a/R/learn.R
+++ b/R/learn.R
@@ -3,7 +3,7 @@
 #' @description If there are any permament tables on a DB, a new [`dm`] object can be created that contains those tables,
 #' along with their primary and foreign key constraints.
 #'
-#' Currently this only works with MSSQL and Postgres databases.
+#' Currently this only works with MSSQL and Postgres/Redshift databases.
 #'
 #' The default database schema will be used; it is currently not possible to parametrize the funcion with a specific database schema.
 #'

--- a/R/schema.R
+++ b/R/schema.R
@@ -299,7 +299,7 @@ sql_schema_table_list_postgres <- function(con, schema = NULL) {
 #'
 #' @inheritParams db_schema_create
 #' @param force Boolean, default `FALSE`. Set to `TRUE` to drop a schema and
-#' all objects it contains at once. Currently only supported for Postgres.
+#' all objects it contains at once. Currently only supported for Postgres/Redshift.
 #'
 #' @details Methods are not available for all DBMS.
 #'
@@ -357,7 +357,7 @@ db_schema_drop.PqConnection <- function(con, schema, force = FALSE, ...) {
 `db_schema_drop.Microsoft SQL Server` <- function(con, schema, force = FALSE, dbname = NULL, ...) {
   warn_if_arg_not(
     force,
-    only_on = "Postgres",
+    only_on = c("Postgres", "Redshift"),
     correct = FALSE,
     additional_msg = "Please remove potential objects from the schema manually."
   )

--- a/man/copy_dm_to.Rd
+++ b/man/copy_dm_to.Rd
@@ -86,7 +86,7 @@ and a \code{\link{dm}} object as its second argument.
 The latter is copied to the former.
 The default is to create temporary tables, set \code{temporary = FALSE} to create permanent tables.
 Unless \code{set_key_constraints} is \code{FALSE}, primary key constraints are set on all databases,
-and in addition foreign key constraints are set on MSSQL and Postgres databases.
+and in addition foreign key constraints are set on MSSQL and Postgres/Redshift databases.
 }
 \examples{
 \dontshow{if (rlang::is_installed(c("RSQLite", "nycflights13", "dbplyr"))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/man/db_schema_drop.Rd
+++ b/man/db_schema_drop.Rd
@@ -12,7 +12,7 @@ db_schema_drop(con, schema, force = FALSE, ...)
 \item{schema}{Class \code{character} or \code{SQL} (cf. Details), name of the schema}
 
 \item{force}{Boolean, default \code{FALSE}. Set to \code{TRUE} to drop a schema and
-all objects it contains at once. Currently only supported for Postgres.}
+all objects it contains at once. Currently only supported for Postgres/Redshift.}
 
 \item{...}{Passed on to the individual methods.}
 }

--- a/man/dm_from_con.Rd
+++ b/man/dm_from_con.Rd
@@ -21,13 +21,13 @@ dm_from_con(
 
 Set to \code{TRUE} to query the definition of primary and
 foreign keys from the database.
-Currently works only for Postgres and SQL Server databases.
+Currently works only for Postgres/Redshift and SQL Server databases.
 The default attempts to query and issues an informative message.}
 
 \item{.names}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 
 A glue specification that describes how to name the tables
-within the output, currently only for MSSQL, Postgres and MySQL/MariaDB.
+within the output, currently only for MSSQL, Postgres/Redshift and MySQL/MariaDB.
 This can use \code{{.table}} to stand for the table name, and
 \code{{.schema}} to stand for the name of the schema which the table lives
 within. The default (\code{NULL}) is equivalent to \code{"{.table}"} when a single
@@ -38,11 +38,11 @@ where multiple schemas are given, and may change in future versions.}
 
 Additional parameters for the schema learning query.
 \itemize{
-\item \code{schema}: supported for MSSQL (default: \code{"dbo"}), Postgres (default: \code{"public"}), and MariaDB/MySQL
+\item \code{schema}: supported for MSSQL (default: \code{"dbo"}), Postgres/Redshift (default: \code{"public"}), and MariaDB/MySQL
 (default: current database). Learn the tables in a specific schema (or database for MariaDB/MySQL).
 \item \code{dbname}: supported for MSSQL. Access different databases on the connected MSSQL-server;
 default: active database.
-\item \code{table_type}: supported for Postgres (default: \code{"BASE TABLE"}). Specify the table type. Options are:
+\item \code{table_type}: supported for Postgres/Redshift (default: \code{"BASE TABLE"}). Specify the table type. Options are:
 \enumerate{
 \item \code{"BASE TABLE"} for a persistent table (normal table type)
 \item \code{"VIEW"} for a view
@@ -57,7 +57,7 @@ A \code{dm} object.
 \description{
 \code{dm_from_con()} creates a \link{dm} from some or all tables in a \link{src}
 (a database or an environment) or which are accessible via a DBI-Connection.
-For Postgres and SQL Server databases, primary and foreign keys
+For Postgres/Redshift and SQL Server databases, primary and foreign keys
 are imported from the database.
 }
 \examples{

--- a/man/dm_from_src.Rd
+++ b/man/dm_from_src.Rd
@@ -15,18 +15,18 @@ dm_from_src(src = NULL, table_names = NULL, learn_keys = NULL, ...)
 
 Set to \code{TRUE} to query the definition of primary and
 foreign keys from the database.
-Currently works only for Postgres and SQL Server databases.
+Currently works only for Postgres/Redshift and SQL Server databases.
 The default attempts to query and issues an informative message.}
 
 \item{...}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 
 Additional parameters for the schema learning query.
 \itemize{
-\item \code{schema}: supported for MSSQL (default: \code{"dbo"}), Postgres (default: \code{"public"}), and MariaDB/MySQL
+\item \code{schema}: supported for MSSQL (default: \code{"dbo"}), Postgres/Redshift (default: \code{"public"}), and MariaDB/MySQL
 (default: current database). Learn the tables in a specific schema (or database for MariaDB/MySQL).
 \item \code{dbname}: supported for MSSQL. Access different databases on the connected MSSQL-server;
 default: active database.
-\item \code{table_type}: supported for Postgres (default: \code{"BASE TABLE"}). Specify the table type. Options are:
+\item \code{table_type}: supported for Postgres/Redshift (default: \code{"BASE TABLE"}). Specify the table type. Options are:
 \enumerate{
 \item \code{"BASE TABLE"} for a persistent table (normal table type)
 \item \code{"VIEW"} for a view

--- a/scratch/info.R
+++ b/scratch/info.R
@@ -56,7 +56,7 @@ info_local <-
   collect()
 
 quote_fq_schema <- function(con, catalog, schema) {
-  if (is_postgres(con) || is_mssql(con)) {
+  if (is_postgres(con) || is_redshift(con) || is_mssql(con)) {
     catalog <- dbQuoteIdentifier(con, catalog)
     schema <- dbQuoteIdentifier(con, schema)
     paste0(catalog, ".", schema)


### PR DESCRIPTION
An attempt to add support for [Amazon Redshift](https://aws.amazon.com/redshift/) connections.

Redshift is based on Postgres - which is great, because {dm} already has excellent Postgres support :grin:

So for the most part, we can just borrow existing functionality.

---

There _are_ some differences between Redshift and Postgres - more detains in the [AWS docs](https://docs.aws.amazon.com/redshift/latest/dg/c_redshift-and-postgres-sql.html). One note in particular caught my eye:

> Unique, primary key, and foreign key constraints are permitted, but they are informational only. They are not enforced by the system, but they are used by the query planner. - https://docs.aws.amazon.com/redshift/latest/dg/c_unsupported-postgresql-features.html

I'm not sure if this has any impact on whether we can build a dm by learning the database keys.

I also tried, but failed, to write a Redshift-friendly version of `postgres_column_constraints` since Redshift doesn't support some of the syntax used there (e.g. `array_position()`). This affects `dm_meta_raw()` - for now I have added an implementation based on the final `else` clause.

---

Testing any Redshift functionality directly might be tricky, since it would require a Redshift warehouse in an AWS organisation - i.e. a lot of additional infrastructure (and cost?!). Would we be happy to rely on the fact that it's "nearly Postgres", and therefore mostly covered by Postgres testing? Or can we think of some way to test directly?

---

Requested indirectly in #1678.