### PR TITLE
fledge: CRAN release v1.0.11

### DIFF
--- a/.github/workflows/R-CMD-check-status.yaml
+++ b/.github/workflows/R-CMD-check-status.yaml
@@ -12,7 +12,7 @@ name: rcc-status
 
 jobs:
   rcc-status:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     name: "Update commit status"
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -43,7 +43,7 @@ name: rcc
 
 jobs:
   rcc-smoke:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       sha: ${{ steps.commit.outputs.sha }}
       versions-matrix: ${{ steps.versions-matrix.outputs.matrix }}
@@ -106,7 +106,7 @@ jobs:
           cache-version: rcc-smoke-2
           needs: check, website
           # Beware of using dev pkgdown here, has brought in dev dependencies in the past
-          extra-packages: any::rcmdcheck r-lib/roxygen2 any::decor r-lib/styler r-lib/pkgdown deps::.
+          extra-packages: any::rcmdcheck r-lib/roxygen2 any::decor r-lib/styler#1235 r-lib/pkgdown deps::.
 
       - name: Install package
         run: |
@@ -205,7 +205,7 @@ jobs:
         shell: bash
 
   rcc-smoke-check-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     name: "Check matrix"
 

--- a/.github/workflows/custom/before-install/action.yml
+++ b/.github/workflows/custom/before-install/action.yml
@@ -3,30 +3,10 @@ name: 'Custom steps to run before R packages are installed'
 runs:
   using: "composite"
   steps:
-    - name: Define R CMD check error condition
-      # Rscript not available on Mac
-      if: runner.os != 'macOS'
-      run: |
-        if (getRversion() < "4.0") {
-          message("Setting RCMDCHECK_ERROR_ON")
-          cat('RCMDCHECK_ERROR_ON="warning"\n', file = Sys.getenv("GITHUB_ENV"), append = TRUE)
-        }
-      shell: Rscript {0}
-
     - name: Define _R_CHECK_PKG_SIZES_THRESHOLD_
       run: |
         echo '_R_CHECK_PKG_SIZES_THRESHOLD_=10' | tee -a $GITHUB_ENV
       shell: bash
-
-    - name: Define _R_CHECK_FORCE_SUGGESTS_
-      # Rscript not available on Mac
-      if: runner.os != 'macOS'
-      run: |
-        if (getRversion() < "4.0") {
-          message("Setting _R_CHECK_FORCE_SUGGESTS_")
-          cat('_R_CHECK_FORCE_SUGGESTS_=false\n', file = Sys.getenv("GITHUB_ENV"), append = TRUE)
-        }
-      shell: Rscript {0}
 
     - name: Define DM_TEST_SRC
       run: |

--- a/.github/workflows/fledge.yaml
+++ b/.github/workflows/fledge.yaml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   check_fork:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       is_forked: ${{ steps.check.outputs.is_forked }}
     steps:
@@ -33,7 +33,7 @@ jobs:
         shell: bash
 
   fledge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: check_fork
     if: needs.check_fork.outputs.is_forked == 'false'
     permissions:
@@ -107,7 +107,7 @@ jobs:
           set -x
           gh pr create --base main --head fledge --fill-first
           gh workflow run rcc -f ref=$(git rev-parse HEAD)
-          gh pr merge --merge --auto
+          gh pr merge --squash --auto
         shell: bash
 
       - name: Check release

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -75,6 +75,12 @@ runs:
         echo "_R_CHECK_CRAN_INCOMING_USE_ASPELL_=true" | tee -a $GITHUB_ENV
       shell: bash
 
+    - name: Remove pkg-config@0.29.2
+      if: runner.os == 'macOS'
+      run: |
+        brew uninstall pkg-config@0.29.2
+      shell: bash
+
     - uses: r-lib/actions/setup-pandoc@v2
 
     - uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   lock:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: dessant/lock-threads@v5
         with:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   pkgdown:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     name: "pkgdown"
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dm
 Title: Relational Data Models
-Version: 1.0.10.9901
+Version: 1.0.11
 Date: 2024-11-24
 Authors@R: 
     c(person(given = "Tobias",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,25 +1,20 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# dm 1.0.10.9901
+# dm 1.0.11
 
 ## Features
 
-- Add support for Redshift connections (@owenjonesuob, #2215).
-
-
-# dm 1.0.10.9900
+- Add support for Redshift connections (@owenjonesuob, \#2215).
 
 ## Chore
 
-- Drop crayon and mockr dependencies (@olivroy, #2220).
+- Drop crayon and mockr dependencies (@olivroy, \#2220).
 
 ## Documentation
 
 - Use `index.md`.
-
-- Tweak formatting (@salim-b, #2232).
-
-- Fix typo (@salim-b, #2218).
+- Tweak formatting (@salim-b, \#2232).
+- Fix typo (@salim-b, \#2218).
 
 ## Testing
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,17 +4,19 @@
 
 ## Features
 
-- Add support for Redshift connections (@owenjonesuob, \#2215).
+- Add support for Redshift connections (@owenjonesuob, #2215).
 
 ## Chore
 
-- Drop crayon and mockr dependencies (@olivroy, \#2220).
+- Drop crayon and mockr dependencies (@olivroy, #2220).
 
 ## Documentation
 
 - Use `index.md`.
-- Tweak formatting (@salim-b, \#2232).
-- Fix typo (@salim-b, \#2218).
+
+- Tweak formatting (@salim-b, #2232).
+
+- Fix typo (@salim-b, #2218).
 
 ## Testing
 

--- a/R/db-helpers.R
+++ b/R/db-helpers.R
@@ -154,7 +154,7 @@ get_src_tbl_names <- function(src, schema = NULL, dbname = NULL, names = NULL) {
     schema <- schema_postgres(con, schema)
     dbname <- warn_if_arg_not(dbname, only_on = "MSSQL")
     names_table <- get_names_table_postgres(con)
-  }  else if (is_redshift(src)) {
+  } else if (is_redshift(src)) {
     # Redshift
     schema <- schema_redshift(con, schema)
     dbname <- warn_if_arg_not(dbname, only_on = "MSSQL")

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-dm 1.0.10.9900
+dm 1.0.11
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2024-11-24, problems found: https://cran.r-project.org/web/checks/check_results_dm.html
- [ ] NOTE: r-devel-linux-x86_64-debian-clang, r-devel-linux-x86_64-debian-gcc, r-devel-windows-x86_64
     Found the following Rd file(s) with Rd \link{} targets missing package
     anchors:
     dm_examine_cardinalities.Rd: as_tibble
     dm_examine_constraints.Rd: as_tibble
     dm_from_con.Rd: src
     dm_zoom_to.Rd: nest_join
     json_nest.Rd: tidyr_tidy_select
     json_pack.Rd: tidyr_tidy_select
     Please provide package anchors for all Rd \link{} targets not in the
     package itself and the base packages.
- [ ] ERROR: r-devel-linux-x86_64-debian-clang
     Running ‘testthat.R’ [154s/81s]
     Running the tests in ‘tests/testthat.R’ failed.
     Complete output:
     > library(testthat)
     > 
     > # Need to use qualified call, this is checked in helper-print.R
     > testthat::test_check("dm")
     Loading required package: dm
     
     Attaching package: 'dm'
     
     The following object is masked from 'package:stats':
     
     filter
     
     Starting 2 test processes
     [ FAIL 1 | WARN 0 | SKIP 242 | PASS 1355 ]
     
     ══ Skipped tests (242) ═════════════════════════════════════════════════════════
     • COMPOUND (1): 'test-rows-dm.R:203:3'
     • Dependent on database version, find better way to record this info (1):
     'test-meta.R:19:3'
     • FIXME (2): 'test-learn.R:154:3', 'test-nest.R:2:3'
     • FIXME: Unstable on GHA? (1): 'test-dm.R:495:3'
     • Need to think about it (1): 'test-key-helpers.R:45:3'
     • On CRAN (191): 'test-zzx-deprecated.R:2:3', 'test-zzx-deprecated.R:15:3',
     'test-zzx-deprecated.R:25:3', 'test-zzx-deprecated.R:35:3',
     'test-zzx-deprecated.R:45:3', 'test-zzx-deprecated.R:58:3',
     'test-zzx-deprecated.R:81:3', 'test-zzx-deprecated.R:91:3',
     'test-zzx-deprecated.R:106:3', 'test-zzx-deprecated.R:121:3',
     'test-zzx-deprecated.R:141:3', 'test-zzx-deprecated.R:151:3',
     'test-zzx-deprecated.R:166:3', 'test-zzx-deprecated.R:185:3',
     'test-zzx-deprecated.R:221:3', 'test-zzx-deprecated.R:255:3',
     'test-zzx-deprecated.R:275:3', 'test-zzx-deprecated.R:291:3',
     'test-zzx-deprecated.R:326:3', 'test-zzx-deprecated.R:341:3',
     'test-zzx-deprecated.R:356:3', 'test-flatten.R:18:3', 'test-flatten.R:99:3',
     'test-dplyr.R:347:3', 'test-dplyr.R:506:3', 'test-dplyr.R:545:3',
     'test-dplyr.R:558:3', 'test-dplyr.R:569:3', 'test-dplyr.R:598:3',
     'test-dplyr.R:614:3', 'test-dplyr.R:806:3', 'test-draw-dm.R:17:3',
     'test-draw-dm.R:104:3', 'test-draw-dm.R:117:3', 'test-draw-dm.R:153:3',
     'test-draw-dm.R:182:3', 'test-filter-dm.R:62:3
- [ ] ERROR: r-devel-linux-x86_64-debian-gcc
     Running ‘testthat.R’ [114s/89s]
     Running the tests in ‘tests/testthat.R’ failed.
     Complete output:
     > library(testthat)
     > 
     > # Need to use qualified call, this is checked in helper-print.R
     > testthat::test_check("dm")
     Loading required package: dm
     
     Attaching package: 'dm'
     
     The following object is masked from 'package:stats':
     
     filter
     
     Starting 2 test processes
     [ FAIL 1 | WARN 0 | SKIP 242 | PASS 1355 ]
     
     ══ Skipped tests (242) ═════════════════════════════════════════════════════════
     • COMPOUND (1): 'test-rows-dm.R:203:3'
     • Dependent on database version, find better way to record this info (1):
     'test-meta.R:19:3'
     • FIXME (2): 'test-learn.R:154:3', 'test-nest.R:2:3'
     • FIXME: Unstable on GHA? (1): 'test-dm.R:495:3'
     • Need to think about it (1): 'test-key-helpers.R:45:3'
     • On CRAN (191): 'test-zzx-deprecated.R:2:3', 'test-zzx-deprecated.R:15:3',
     'test-zzx-deprecated.R:25:3', 'test-zzx-deprecated.R:35:3',
     'test-zzx-deprecated.R:45:3', 'test-zzx-deprecated.R:58:3',
     'test-zzx-deprecated.R:81:3', 'test-zzx-deprecated.R:91:3',
     'test-zzx-deprecated.R:106:3', 'test-zzx-deprecated.R:121:3',
     'test-zzx-deprecated.R:141:3', 'test-zzx-deprecated.R:151:3',
     'test-zzx-deprecated.R:166:3', 'test-zzx-deprecated.R:185:3',
     'test-zzx-deprecated.R:221:3', 'test-zzx-deprecated.R:255:3',
     'test-zzx-deprecated.R:275:3', 'test-zzx-deprecated.R:291:3',
     'test-zzx-deprecated.R:326:3', 'test-zzx-deprecated.R:341:3',
     'test-zzx-deprecated.R:356:3', 'test-flatten.R:18:3', 'test-flatten.R:99:3',
     'test-dplyr.R:347:3', 'test-dplyr.R:506:3', 'test-dplyr.R:545:3',
     'test-dplyr.R:558:3', 'test-dplyr.R:569:3', 'test-dplyr.R:598:3',
     'test-dplyr.R:614:3', 'test-dplyr.R:806:3', 'test-draw-dm.R:17:3',
     'test-draw-dm.R:104:3', 'test-draw-dm.R:117:3', 'test-draw-dm.R:153:3',
     'test-draw-dm.R:182:3', 'test-filter-dm.R:62:3
- [ ] ERROR: r-devel-linux-x86_64-fedora-clang
     Running ‘testthat.R’ [267s/144s]
     Running the tests in ‘tests/testthat.R’ failed.
     Complete output:
     > library(testthat)
     > 
     > # Need to use qualified call, this is checked in helper-print.R
     > testthat::test_check("dm")
     Loading required package: dm
     
     Attaching package: 'dm'
     
     The following object is masked from 'package:stats':
     
     filter
     
     Starting 2 test processes
     [ FAIL 1 | WARN 0 | SKIP 242 | PASS 1355 ]
     
     ══ Skipped tests (242) ═════════════════════════════════════════════════════════
     • COMPOUND (1): 'test-rows-dm.R:203:3'
     • Dependent on database version, find better way to record this info (1):
     'test-meta.R:19:3'
     • FIXME (2): 'test-learn.R:154:3', 'test-nest.R:2:3'
     • FIXME: Unstable on GHA? (1): 'test-dm.R:495:3'
     • Need to think about it (1): 'test-key-helpers.R:45:3'
     • On CRAN (191): 'test-zzx-deprecated.R:2:3', 'test-zzx-deprecated.R:15:3',
     'test-zzx-deprecated.R:25:3', 'test-zzx-deprecated.R:35:3',
     'test-zzx-deprecated.R:45:3', 'test-zzx-deprecated.R:58:3',
     'test-zzx-deprecated.R:81:3', 'test-zzx-deprecated.R:91:3',
     'test-zzx-deprecated.R:106:3', 'test-zzx-deprecated.R:121:3',
     'test-zzx-deprecated.R:141:3', 'test-zzx-deprecated.R:151:3',
     'test-zzx-deprecated.R:166:3', 'test-zzx-deprecated.R:185:3',
     'test-zzx-deprecated.R:221:3', 'test-zzx-deprecated.R:255:3',
     'test-zzx-deprecated.R:275:3', 'test-zzx-deprecated.R:291:3',
     'test-zzx-deprecated.R:326:3', 'test-zzx-deprecated.R:341:3',
     'test-zzx-deprecated.R:356:3', 'test-flatten.R:18:3', 'test-flatten.R:99:3',
     'test-dplyr.R:347:3', 'test-dplyr.R:506:3', 'test-dplyr.R:545:3',
     'test-dplyr.R:558:3', 'test-dplyr.R:569:3', 'test-dplyr.R:598:3',
     'test-dplyr.R:614:3', 'test-dplyr.R:806:3', 'test-draw-dm.R:17:3',
     'test-draw-dm.R:104:3', 'test-draw-dm.R:117:3', 'test-draw-dm.R:153:3',
     'test-draw-dm.R:182:3', 'test-filter-dm.R:62:
- [ ] ERROR: r-devel-linux-x86_64-fedora-gcc
     Running ‘testthat.R’ [261s/149s]
     Running the tests in ‘tests/testthat.R’ failed.
     Complete output:
     > library(testthat)
     > 
     > # Need to use qualified call, this is checked in helper-print.R
     > testthat::test_check("dm")
     Loading required package: dm
     
     Attaching package: 'dm'
     
     The following object is masked from 'package:stats':
     
     filter
     
     Starting 2 test processes
     [ FAIL 1 | WARN 0 | SKIP 242 | PASS 1355 ]
     
     ══ Skipped tests (242) ═════════════════════════════════════════════════════════
     • COMPOUND (1): 'test-rows-dm.R:203:3'
     • Dependent on database version, find better way to record this info (1):
     'test-meta.R:19:3'
     • FIXME (2): 'test-learn.R:154:3', 'test-nest.R:2:3'
     • FIXME: Unstable on GHA? (1): 'test-dm.R:495:3'
     • Need to think about it (1): 'test-key-helpers.R:45:3'
     • On CRAN (191): 'test-zzx-deprecated.R:2:3', 'test-zzx-deprecated.R:15:3',
     'test-zzx-deprecated.R:25:3', 'test-zzx-deprecated.R:35:3',
     'test-zzx-deprecated.R:45:3', 'test-zzx-deprecated.R:58:3',
     'test-zzx-deprecated.R:81:3', 'test-zzx-deprecated.R:91:3',
     'test-zzx-deprecated.R:106:3', 'test-zzx-deprecated.R:121:3',
     'test-zzx-deprecated.R:141:3', 'test-zzx-deprecated.R:151:3',
     'test-zzx-deprecated.R:166:3', 'test-zzx-deprecated.R:185:3',
     'test-zzx-deprecated.R:221:3', 'test-zzx-deprecated.R:255:3',
     'test-zzx-deprecated.R:275:3', 'test-zzx-deprecated.R:291:3',
     'test-zzx-deprecated.R:326:3', 'test-zzx-deprecated.R:341:3',
     'test-zzx-deprecated.R:356:3', 'test-flatten.R:18:3', 'test-flatten.R:99:3',
     'test-dplyr.R:347:3', 'test-dplyr.R:506:3', 'test-dplyr.R:545:3',
     'test-dplyr.R:558:3', 'test-dplyr.R:569:3', 'test-dplyr.R:598:3',
     'test-dplyr.R:614:3', 'test-dplyr.R:806:3', 'test-draw-dm.R:17:3',
     'test-draw-dm.R:104:3', 'test-draw-dm.R:117:3', 'test-draw-dm.R:153:3',
     'test-draw-dm.R:182:3', 'test-filter-dm.R:62:
- [ ] ERROR: r-devel-windows-x86_64
     Running 'testthat.R' [67s]
     Running the tests in 'tests/testthat.R' failed.
     Complete output:
     > library(testthat)
     > 
     > # Need to use qualified call, this is checked in helper-print.R
     > testthat::test_check("dm")
     Loading required package: dm
     
     Attaching package: 'dm'
     
     The following object is masked from 'package:stats':
     
     filter
     
     Starting 2 test processes
     [ FAIL 1 | WARN 0 | SKIP 242 | PASS 1355 ]
     
     ══ Skipped tests (242) ═════════════════════════════════════════════════════════
     • COMPOUND (1): 'test-rows-dm.R:203:3'
     • Dependent on database version, find better way to record this info (1):
     'test-meta.R:19:3'
     • FIXME (2): 'test-learn.R:154:3', 'test-nest.R:2:3'
     • FIXME: Unstable on GHA? (1): 'test-dm.R:495:3'
     • Need to think about it (1): 'test-key-helpers.R:45:3'
     • On CRAN (191): 'test-zzx-deprecated.R:2:3', 'test-zzx-deprecated.R:15:3',
     'test-zzx-deprecated.R:25:3', 'test-zzx-deprecated.R:35:3',
     'test-zzx-deprecated.R:45:3', 'test-zzx-deprecated.R:58:3',
     'test-zzx-deprecated.R:81:3', 'test-zzx-deprecated.R:91:3',
     'test-zzx-deprecated.R:106:3', 'test-zzx-deprecated.R:121:3',
     'test-zzx-deprecated.R:141:3', 'test-zzx-deprecated.R:151:3',
     'test-zzx-deprecated.R:166:3', 'test-zzx-deprecated.R:185:3',
     'test-zzx-deprecated.R:221:3', 'test-zzx-deprecated.R:255:3',
     'test-zzx-deprecated.R:275:3', 'test-zzx-deprecated.R:291:3',
     'test-zzx-deprecated.R:326:3', 'test-zzx-deprecated.R:341:3',
     'test-zzx-deprecated.R:356:3', 'test-flatten.R:18:3', 'test-flatten.R:99:3',
     'test-dplyr.R:347:3', 'test-dplyr.R:506:3', 'test-dplyr.R:545:3',
     'test-dplyr.R:558:3', 'test-dplyr.R:569:3', 'test-dplyr.R:598:3',
     'test-dplyr.R:614:3', 'test-dplyr.R:806:3', 'test-draw-dm.R:17:3',
     'test-draw-dm.R:104:3', 'test-draw-dm.R:117:3', 'test-draw-dm.R:153:3',
     'test-draw-dm.R:182:3', 'test-filter-dm.R:62:3', 't
- [ ] ERROR: r-patched-linux-x86_64
     Running ‘testthat.R’ [150s/79s]
     Running the tests in ‘tests/testthat.R’ failed.
     Complete output:
     > library(testthat)
     > 
     > # Need to use qualified call, this is checked in helper-print.R
     > testthat::test_check("dm")
     Loading required package: dm
     
     Attaching package: 'dm'
     
     The following object is masked from 'package:stats':
     
     filter
     
     Starting 2 test processes
     [ FAIL 1 | WARN 0 | SKIP 242 | PASS 1355 ]
     
     ══ Skipped tests (242) ═════════════════════════════════════════════════════════
     • COMPOUND (1): 'test-rows-dm.R:203:3'
     • Dependent on database version, find better way to record this info (1):
     'test-meta.R:19:3'
     • FIXME (2): 'test-learn.R:154:3', 'test-nest.R:2:3'
     • FIXME: Unstable on GHA? (1): 'test-dm.R:495:3'
     • Need to think about it (1): 'test-key-helpers.R:45:3'
     • On CRAN (191): 'test-zzx-deprecated.R:2:3', 'test-zzx-deprecated.R:15:3',
     'test-zzx-deprecated.R:25:3', 'test-zzx-deprecated.R:35:3',
     'test-zzx-deprecated.R:45:3', 'test-zzx-deprecated.R:58:3',
     'test-zzx-deprecated.R:81:3', 'test-zzx-deprecated.R:91:3',
     'test-zzx-deprecated.R:106:3', 'test-zzx-deprecated.R:121:3',
     'test-zzx-deprecated.R:141:3', 'test-zzx-deprecated.R:151:3',
     'test-zzx-deprecated.R:166:3', 'test-zzx-deprecated.R:185:3',
     'test-zzx-deprecated.R:221:3', 'test-zzx-deprecated.R:255:3',
     'test-zzx-deprecated.R:275:3', 'test-zzx-deprecated.R:291:3',
     'test-zzx-deprecated.R:326:3', 'test-zzx-deprecated.R:341:3',
     'test-zzx-deprecated.R:356:3', 'test-flatten.R:18:3', 'test-flatten.R:99:3',
     'test-dplyr.R:347:3', 'test-dplyr.R:506:3', 'test-dplyr.R:545:3',
     'test-dplyr.R:558:3', 'test-dplyr.R:569:3', 'test-dplyr.R:598:3',
     'test-dplyr.R:614:3', 'test-dplyr.R:806:3', 'test-draw-dm.R:17:3',
     'test-draw-dm.R:104:3', 'test-draw-dm.R:117:3', 'test-draw-dm.R:153:3',
     'test-draw-dm.R:182:3', 'test-filter-dm.R:62:3
- [ ] ERROR: r-release-linux-x86_64
     Running ‘testthat.R’ [153s/82s]
     Running the tests in ‘tests/testthat.R’ failed.
     Complete output:
     > library(testthat)
     > 
     > # Need to use qualified call, this is checked in helper-print.R
     > testthat::test_check("dm")
     Loading required package: dm
     
     Attaching package: 'dm'
     
     The following object is masked from 'package:stats':
     
     filter
     
     Starting 2 test processes
     [ FAIL 1 | WARN 0 | SKIP 242 | PASS 1355 ]
     
     ══ Skipped tests (242) ═════════════════════════════════════════════════════════
     • COMPOUND (1): 'test-rows-dm.R:203:3'
     • Dependent on database version, find better way to record this info (1):
     'test-meta.R:19:3'
     • FIXME (2): 'test-learn.R:154:3', 'test-nest.R:2:3'
     • FIXME: Unstable on GHA? (1): 'test-dm.R:495:3'
     • Need to think about it (1): 'test-key-helpers.R:45:3'
     • On CRAN (191): 'test-zzx-deprecated.R:2:3', 'test-zzx-deprecated.R:15:3',
     'test-zzx-deprecated.R:25:3', 'test-zzx-deprecated.R:35:3',
     'test-zzx-deprecated.R:45:3', 'test-zzx-deprecated.R:58:3',
     'test-zzx-deprecated.R:81:3', 'test-zzx-deprecated.R:91:3',
     'test-zzx-deprecated.R:106:3', 'test-zzx-deprecated.R:121:3',
     'test-zzx-deprecated.R:141:3', 'test-zzx-deprecated.R:151:3',
     'test-zzx-deprecated.R:166:3', 'test-zzx-deprecated.R:185:3',
     'test-zzx-deprecated.R:221:3', 'test-zzx-deprecated.R:255:3',
     'test-zzx-deprecated.R:275:3', 'test-zzx-deprecated.R:291:3',
     'test-zzx-deprecated.R:326:3', 'test-zzx-deprecated.R:341:3',
     'test-zzx-deprecated.R:356:3', 'test-flatten.R:18:3', 'test-flatten.R:99:3',
     'test-dplyr.R:347:3', 'test-dplyr.R:506:3', 'test-dplyr.R:545:3',
     'test-dplyr.R:558:3', 'test-dplyr.R:569:3', 'test-dplyr.R:598:3',
     'test-dplyr.R:614:3', 'test-dplyr.R:806:3', 'test-draw-dm.R:17:3',
     'test-draw-dm.R:104:3', 'test-draw-dm.R:117:3', 'test-draw-dm.R:153:3',
     'test-draw-dm.R:182:3', 'test-filter-dm.R:62:3
- [ ] ERROR: r-release-windows-x86_64
     Running 'testthat.R' [68s]
     Running the tests in 'tests/testthat.R' failed.
     Complete output:
     > library(testthat)
     > 
     > # Need to use qualified call, this is checked in helper-print.R
     > testthat::test_check("dm")
     Loading required package: dm
     
     Attaching package: 'dm'
     
     The following object is masked from 'package:stats':
     
     filter
     
     Starting 2 test processes
     [ FAIL 1 | WARN 0 | SKIP 242 | PASS 1355 ]
     
     ══ Skipped tests (242) ═════════════════════════════════════════════════════════
     • COMPOUND (1): 'test-rows-dm.R:203:3'
     • Dependent on database version, find better way to record this info (1):
     'test-meta.R:19:3'
     • FIXME (2): 'test-learn.R:154:3', 'test-nest.R:2:3'
     • FIXME: Unstable on GHA? (1): 'test-dm.R:495:3'
     • Need to think about it (1): 'test-key-helpers.R:45:3'
     • On CRAN (191): 'test-zzx-deprecated.R:2:3', 'test-zzx-deprecated.R:15:3',
     'test-zzx-deprecated.R:25:3', 'test-zzx-deprecated.R:35:3',
     'test-zzx-deprecated.R:45:3', 'test-zzx-deprecated.R:58:3',
     'test-zzx-deprecated.R:81:3', 'test-zzx-deprecated.R:91:3',
     'test-zzx-deprecated.R:106:3', 'test-zzx-deprecated.R:121:3',
     'test-zzx-deprecated.R:141:3', 'test-zzx-deprecated.R:151:3',
     'test-zzx-deprecated.R:166:3', 'test-zzx-deprecated.R:185:3',
     'test-zzx-deprecated.R:221:3', 'test-zzx-deprecated.R:255:3',
     'test-zzx-deprecated.R:275:3', 'test-zzx-deprecated.R:291:3',
     'test-zzx-deprecated.R:326:3', 'test-zzx-deprecated.R:341:3',
     'test-zzx-deprecated.R:356:3', 'test-flatten.R:18:3', 'test-flatten.R:99:3',
     'test-dplyr.R:347:3', 'test-dplyr.R:506:3', 'test-dplyr.R:545:3',
     'test-dplyr.R:558:3', 'test-dplyr.R:569:3', 'test-dplyr.R:598:3',
     'test-dplyr.R:614:3', 'test-dplyr.R:806:3', 'test-draw-dm.R:17:3',
     'test-draw-dm.R:104:3', 'test-draw-dm.R:117:3', 'test-draw-dm.R:153:3',
     'test-draw-dm.R:182:3', 'test-filter-dm.R:62:3', 't
- [ ] ERROR: r-oldrel-windows-x86_64
     Running 'testthat.R' [100s]
     Running the tests in 'tests/testthat.R' failed.
     Complete output:
     > library(testthat)
     > 
     > # Need to use qualified call, this is checked in helper-print.R
     > testthat::test_check("dm")
     Loading required package: dm
     
     Attaching package: 'dm'
     
     The following object is masked from 'package:stats':
     
     filter
     
     Starting 2 test processes
     [ FAIL 1 | WARN 0 | SKIP 242 | PASS 1355 ]
     
     ══ Skipped tests (242) ═════════════════════════════════════════════════════════
     • COMPOUND (1): 'test-rows-dm.R:203:3'
     • Dependent on database version, find better way to record this info (1):
     'test-meta.R:19:3'
     • FIXME (2): 'test-learn.R:154:3', 'test-nest.R:2:3'
     • FIXME: Unstable on GHA? (1): 'test-dm.R:495:3'
     • Need to think about it (1): 'test-key-helpers.R:45:3'
     • On CRAN (191): 'test-zzx-deprecated.R:2:3', 'test-zzx-deprecated.R:15:3',
     'test-zzx-deprecated.R:25:3', 'test-zzx-deprecated.R:35:3',
     'test-zzx-deprecated.R:45:3', 'test-zzx-deprecated.R:58:3',
     'test-zzx-deprecated.R:81:3', 'test-zzx-deprecated.R:91:3',
     'test-zzx-deprecated.R:106:3', 'test-zzx-deprecated.R:121:3',
     'test-zzx-deprecated.R:141:3', 'test-zzx-deprecated.R:151:3',
     'test-zzx-deprecated.R:166:3', 'test-zzx-deprecated.R:185:3',
     'test-zzx-deprecated.R:221:3', 'test-zzx-deprecated.R:255:3',
     'test-zzx-deprecated.R:275:3', 'test-zzx-deprecated.R:291:3',
     'test-zzx-deprecated.R:326:3', 'test-zzx-deprecated.R:341:3',
     'test-zzx-deprecated.R:356:3', 'test-flatten.R:18:3', 'test-flatten.R:99:3',
     'test-dplyr.R:347:3', 'test-dplyr.R:506:3', 'test-dplyr.R:545:3',
     'test-dplyr.R:558:3', 'test-dplyr.R:569:3', 'test-dplyr.R:598:3',
     'test-dplyr.R:614:3', 'test-dplyr.R:806:3', 'test-draw-dm.R:17:3',
     'test-draw-dm.R:104:3', 'test-draw-dm.R:117:3', 'test-draw-dm.R:153:3',
     'test-draw-dm.R:182:3', 'test-filter-dm.R:62:3', '

Check results at: https://cran.r-project.org/web/checks/check_results_dm.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`