### PR TITLE
fledge: CRAN release v1.0.12

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dm
 Title: Relational Data Models
-Version: 1.0.11.9902
+Version: 1.0.12
 Date: 2025-07-02
 Authors@R: 
     c(person(given = "Tobias",

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,8 +14,6 @@
 
 ## Chore
 
-- Build-ignore.
-
 - Remove fansi.
 
 - Suggest package used in demo.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,20 +1,6 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# dm 1.0.11.9902
-
-## Chore
-
-- Build-ignore.
-
-
-# dm 1.0.11.9901
-
-## Testing
-
-- Stabilize learning tests (#2291).
-
-
-# dm 1.0.11.9900
+# dm 1.0.12
 
 ## Bug fixes
 
@@ -27,6 +13,8 @@
 - Add support for Redshift connections (@owenjonesuob, #2215).
 
 ## Chore
+
+- Build-ignore.
 
 - Remove fansi.
 
@@ -51,6 +39,8 @@
 - Fix typo (@salim-b, #2218).
 
 ## Testing
+
+- Stabilize learning tests (#2291).
 
 - Fix compatibility with waldo \>= 0.6.0 (#2240).
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-dm 1.0.11.9900
+dm 1.0.12
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-07-02, problems found: https://cran.r-project.org/web/checks/check_results_dm.html
- [ ] NOTE: r-devel-linux-x86_64-debian-clang, r-devel-linux-x86_64-debian-gcc, r-patched-linux-x86_64, r-release-linux-x86_64
     'library' or 'require' call not declared from: ‘tidyverse’

Check results at: https://cran.r-project.org/web/checks/check_results_dm.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`