### PR TITLE
fix: Avoid unnecessary disambiguation message for `dm_rm_fk()`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,17 @@ testthat::test_local()
 
 **Important**: The `filter` argument filters by test file names, not individual test names within files.
 
+### Where to Add Tests
+
+When adding new tests, follow these guidelines:
+
+- **Foreign key functionality**: Add tests to `tests/testthat/test-foreign-keys.R`
+- **Primary key functionality**: Add tests to `tests/testthat/test-primary-keys.R` 
+- **General dm operations**: Look for existing test files that match the functionality (e.g., `test-dm.R`, `test-filter.R`)
+- **New functionality**: Create new test files following the naming pattern `test-[functionality].R`
+
+Always add tests when fixing bugs to prevent regression. Test both the fix and edge cases.
+
 ---
 
 *This file should be updated as new patterns are discovered.*

--- a/R/foreign-keys.R
+++ b/R/foreign-keys.R
@@ -406,10 +406,10 @@ dm_rm_fk_impl <- function(dm, table_name, cols, ref_table_name, ref_cols) {
   } else if (!is.null(ref_cols)) {
     show_disambiguation <- FALSE
   } else {
-    # Check if all FKs point to the primary key
-    show_disambiguation <- !all(map2_lgl(def$fks[idx], def$pks[idx], ~ {
-      all(map_lgl(.x$ref_column, identical, .y$column[[1]]))
-    }))
+    # If we have a specific specification (table + cols + ref_table), 
+    # only show disambiguation if multiple FKs match
+    total_fks_to_remove <- sum(lengths(idx_fk))
+    show_disambiguation <- total_fks_to_remove > 1
   }
 
   if (show_disambiguation) {

--- a/tests/testthat/test-foreign-keys.R
+++ b/tests/testthat/test-foreign-keys.R
@@ -265,6 +265,33 @@ test_that("bogus arguments are rejected", {
   })
 })
 
+test_that("dm_rm_fk() doesn't show bogus message for specific FK removal", {
+  # Issue #1270: dm_rm_fk() should not show disambiguation message
+  # when removing a specific, unambiguous foreign key
+  
+  p <- tibble(p_id = 1, p2_id = 1)
+  c1 <- tibble(p_id = 1)
+  c2 <- tibble(p2_id = 1)
+
+  my_dm <-
+    dm(p, c1, c2) %>% 
+    dm_add_pk(p, p_id) %>% 
+    dm_add_fk(c1, p_id, p) %>% 
+    dm_add_fk(c2, p2_id, p, p2_id)
+
+  # Should not produce a disambiguation message
+  expect_silent(
+    my_dm %>% 
+      dm_rm_fk(c1, p_id, p)
+  )
+  
+  # Should also not produce a disambiguation message for non-PK FK
+  expect_silent(
+    my_dm %>% 
+      dm_rm_fk(c2, p2_id, p, p2_id)
+  )
+})
+
 
 # all foreign keys --------------------------------------------------------------------
 


### PR DESCRIPTION
This PR addresses issue #1270

Generated with [Claude Code](https://claude.ai/code)