### PR TITLE
fix: `check_key()` returns input data frame when key is valid

### DIFF
--- a/R/key-helpers.R
+++ b/R/key-helpers.R
@@ -35,7 +35,7 @@ check_key <- function(x, ..., .data = deprecated()) {
 check_key_impl <- function(.data, ...) {
   data_q <- enquo(.data)
   original_data <- eval_tidy(data_q)
-  
+
   selected_data <- original_data
   if (dots_n(...) > 0) {
     selected_data <- selected_data %>% select(...)

--- a/R/key-helpers.R
+++ b/R/key-helpers.R
@@ -34,13 +34,15 @@ check_key <- function(x, ..., .data = deprecated()) {
 
 check_key_impl <- function(.data, ...) {
   data_q <- enquo(.data)
-  .data <- eval_tidy(data_q)
-
+  original_data <- eval_tidy(data_q)
+  
+  selected_data <- original_data
   if (dots_n(...) > 0) {
-    .data <- .data %>% select(...)
+    selected_data <- selected_data %>% select(...)
   }
 
-  check_key_impl0(.data, as_label(data_q))
+  check_key_impl0(selected_data, as_label(data_q))
+  invisible(original_data)
 }
 
 check_key_impl0 <- function(x, x_label) {

--- a/tests/testthat/test-key-helpers.R
+++ b/tests/testthat/test-key-helpers.R
@@ -50,6 +50,23 @@ test_that("check_key() checks primary key properly?", {
   )
 })
 
+test_that("check_key() returns data frame when key is valid", {
+  # Test from issue #2221: check_key() should return the data frame when columns are a valid key
+  dat <- tibble(a = c(1, 2, 3), b = c(5, 5, 6), c = c(7, 8, 9))
+  
+  # Should return the original data frame, not NULL
+  result <- check_key(dat, a)
+  expect_identical(result, dat)
+  
+  # Also test with multiple columns as key
+  result2 <- check_key(dat, a, c)
+  expect_identical(result2, dat)
+  
+  # Also test with data_mcard examples
+  result3 <- check_key(data_mcard(), c1, c3)
+  expect_identical(result3, data_mcard())
+})
+
 test_that("check_api() new interface", {
   local_options(lifecycle_verbosity = "quiet")
 

--- a/tests/testthat/test-key-helpers.R
+++ b/tests/testthat/test-key-helpers.R
@@ -53,15 +53,15 @@ test_that("check_key() checks primary key properly?", {
 test_that("check_key() returns data frame when key is valid", {
   # Test from issue #2221: check_key() should return the data frame when columns are a valid key
   dat <- tibble(a = c(1, 2, 3), b = c(5, 5, 6), c = c(7, 8, 9))
-  
+
   # Should return the original data frame, not NULL
   result <- check_key(dat, a)
   expect_identical(result, dat)
-  
+
   # Also test with multiple columns as key
   result2 <- check_key(dat, a, c)
   expect_identical(result2, dat)
-  
+
   # Also test with data_mcard examples
   result3 <- check_key(data_mcard(), c1, c3)
   expect_identical(result3, data_mcard())


### PR DESCRIPTION
Adds test to verify that check_key() returns the original data frame when columns form a valid key, addressing issue #2221. Also fixes the underlying bug in check_key_impl() to ensure it returns the original data frame invisibly for piping support.

Fixes #2221

Generated with [Claude Code](https://claude.ai/code)