### PR TITLE
fledge: CRAN release v1.0.10.9900

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dm
 Title: Relational Data Models
-Version: 1.0.10.9016
+Version: 1.0.10.9900
 Date: 2024-11-21
 Authors@R: 
     c(person(given = "Tobias",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,241 +1,78 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# dm 1.0.10.9016
+# dm 1.0.10.9900
 
 ## Chore
 
 - Ignore.
-
 - Fix creation of documentation in the RStudio IDE \[ci skip\].
-
-## Documentation
-
-- Use `index.md`.
-
-
-# dm 1.0.10.9015
-
-## Chore
-
 - Bump RMariaDB version (#2244).
+- Drop crayon and mockr dependencies (@olivroy, #2220).
+- Auto-update from GitHub Actions (#2231).
+- Auto-update from GitHub Actions.
+  Run: https://github.com/cynkra/dm/actions/runs/10395389155
+- Use dev RMariaDB.
+  Run: https://github.com/cynkra/dm/actions/runs/10223713876
+- Roxygenize.
+  Run: https://github.com/cynkra/dm/actions/runs/10200118253
+  Run: https://github.com/cynkra/dm/actions/runs/9727972354
+  Run: https://github.com/cynkra/dm/actions/runs/9692097886
+- Use CRAN dbplyr.
+- Update peter-evans/create-pull-request action to v6.
+- Update nick-fields/retry action to v3.
+- Update actions/cache action to v4 (#2186).
+
+- Use dev odbc and dbplyr to fix CI/CD (#2189).
+- Tweak Compose file.
+- Format NEWS.
 
 ## Continuous integration
 
 - Configure token.
-
 - Count rulesets to understand if branch protection is enabled.
-
 - Remove Aviator.
+- Use stable pak (#2239).
+- Trigger run (#2238).
+  - ci: Trigger run
+  - ci: Latest changes
+- Use pkgdown branch (#2237).
+- Install via R CMD INSTALL ., not pak (#2230).
+  - ci: Install via R CMD INSTALL ., not pak
+  - ci: Bump version of upload-artifact action
+- Install local package for pkgdown builds.
+- Improve support for protected branches with fledge.
+- Improve support for protected branches, without fledge.
+- Sync with latest developments.
+- Use v2 instead of master.
+- Inline action.
+- Use dev roxygen2 and decor.
+- Fix on Windows, tweak lock workflow.
+- Avoid checking bashisms on Windows.
+- Better commit message.
+- Harmonize workflows.
+- Use value after `source()`.
+- Bump versions, better default.
+- Recent updates.
+- Prepare for dynamic build matrix.
+
+## Documentation
+
+- Use `index.md`.
+- Tweak formatting (@salim-b, #2232).
+- Fix typo (@salim-b, #2218).
+- Set BS version explicitly for now.
+  https://github.com/cynkra/cynkratemplate/issues/53
 
 ## Testing
 
 - Fix compatibility with waldo \>= 0.6.0 (#2240).
-
-
-# dm 1.0.10.9014
-
-## Continuous integration
-
-  - Configure token.
-
-  - Count rulesets to understand if branch protection is enabled.
-
-  - Remove Aviator.
-
-## Testing
-
-  - Fix compatibility with waldo \>= 0.6.0 (#2240).
-    
-      - test: Fix compatibility with waldo \>= 0.6.0
-    
-      - chore: Auto-update from GitHub Actions
-    
-    Run: https://github.com/cynkra/dm/actions/runs/11885168927
-
-
-# dm 1.0.10.9013
-
-## Continuous integration
-
-  - Use stable pak (#2239).
-
-
-# dm 1.0.10.9012
-
-## Continuous integration
-
-  - Trigger run (#2238).
-    
-      - ci: Trigger run
-    
-      - ci: Latest changes
-
-
-# dm 1.0.10.9011
-
-## Chore
-
-  - Drop crayon and mockr dependencies (@olivroy, #2220).
-
-  - Auto-update from GitHub Actions (#2231).
-
-  - Auto-update from GitHub Actions.
-    
-    Run: https://github.com/cynkra/dm/actions/runs/10395389155
-
-  - Use dev RMariaDB.
-
-  - Auto-update from GitHub Actions.
-    
-    Run: https://github.com/cynkra/dm/actions/runs/10223713876
-
-  - Roxygenize.
-
-## Continuous integration
-
-  - Use pkgdown branch (#2237).
-
-  - Install via R CMD INSTALL ., not pak (#2230).
-    
-      - ci: Install via R CMD INSTALL ., not pak
-    
-      - ci: Bump version of upload-artifact action
-
-  - Install local package for pkgdown builds.
-
-  - Improve support for protected branches with fledge.
-
-  - Improve support for protected branches, without fledge.
-
-  - Sync with latest developments.
-
-  - Use v2 instead of master.
-
-  - Inline action.
-
-## Documentation
-
-  - Tweak formatting (@salim-b, #2232).
-
-  - Fix typo (@salim-b, #2218).
+  - test: Fix compatibility with waldo \>= 0.6.0
+  - chore: Auto-update from GitHub Actions
+  Run: https://github.com/cynkra/dm/actions/runs/11885168927
 
 ## Uncategorized
 
-  - Merge branch 'docs'.
-
-  - Merge branch 'docs'.
-
-
-# dm 1.0.10.9010
-
-## Chore
-
-- Auto-update from GitHub Actions.
-
-  Run: https://github.com/cynkra/dm/actions/runs/10200118253
-
-## Continuous integration
-
-- Use dev roxygen2 and decor.
-
-
-# dm 1.0.10.9009
-
-## Continuous integration
-
-- Fix on Windows, tweak lock workflow.
-
-
-# dm 1.0.10.9008
-
-## Chore
-
-- Auto-update from GitHub Actions.
-
-  Run: https://github.com/cynkra/dm/actions/runs/9727972354
-
-
-# dm 1.0.10.9007
-
-## Chore
-
-- Auto-update from GitHub Actions.
-
-  Run: https://github.com/cynkra/dm/actions/runs/9692097886
-
-## Continuous integration
-
-- Avoid checking bashisms on Windows.
-
-- Better commit message.
-
-- Harmonize workflows.
-
-- Use value after `source()`.
-
-- Bump versions, better default.
-
-- Recent updates.
-
-- Prepare for dynamic build matrix.
-
-
-# dm 1.0.10.9006
-
-## Documentation
-
-- Set BS version explicitly for now.
-
-  https://github.com/cynkra/cynkratemplate/issues/53
-
-
-# dm 1.0.10.9005
-
-## Chore
-
-- Use CRAN dbplyr.
-
-
-# dm 1.0.10.9004
-
-## Chore
-
-### deps
-
-- Update peter-evans/create-pull-request action to v6.
-
-
-# dm 1.0.10.9003
-
-## Chore
-
-### deps
-
-- Update nick-fields/retry action to v3.
-
-### deps
-
-- Update actions/cache action to v4 (#2186).
-
-- Use dev odbc and dbplyr to fix CI/CD (#2189).
-
-
-# dm 1.0.10.9002
-
-## Chore
-
-- Tweak Compose file.
-
-
-# dm 1.0.10.9001
-
-## Chore
-
-- Format NEWS.
-
-
-# dm 1.0.10.9000
-
+- Merge branch 'docs'.
 - Merge branch 'cran-1.0.10'.
 
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,11 +1,5 @@
-dm 1.0.10
+dm 1.0.10.9900
 
-## R CMD check results
+## Cran Repository Policy
 
-- [x] Checked locally, R 4.3.2
-- [x] Checked on CI system, R 4.3.2
-- [x] Checked on win-builder, R devel
-
-## Current CRAN check results
-
-- [x] Checked on 2024-01-21, no problems found.
+- [x] Reviewed CRP last edited 2024-08-27.


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2024-11-21, problems found: https://cran.r-project.org/web/checks/check_results_dm.html
- [ ] NOTE: r-devel-linux-x86_64-debian-clang, r-devel-linux-x86_64-debian-gcc, r-devel-windows-x86_64
     Found the following Rd file(s) with Rd \link{} targets missing package
     anchors:
     dm_examine_cardinalities.Rd: as_tibble
     dm_examine_constraints.Rd: as_tibble
     dm_from_con.Rd: src
     dm_zoom_to.Rd: nest_join
     json_nest.Rd: tidyr_tidy_select
     json_pack.Rd: tidyr_tidy_select
     Please provide package anchors for all Rd \link{} targets not in the
     package itself and the base packages.
- [ ] ERROR: r-devel-linux-x86_64-debian-clang
     Running ‘testthat.R’ [160s/86s]
     Running the tests in ‘tests/testthat.R’ failed.
     Complete output:
     > library(testthat)
     > 
     > # Need to use qualified call, this is checked in helper-print.R
     > testthat::test_check("dm")
     Loading required package: dm
     
     Attaching package: 'dm'
     
     The following object is masked from 'package:stats':
     
     filter
     
     Starting 2 test processes
     [ FAIL 1 | WARN 0 | SKIP 242 | PASS 1355 ]
     
     ══ Skipped tests (242) ═════════════════════════════════════════════════════════
     • COMPOUND (1): 'test-rows-dm.R:203:3'
     • Dependent on database version, find better way to record this info (1):
     'test-meta.R:19:3'
     • FIXME (2): 'test-learn.R:154:3', 'test-nest.R:2:3'
     • FIXME: Unstable on GHA? (1): 'test-dm.R:495:3'
     • Need to think about it (1): 'test-key-helpers.R:45:3'
     • On CRAN (191): 'test-zzx-deprecated.R:2:3', 'test-zzx-deprecated.R:15:3',
     'test-zzx-deprecated.R:25:3', 'test-zzx-deprecated.R:35:3',
     'test-zzx-deprecated.R:45:3', 'test-zzx-deprecated.R:58:3',
     'test-zzx-deprecated.R:81:3', 'test-zzx-deprecated.R:91:3',
     'test-zzx-deprecated.R:106:3', 'test-zzx-deprecated.R:121:3',
     'test-zzx-deprecated.R:141:3', 'test-zzx-deprecated.R:151:3',
     'test-zzx-deprecated.R:166:3', 'test-zzx-deprecated.R:185:3',
     'test-zzx-deprecated.R:221:3', 'test-zzx-deprecated.R:255:3',
     'test-zzx-deprecated.R:275:3', 'test-zzx-deprecated.R:291:3',
     'test-zzx-deprecated.R:326:3', 'test-zzx-deprecated.R:341:3',
     'test-zzx-deprecated.R:356:3', 'test-flatten.R:18:3', 'test-flatten.R:99:3',
     'test-dplyr.R:347:3', 'test-dplyr.R:506:3', 'test-dplyr.R:545:3',
     'test-dplyr.R:558:3', 'test-dplyr.R:569:3', 'test-dplyr.R:598:3',
     'test-dplyr.R:614:3', 'test-dplyr.R:806:3', 'test-draw-dm.R:17:3',
     'test-draw-dm.R:104:3', 'test-draw-dm.R:117:3', 'test-draw-dm.R:153:3',
     'test-draw-dm.R:182:3', 'test-filter-dm.R:62:3
- [ ] ERROR: r-devel-linux-x86_64-debian-gcc
     Running ‘testthat.R’ [116s/86s]
     Running the tests in ‘tests/testthat.R’ failed.
     Complete output:
     > library(testthat)
     > 
     > # Need to use qualified call, this is checked in helper-print.R
     > testthat::test_check("dm")
     Loading required package: dm
     
     Attaching package: 'dm'
     
     The following object is masked from 'package:stats':
     
     filter
     
     Starting 2 test processes
     [ FAIL 1 | WARN 0 | SKIP 242 | PASS 1355 ]
     
     ══ Skipped tests (242) ═════════════════════════════════════════════════════════
     • COMPOUND (1): 'test-rows-dm.R:203:3'
     • Dependent on database version, find better way to record this info (1):
     'test-meta.R:19:3'
     • FIXME (2): 'test-learn.R:154:3', 'test-nest.R:2:3'
     • FIXME: Unstable on GHA? (1): 'test-dm.R:495:3'
     • Need to think about it (1): 'test-key-helpers.R:45:3'
     • On CRAN (191): 'test-zzx-deprecated.R:2:3', 'test-zzx-deprecated.R:15:3',
     'test-zzx-deprecated.R:25:3', 'test-zzx-deprecated.R:35:3',
     'test-zzx-deprecated.R:45:3', 'test-zzx-deprecated.R:58:3',
     'test-zzx-deprecated.R:81:3', 'test-zzx-deprecated.R:91:3',
     'test-zzx-deprecated.R:106:3', 'test-zzx-deprecated.R:121:3',
     'test-zzx-deprecated.R:141:3', 'test-zzx-deprecated.R:151:3',
     'test-zzx-deprecated.R:166:3', 'test-zzx-deprecated.R:185:3',
     'test-zzx-deprecated.R:221:3', 'test-zzx-deprecated.R:255:3',
     'test-zzx-deprecated.R:275:3', 'test-zzx-deprecated.R:291:3',
     'test-zzx-deprecated.R:326:3', 'test-zzx-deprecated.R:341:3',
     'test-zzx-deprecated.R:356:3', 'test-flatten.R:18:3', 'test-flatten.R:99:3',
     'test-dplyr.R:347:3', 'test-dplyr.R:506:3', 'test-dplyr.R:545:3',
     'test-dplyr.R:558:3', 'test-dplyr.R:569:3', 'test-dplyr.R:598:3',
     'test-dplyr.R:614:3', 'test-dplyr.R:806:3', 'test-draw-dm.R:17:3',
     'test-draw-dm.R:104:3', 'test-draw-dm.R:117:3', 'test-draw-dm.R:153:3',
     'test-draw-dm.R:182:3', 'test-filter-dm.R:62:3
- [ ] ERROR: r-devel-linux-x86_64-fedora-clang
     Running ‘testthat.R’ [267s/144s]
     Running the tests in ‘tests/testthat.R’ failed.
     Complete output:
     > library(testthat)
     > 
     > # Need to use qualified call, this is checked in helper-print.R
     > testthat::test_check("dm")
     Loading required package: dm
     
     Attaching package: 'dm'
     
     The following object is masked from 'package:stats':
     
     filter
     
     Starting 2 test processes
     [ FAIL 1 | WARN 0 | SKIP 242 | PASS 1355 ]
     
     ══ Skipped tests (242) ═════════════════════════════════════════════════════════
     • COMPOUND (1): 'test-rows-dm.R:203:3'
     • Dependent on database version, find better way to record this info (1):
     'test-meta.R:19:3'
     • FIXME (2): 'test-learn.R:154:3', 'test-nest.R:2:3'
     • FIXME: Unstable on GHA? (1): 'test-dm.R:495:3'
     • Need to think about it (1): 'test-key-helpers.R:45:3'
     • On CRAN (191): 'test-zzx-deprecated.R:2:3', 'test-zzx-deprecated.R:15:3',
     'test-zzx-deprecated.R:25:3', 'test-zzx-deprecated.R:35:3',
     'test-zzx-deprecated.R:45:3', 'test-zzx-deprecated.R:58:3',
     'test-zzx-deprecated.R:81:3', 'test-zzx-deprecated.R:91:3',
     'test-zzx-deprecated.R:106:3', 'test-zzx-deprecated.R:121:3',
     'test-zzx-deprecated.R:141:3', 'test-zzx-deprecated.R:151:3',
     'test-zzx-deprecated.R:166:3', 'test-zzx-deprecated.R:185:3',
     'test-zzx-deprecated.R:221:3', 'test-zzx-deprecated.R:255:3',
     'test-zzx-deprecated.R:275:3', 'test-zzx-deprecated.R:291:3',
     'test-zzx-deprecated.R:326:3', 'test-zzx-deprecated.R:341:3',
     'test-zzx-deprecated.R:356:3', 'test-flatten.R:18:3', 'test-flatten.R:99:3',
     'test-dplyr.R:347:3', 'test-dplyr.R:506:3', 'test-dplyr.R:545:3',
     'test-dplyr.R:558:3', 'test-dplyr.R:569:3', 'test-dplyr.R:598:3',
     'test-dplyr.R:614:3', 'test-dplyr.R:806:3', 'test-draw-dm.R:17:3',
     'test-draw-dm.R:104:3', 'test-draw-dm.R:117:3', 'test-draw-dm.R:153:3',
     'test-draw-dm.R:182:3', 'test-filter-dm.R:62:
- [ ] ERROR: r-devel-linux-x86_64-fedora-gcc
     Running ‘testthat.R’ [169s/84s]
     Running the tests in ‘tests/testthat.R’ failed.
     Complete output:
     > library(testthat)
     > 
     > # Need to use qualified call, this is checked in helper-print.R
     > testthat::test_check("dm")
     Loading required package: dm
     
     Attaching package: 'dm'
     
     The following object is masked from 'package:stats':
     
     filter
     
     Starting 2 test processes
     [ FAIL 1 | WARN 0 | SKIP 242 | PASS 1355 ]
     
     ══ Skipped tests (242) ═════════════════════════════════════════════════════════
     • COMPOUND (1): 'test-rows-dm.R:203:3'
     • Dependent on database version, find better way to record this info (1):
     'test-meta.R:19:3'
     • FIXME (2): 'test-learn.R:154:3', 'test-nest.R:2:3'
     • FIXME: Unstable on GHA? (1): 'test-dm.R:495:3'
     • Need to think about it (1): 'test-key-helpers.R:45:3'
     • On CRAN (191): 'test-zzx-deprecated.R:2:3', 'test-zzx-deprecated.R:15:3',
     'test-zzx-deprecated.R:25:3', 'test-zzx-deprecated.R:35:3',
     'test-zzx-deprecated.R:45:3', 'test-zzx-deprecated.R:58:3',
     'test-zzx-deprecated.R:81:3', 'test-zzx-deprecated.R:91:3',
     'test-zzx-deprecated.R:106:3', 'test-zzx-deprecated.R:121:3',
     'test-zzx-deprecated.R:141:3', 'test-zzx-deprecated.R:151:3',
     'test-zzx-deprecated.R:166:3', 'test-zzx-deprecated.R:185:3',
     'test-zzx-deprecated.R:221:3', 'test-zzx-deprecated.R:255:3',
     'test-zzx-deprecated.R:275:3', 'test-zzx-deprecated.R:291:3',
     'test-zzx-deprecated.R:326:3', 'test-zzx-deprecated.R:341:3',
     'test-zzx-deprecated.R:356:3', 'test-flatten.R:18:3', 'test-flatten.R:99:3',
     'test-dplyr.R:347:3', 'test-dplyr.R:506:3', 'test-dplyr.R:545:3',
     'test-dplyr.R:558:3', 'test-dplyr.R:569:3', 'test-dplyr.R:598:3',
     'test-dplyr.R:614:3', 'test-dplyr.R:806:3', 'test-draw-dm.R:17:3',
     'test-draw-dm.R:104:3', 'test-draw-dm.R:117:3', 'test-draw-dm.R:153:3',
     'test-draw-dm.R:182:3', 'test-filter-dm.R:62:3
- [ ] ERROR: r-devel-windows-x86_64
     Running 'testthat.R' [66s]
     Running the tests in 'tests/testthat.R' failed.
     Complete output:
     > library(testthat)
     > 
     > # Need to use qualified call, this is checked in helper-print.R
     > testthat::test_check("dm")
     Loading required package: dm
     
     Attaching package: 'dm'
     
     The following object is masked from 'package:stats':
     
     filter
     
     Starting 2 test processes
     [ FAIL 1 | WARN 0 | SKIP 242 | PASS 1355 ]
     
     ══ Skipped tests (242) ═════════════════════════════════════════════════════════
     • COMPOUND (1): 'test-rows-dm.R:203:3'
     • Dependent on database version, find better way to record this info (1):
     'test-meta.R:19:3'
     • FIXME (2): 'test-learn.R:154:3', 'test-nest.R:2:3'
     • FIXME: Unstable on GHA? (1): 'test-dm.R:495:3'
     • Need to think about it (1): 'test-key-helpers.R:45:3'
     • On CRAN (191): 'test-zzx-deprecated.R:2:3', 'test-zzx-deprecated.R:15:3',
     'test-zzx-deprecated.R:25:3', 'test-zzx-deprecated.R:35:3',
     'test-zzx-deprecated.R:45:3', 'test-zzx-deprecated.R:58:3',
     'test-zzx-deprecated.R:81:3', 'test-zzx-deprecated.R:91:3',
     'test-zzx-deprecated.R:106:3', 'test-zzx-deprecated.R:121:3',
     'test-zzx-deprecated.R:141:3', 'test-zzx-deprecated.R:151:3',
     'test-zzx-deprecated.R:166:3', 'test-zzx-deprecated.R:185:3',
     'test-zzx-deprecated.R:221:3', 'test-zzx-deprecated.R:255:3',
     'test-zzx-deprecated.R:275:3', 'test-zzx-deprecated.R:291:3',
     'test-zzx-deprecated.R:326:3', 'test-zzx-deprecated.R:341:3',
     'test-zzx-deprecated.R:356:3', 'test-flatten.R:18:3', 'test-flatten.R:99:3',
     'test-dplyr.R:347:3', 'test-dplyr.R:506:3', 'test-dplyr.R:545:3',
     'test-dplyr.R:558:3', 'test-dplyr.R:569:3', 'test-dplyr.R:598:3',
     'test-dplyr.R:614:3', 'test-dplyr.R:806:3', 'test-draw-dm.R:17:3',
     'test-draw-dm.R:104:3', 'test-draw-dm.R:117:3', 'test-draw-dm.R:153:3',
     'test-draw-dm.R:182:3', 'test-filter-dm.R:62:3', 't
- [ ] ERROR: r-patched-linux-x86_64
     Running ‘testthat.R’ [146s/76s]
     Running the tests in ‘tests/testthat.R’ failed.
     Complete output:
     > library(testthat)
     > 
     > # Need to use qualified call, this is checked in helper-print.R
     > testthat::test_check("dm")
     Loading required package: dm
     
     Attaching package: 'dm'
     
     The following object is masked from 'package:stats':
     
     filter
     
     Starting 2 test processes
     [ FAIL 1 | WARN 0 | SKIP 242 | PASS 1355 ]
     
     ══ Skipped tests (242) ═════════════════════════════════════════════════════════
     • COMPOUND (1): 'test-rows-dm.R:203:3'
     • Dependent on database version, find better way to record this info (1):
     'test-meta.R:19:3'
     • FIXME (2): 'test-learn.R:154:3', 'test-nest.R:2:3'
     • FIXME: Unstable on GHA? (1): 'test-dm.R:495:3'
     • Need to think about it (1): 'test-key-helpers.R:45:3'
     • On CRAN (191): 'test-zzx-deprecated.R:2:3', 'test-zzx-deprecated.R:15:3',
     'test-zzx-deprecated.R:25:3', 'test-zzx-deprecated.R:35:3',
     'test-zzx-deprecated.R:45:3', 'test-zzx-deprecated.R:58:3',
     'test-zzx-deprecated.R:81:3', 'test-zzx-deprecated.R:91:3',
     'test-zzx-deprecated.R:106:3', 'test-zzx-deprecated.R:121:3',
     'test-zzx-deprecated.R:141:3', 'test-zzx-deprecated.R:151:3',
     'test-zzx-deprecated.R:166:3', 'test-zzx-deprecated.R:185:3',
     'test-zzx-deprecated.R:221:3', 'test-zzx-deprecated.R:255:3',
     'test-zzx-deprecated.R:275:3', 'test-zzx-deprecated.R:291:3',
     'test-zzx-deprecated.R:326:3', 'test-zzx-deprecated.R:341:3',
     'test-zzx-deprecated.R:356:3', 'test-flatten.R:18:3', 'test-flatten.R:99:3',
     'test-dplyr.R:347:3', 'test-dplyr.R:506:3', 'test-dplyr.R:545:3',
     'test-dplyr.R:558:3', 'test-dplyr.R:569:3', 'test-dplyr.R:598:3',
     'test-dplyr.R:614:3', 'test-dplyr.R:806:3', 'test-draw-dm.R:17:3',
     'test-draw-dm.R:104:3', 'test-draw-dm.R:117:3', 'test-draw-dm.R:153:3',
     'test-draw-dm.R:182:3', 'test-filter-dm.R:62:3
- [ ] ERROR: r-release-linux-x86_64
     Running ‘testthat.R’ [153s/82s]
     Running the tests in ‘tests/testthat.R’ failed.
     Complete output:
     > library(testthat)
     > 
     > # Need to use qualified call, this is checked in helper-print.R
     > testthat::test_check("dm")
     Loading required package: dm
     
     Attaching package: 'dm'
     
     The following object is masked from 'package:stats':
     
     filter
     
     Starting 2 test processes
     [ FAIL 1 | WARN 0 | SKIP 242 | PASS 1355 ]
     
     ══ Skipped tests (242) ═════════════════════════════════════════════════════════
     • COMPOUND (1): 'test-rows-dm.R:203:3'
     • Dependent on database version, find better way to record this info (1):
     'test-meta.R:19:3'
     • FIXME (2): 'test-learn.R:154:3', 'test-nest.R:2:3'
     • FIXME: Unstable on GHA? (1): 'test-dm.R:495:3'
     • Need to think about it (1): 'test-key-helpers.R:45:3'
     • On CRAN (191): 'test-zzx-deprecated.R:2:3', 'test-zzx-deprecated.R:15:3',
     'test-zzx-deprecated.R:25:3', 'test-zzx-deprecated.R:35:3',
     'test-zzx-deprecated.R:45:3', 'test-zzx-deprecated.R:58:3',
     'test-zzx-deprecated.R:81:3', 'test-zzx-deprecated.R:91:3',
     'test-zzx-deprecated.R:106:3', 'test-zzx-deprecated.R:121:3',
     'test-zzx-deprecated.R:141:3', 'test-zzx-deprecated.R:151:3',
     'test-zzx-deprecated.R:166:3', 'test-zzx-deprecated.R:185:3',
     'test-zzx-deprecated.R:221:3', 'test-zzx-deprecated.R:255:3',
     'test-zzx-deprecated.R:275:3', 'test-zzx-deprecated.R:291:3',
     'test-zzx-deprecated.R:326:3', 'test-zzx-deprecated.R:341:3',
     'test-zzx-deprecated.R:356:3', 'test-flatten.R:18:3', 'test-flatten.R:99:3',
     'test-dplyr.R:347:3', 'test-dplyr.R:506:3', 'test-dplyr.R:545:3',
     'test-dplyr.R:558:3', 'test-dplyr.R:569:3', 'test-dplyr.R:598:3',
     'test-dplyr.R:614:3', 'test-dplyr.R:806:3', 'test-draw-dm.R:17:3',
     'test-draw-dm.R:104:3', 'test-draw-dm.R:117:3', 'test-draw-dm.R:153:3',
     'test-draw-dm.R:182:3', 'test-filter-dm.R:62:3
- [ ] ERROR: r-release-windows-x86_64
     Running 'testthat.R' [67s]
     Running the tests in 'tests/testthat.R' failed.
     Complete output:
     > library(testthat)
     > 
     > # Need to use qualified call, this is checked in helper-print.R
     > testthat::test_check("dm")
     Loading required package: dm
     
     Attaching package: 'dm'
     
     The following object is masked from 'package:stats':
     
     filter
     
     Starting 2 test processes
     [ FAIL 1 | WARN 0 | SKIP 242 | PASS 1355 ]
     
     ══ Skipped tests (242) ═════════════════════════════════════════════════════════
     • COMPOUND (1): 'test-rows-dm.R:203:3'
     • Dependent on database version, find better way to record this info (1):
     'test-meta.R:19:3'
     • FIXME (2): 'test-learn.R:154:3', 'test-nest.R:2:3'
     • FIXME: Unstable on GHA? (1): 'test-dm.R:495:3'
     • Need to think about it (1): 'test-key-helpers.R:45:3'
     • On CRAN (191): 'test-zzx-deprecated.R:2:3', 'test-zzx-deprecated.R:15:3',
     'test-zzx-deprecated.R:25:3', 'test-zzx-deprecated.R:35:3',
     'test-zzx-deprecated.R:45:3', 'test-zzx-deprecated.R:58:3',
     'test-zzx-deprecated.R:81:3', 'test-zzx-deprecated.R:91:3',
     'test-zzx-deprecated.R:106:3', 'test-zzx-deprecated.R:121:3',
     'test-zzx-deprecated.R:141:3', 'test-zzx-deprecated.R:151:3',
     'test-zzx-deprecated.R:166:3', 'test-zzx-deprecated.R:185:3',
     'test-zzx-deprecated.R:221:3', 'test-zzx-deprecated.R:255:3',
     'test-zzx-deprecated.R:275:3', 'test-zzx-deprecated.R:291:3',
     'test-zzx-deprecated.R:326:3', 'test-zzx-deprecated.R:341:3',
     'test-zzx-deprecated.R:356:3', 'test-flatten.R:18:3', 'test-flatten.R:99:3',
     'test-dplyr.R:347:3', 'test-dplyr.R:506:3', 'test-dplyr.R:545:3',
     'test-dplyr.R:558:3', 'test-dplyr.R:569:3', 'test-dplyr.R:598:3',
     'test-dplyr.R:614:3', 'test-dplyr.R:806:3', 'test-draw-dm.R:17:3',
     'test-draw-dm.R:104:3', 'test-draw-dm.R:117:3', 'test-draw-dm.R:153:3',
     'test-draw-dm.R:182:3', 'test-filter-dm.R:62:3', 't
- [ ] ERROR: r-oldrel-windows-x86_64
     Running 'testthat.R' [97s]
     Running the tests in 'tests/testthat.R' failed.
     Complete output:
     > library(testthat)
     > 
     > # Need to use qualified call, this is checked in helper-print.R
     > testthat::test_check("dm")
     Loading required package: dm
     
     Attaching package: 'dm'
     
     The following object is masked from 'package:stats':
     
     filter
     
     Starting 2 test processes
     [ FAIL 1 | WARN 0 | SKIP 242 | PASS 1355 ]
     
     ══ Skipped tests (242) ═════════════════════════════════════════════════════════
     • COMPOUND (1): 'test-rows-dm.R:203:3'
     • Dependent on database version, find better way to record this info (1):
     'test-meta.R:19:3'
     • FIXME (2): 'test-learn.R:154:3', 'test-nest.R:2:3'
     • FIXME: Unstable on GHA? (1): 'test-dm.R:495:3'
     • Need to think about it (1): 'test-key-helpers.R:45:3'
     • On CRAN (191): 'test-zzx-deprecated.R:2:3', 'test-zzx-deprecated.R:15:3',
     'test-zzx-deprecated.R:25:3', 'test-zzx-deprecated.R:35:3',
     'test-zzx-deprecated.R:45:3', 'test-zzx-deprecated.R:58:3',
     'test-zzx-deprecated.R:81:3', 'test-zzx-deprecated.R:91:3',
     'test-zzx-deprecated.R:106:3', 'test-zzx-deprecated.R:121:3',
     'test-zzx-deprecated.R:141:3', 'test-zzx-deprecated.R:151:3',
     'test-zzx-deprecated.R:166:3', 'test-zzx-deprecated.R:185:3',
     'test-zzx-deprecated.R:221:3', 'test-zzx-deprecated.R:255:3',
     'test-zzx-deprecated.R:275:3', 'test-zzx-deprecated.R:291:3',
     'test-zzx-deprecated.R:326:3', 'test-zzx-deprecated.R:341:3',
     'test-zzx-deprecated.R:356:3', 'test-flatten.R:18:3', 'test-flatten.R:99:3',
     'test-dplyr.R:347:3', 'test-dplyr.R:506:3', 'test-dplyr.R:545:3',
     'test-dplyr.R:558:3', 'test-dplyr.R:569:3', 'test-dplyr.R:598:3',
     'test-dplyr.R:614:3', 'test-dplyr.R:806:3', 'test-draw-dm.R:17:3',
     'test-draw-dm.R:104:3', 'test-draw-dm.R:117:3', 'test-draw-dm.R:153:3',
     'test-draw-dm.R:182:3', 'test-filter-dm.R:62:3', 't

Check results at: https://cran.r-project.org/web/checks/check_results_dm.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`