### PR TITLE
chore: Drop crayon and mockr dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -67,7 +67,6 @@ Suggests:
     brio,
     colourpicker,
     covr,
-    crayon,
     DBI (>= 1.2.0),
     dbplyr (>= 2.3.4),
     DiagrammeR,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -83,7 +83,6 @@ Suggests:
     knitr,
     labelled (>= 2.12.0),
     magrittr,
-    mockr,
     nycflights13,
     odbc (>= 1.4.2),
     pillar,
@@ -99,7 +98,7 @@ Suggests:
     shiny,
     shinyAce,
     shinydashboard,
-    testthat (>= 3.1.2),
+    testthat (>= 3.2.0),
     waldo,
     withr
 Remotes: 

--- a/tests/testthat/helper-src.R
+++ b/tests/testthat/helper-src.R
@@ -62,7 +62,7 @@ my_test_src_name <- {
     src <- "df"
   }
   name <- gsub("^.*-", "", src)
-  inform(crayon::green(paste0("Testing on ", name)))
+  cli::cli_inform(cli::col_green("Testing on {name}"))
   name
 }
 

--- a/tests/testthat/test-db-interface.R
+++ b/tests/testthat/test-db-interface.R
@@ -52,8 +52,6 @@ test_that("copy_dm_to() fails with duplicate table names", {
 })
 
 test_that("default table repair works", {
-  skip_if_not_installed("mockr")
-
   con <- con_from_src_or_con(my_db_test_src())
 
   table_names <- c("t1", "t2", "t3")
@@ -65,16 +63,14 @@ test_that("default table repair works", {
     glue::glue("{table_name}_2020_05_15_10_45_29_0")
   }
 
-  mockr::with_mock(
-    unique_db_table_name = my_unique_db_table_name,
-    {
-      repair_table_names_for_db(table_names, temporary = FALSE, con)
-      expect_equal(calls, 0)
-      repair_table_names_for_db(table_names, temporary = TRUE, con)
-      expect_gt(calls, 0)
-    },
-    .env = asNamespace("dm")
+  local_mocked_bindings(
+    unique_db_table_name = function(table_name) my_unique_db_table_name(table_name)
   )
+  repair_table_names_for_db(table_names, temporary = FALSE, con)
+  expect_equal(calls, 0)
+  repair_table_names_for_db(table_names, temporary = TRUE, con)
+  expect_gt(calls, 0)
+
 })
 
 test_that("copy_dm_to() fails legibly if target schema missing for MSSQL & Postgres", {


### PR DESCRIPTION
Small PR to drop mockr in favour of `local_mocked_bindings()` and crayon in favour of cli.

relates to #365