### PR TITLE
fix: correct deprecation warning message for `dm_squash_to_tbl()`

### DIFF
--- a/R/zzx-deprecated.R
+++ b/R/zzx-deprecated.R
@@ -727,14 +727,14 @@ dm_bind <- function(..., repair = "check_unique", quiet = FALSE) {
 
 #' @description
 #' `dm_squash_to_tbl()`  is deprecated as of dm 1.0.0, because the same functionality
-#' is offered by [dm_flatten_to_tbl()] with `recursive = TRUE`.
+#' is offered by [dm_flatten_to_tbl()] with `.recursive = TRUE`.
 #'
 #' @rdname deprecated
 #' @keywords internal
 #'
 #' @export
 dm_squash_to_tbl <- function(dm, start, ..., join = left_join) {
-  deprecate_soft("1.0.0", "dm_squash_to_tbl()", details = "Please use `recursive = TRUE` in `dm_flatten_to_tbl()` instead.")
+  deprecate_soft("1.0.0", "dm_squash_to_tbl()", details = "Please use `.recursive = TRUE` in `dm_flatten_to_tbl()` instead.")
 
   check_not_zoomed(dm)
   join_name <- as_label(enexpr(join))

--- a/man/deprecated.Rd
+++ b/man/deprecated.Rd
@@ -277,7 +277,7 @@ is offered by \code{\link[=dm]{dm()}} with \code{.name_repair = "unique"}.
 is offered by \code{\link[=dm]{dm()}}.
 
 \code{dm_squash_to_tbl()}  is deprecated as of dm 1.0.0, because the same functionality
-is offered by \code{\link[=dm_flatten_to_tbl]{dm_flatten_to_tbl()}} with \code{recursive = TRUE}.
+is offered by \code{\link[=dm_flatten_to_tbl]{dm_flatten_to_tbl()}} with \code{.recursive = TRUE}.
 
 \code{rows_truncate()} is deprecated as of dm 1.0.0, because it's a DDL operation
 and requires different permissions than the


### PR DESCRIPTION
Update deprecation warning message to use '.recursive = TRUE' instead of 
'recursive = TRUE' to match the actual parameter name in dm_flatten_to_tbl().

Fixes #1364

Generated with [Claude Code](https://claude.ai/code)