### PR TITLE
fix: Avoid including constraints from a different `constraint_schema` when learning from a database

### DIFF
--- a/R/learn.R
+++ b/R/learn.R
@@ -135,7 +135,8 @@ dm_learn_from_db <- function(dest, dbname = NA, schema = NULL, name_format = "{t
     dm_rename(key_column_usage, key_column_usage.table_name = table_name) %>%
     dm_rename(key_column_usage, key_column_usage.column_name = column_name) %>%
     dm_rename(key_column_usage, key_column_usage.dm_name = dm_name) %>%
-    dm_flatten_to_tbl(constraint_column_usage) %>%
+    # inner_join: Sometimes, constraint_schema is different, https://github.com/cynkra/dm/issues/2228
+    dm_flatten_to_tbl(constraint_column_usage, .join = inner_join) %>%
     select(
       constraint_catalog,
       constraint_schema,


### PR DESCRIPTION
Closes #2228.

@LDalby: Can you please check if this PR works for your database?