### PR TITLE
feat: Simplify testing infrastructure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,13 +53,41 @@ testthat::test_local(reporter = "summary")
 
 ### Different Backends
 
-**Important**: Set the `DM_TEST_SRC` environment variable to test against various backends. Always test all backends. Supported values include:
+The testing infrastructure has been simplified to use backend-specific test files instead of the `DM_TEST_SRC` environment variable. Each backend now has its own dedicated test files generated from templates.
 
-- `df`
-- `postgres`
-- `maria` (MariaDB)
-- `mssql` (SQL Server)
-- `duckdb`
+**Supported backends:**
+- `df` - Data frames (no database)
+- `postgres` - PostgreSQL  
+- `maria` - MariaDB
+- `mssql` - SQL Server
+- `duckdb` - DuckDB
+- `sqlite` - SQLite
+
+**Backend-specific test files:**
+Tests that require specific backends are automatically generated as separate files:
+- `test-*-df.R` - Data frame tests
+- `test-*-postgres.R` - PostgreSQL tests
+- `test-*-maria.R` - MariaDB tests
+- `test-*-mssql.R` - SQL Server tests
+- `test-*-duckdb.R` - DuckDB tests  
+- `test-*-sqlite.R` - SQLite tests
+
+**Regenerating backend tests:**
+If you modify a template test file, regenerate the backend-specific versions:
+```bash
+devcontainer exec --workspace-folder . Rscript tools/generate-backend-tests.R
+```
+
+**Testing specific backends:**
+Use the Makefile targets to test specific backends:
+```bash
+make test-df          # Test data frame backend
+make test-postgres    # Test PostgreSQL backend
+make test-maria       # Test MariaDB backend
+make test-mssql       # Test SQL Server backend
+make test-duckdb      # Test DuckDB backend
+make test-sqlite      # Test SQLite backend
+```
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -18,19 +18,19 @@ stest: stest-df stest-sqlite stest-postgres stest-mssql stest-duckdb stest-maria
 connect: connect-sqlite connect-postgres connect-mssql connect-duckdb connect-maria
 
 qtest-%:
-	DM_TEST_SRC=$@ time R -q -e 'options("crayon.enabled" = TRUE); Sys.setenv(TESTTHAT_PARALLEL = FALSE); testthat::test_local(filter = "${DM_TEST_FILTER}")'
+	time R -q -e 'options("crayon.enabled" = TRUE); Sys.setenv(TESTTHAT_PARALLEL = FALSE); testthat::test_local(filter = "${DM_TEST_FILTER}|$@")'
 
 test-%:
-	DM_TEST_SRC=$@ time R -q -e 'Sys.setenv(TESTTHAT_PARALLEL = TRUE); testthat::test_local(filter = "${DM_TEST_FILTER}")'
+	time R -q -e 'Sys.setenv(TESTTHAT_PARALLEL = TRUE); testthat::test_local(filter = "${DM_TEST_FILTER}|$@")'
 
 stest-%:
-	DM_TEST_SRC=$@ time R -q -e 'options(testthat.progress.max_fails = 1); testthat::test_local(filter = "${DM_TEST_FILTER}", reporter = "silent")'
+	time R -q -e 'options(testthat.progress.max_fails = 1); testthat::test_local(filter = "${DM_TEST_FILTER}|$@", reporter = "silent")'
 
 ltest-%:
-	DM_TEST_SRC=$@ time R -q -e 'Sys.setenv(TESTTHAT_PARALLEL = TRUE); lazytest::lazytest_local()'
+	time R -q -e 'Sys.setenv(TESTTHAT_PARALLEL = TRUE); lazytest::lazytest_local()'
 
 connect-%:
-	DM_TEST_SRC=$@ R -q -e 'suppressMessages(pkgload::load_all()); my_test_con()'
+	R -q -e 'suppressMessages(pkgload::load_all()); test_src_$@()$$con'
 
 db-start:
 	docker-compose up -d --force-recreate

--- a/tests/testthat/_snaps/df/build_copy_queries-df.md
+++ b/tests/testthat/_snaps/df/build_copy_queries-df.md
@@ -1,0 +1,316 @@
+# build_copy_queries snapshot test for pixarfilms
+
+    Code
+      pixar_dm %>% build_copy_queries(src_db, .) %>% as.list()
+    Output
+      $name
+      [1] "pixar_films"     "academy"         "box_office"      "genres"         
+      [5] "public_response"
+      
+      $remote_name
+            pixar_films           academy        box_office            genres 
+          "pixar_films"         "academy"      "box_office"          "genres" 
+        public_response 
+      "public_response" 
+      
+      $columns
+      $columns[[1]]
+      [1] "number"       "film"         "release_date" "run_time"     "film_rating" 
+      
+      $columns[[2]]
+      [1] "film"       "award_type" "status"    
+      
+      $columns[[3]]
+      [1] "film"                 "budget"               "box_office_us_canada"
+      [4] "box_office_other"     "box_office_worldwide"
+      
+      $columns[[4]]
+      [1] "film"  "genre"
+      
+      $columns[[5]]
+      [1] "film"            "rotten_tomatoes" "metacritic"      "cinema_score"   
+      [5] "critics_choice" 
+      
+      
+      $sql_table
+      <SQL> CREATE TEMPORARY TABLE pixar_films (
+        number STRING,
+        film STRING,
+        release_date DATE,
+        run_time DOUBLE,
+        film_rating STRING,
+        PRIMARY KEY (film)
+      )
+      <SQL> CREATE TEMPORARY TABLE academy (
+        film STRING,
+        award_type STRING,
+        status STRING,
+        PRIMARY KEY (film, award_type),
+        FOREIGN KEY (film) REFERENCES pixar_films (film)
+      )
+      <SQL> CREATE TEMPORARY TABLE box_office (
+        film STRING,
+        budget DOUBLE,
+        box_office_us_canada DOUBLE,
+        box_office_other DOUBLE,
+        box_office_worldwide DOUBLE,
+        PRIMARY KEY (film),
+        FOREIGN KEY (film) REFERENCES pixar_films (film)
+      )
+      <SQL> CREATE TEMPORARY TABLE genres (
+        film STRING,
+        genre STRING,
+        PRIMARY KEY (film, genre),
+        FOREIGN KEY (film) REFERENCES pixar_films (film)
+      )
+      <SQL> CREATE TEMPORARY TABLE public_response (
+        film STRING,
+        rotten_tomatoes DOUBLE,
+        metacritic DOUBLE,
+        cinema_score STRING,
+        critics_choice DOUBLE,
+        PRIMARY KEY (film),
+        FOREIGN KEY (film) REFERENCES pixar_films (film)
+      )
+      
+      $sql_index
+      $sql_index[[1]]
+      NULL
+      
+      $sql_index[[2]]
+      <SQL> CREATE INDEX academy__film ON academy (film)
+      
+      $sql_index[[3]]
+      <SQL> CREATE INDEX box_office__film ON box_office (film)
+      
+      $sql_index[[4]]
+      <SQL> CREATE INDEX genres__film ON genres (film)
+      
+      $sql_index[[5]]
+      <SQL> CREATE INDEX public_response__film ON public_response (film)
+      
+      
+      $index_name
+      $index_name[[1]]
+      NULL
+      
+      $index_name[[2]]
+      [1] "academy__film"
+      
+      $index_name[[3]]
+      [1] "box_office__film"
+      
+      $index_name[[4]]
+      [1] "genres__film"
+      
+      $index_name[[5]]
+      [1] "public_response__film"
+      
+      
+
+# build_copy_queries snapshot test for dm_for_filter()
+
+    Code
+      dm_for_filter() %>% collect() %>% build_copy_queries(src_db, .) %>% as.list()
+    Message
+      `on_delete = "cascade"` not supported for duckdb
+    Output
+      $name
+      [1] "tf_1" "tf_3" "tf_6" "tf_2" "tf_4" "tf_5"
+      
+      $remote_name
+        tf_1   tf_3   tf_6   tf_2   tf_4   tf_5 
+      "tf_1" "tf_3" "tf_6" "tf_2" "tf_4" "tf_5" 
+      
+      $columns
+      $columns[[1]]
+      [1] "a" "b"
+      
+      $columns[[2]]
+      [1] "f"  "f1" "g" 
+      
+      $columns[[3]]
+      [1] "zz" "n"  "o" 
+      
+      $columns[[4]]
+      [1] "c"  "d"  "e"  "e1"
+      
+      $columns[[5]]
+      [1] "h"  "i"  "j"  "j1"
+      
+      $columns[[6]]
+      [1] "ww" "k"  "l"  "m" 
+      
+      
+      $sql_table
+      <SQL> CREATE TEMPORARY TABLE tf_1 (
+        a INTEGER,
+        b STRING,
+        PRIMARY KEY (a)
+      )
+      <SQL> CREATE TEMPORARY TABLE tf_3 (
+        f STRING,
+        f1 INTEGER,
+        g STRING,
+        PRIMARY KEY (f, f1)
+      )
+      <SQL> CREATE TEMPORARY TABLE tf_6 (
+        zz INTEGER,
+        n STRING,
+        o STRING,
+        PRIMARY KEY (o),
+        UNIQUE (n)
+      )
+      <SQL> CREATE TEMPORARY TABLE tf_2 (
+        c STRING,
+        d INTEGER,
+        e STRING,
+        e1 INTEGER,
+        PRIMARY KEY (c),
+        FOREIGN KEY (d) REFERENCES tf_1 (a),
+        FOREIGN KEY (e, e1) REFERENCES tf_3 (f, f1)
+      )
+      <SQL> CREATE TEMPORARY TABLE tf_4 (
+        h STRING,
+        i STRING,
+        j STRING,
+        j1 INTEGER,
+        PRIMARY KEY (h),
+        FOREIGN KEY (j, j1) REFERENCES tf_3 (f, f1)
+      )
+      <SQL> CREATE TEMPORARY TABLE tf_5 (
+        ww INTEGER,
+        k INTEGER,
+        l STRING,
+        m STRING,
+        PRIMARY KEY (k),
+        FOREIGN KEY (m) REFERENCES tf_6 (n),
+        FOREIGN KEY (l) REFERENCES tf_4 (h)
+      )
+      
+      $sql_index
+      $sql_index[[1]]
+      NULL
+      
+      $sql_index[[2]]
+      NULL
+      
+      $sql_index[[3]]
+      NULL
+      
+      $sql_index[[4]]
+      <SQL> CREATE INDEX tf_2__d ON tf_2 (d)
+      <SQL> CREATE INDEX tf_2__e_e1 ON tf_2 (e, e1)
+      
+      $sql_index[[5]]
+      <SQL> CREATE INDEX tf_4__j_j1 ON tf_4 (j, j1)
+      
+      $sql_index[[6]]
+      <SQL> CREATE INDEX tf_5__m ON tf_5 (m)
+      <SQL> CREATE INDEX tf_5__l ON tf_5 (l)
+      
+      
+      $index_name
+      $index_name[[1]]
+      NULL
+      
+      $index_name[[2]]
+      NULL
+      
+      $index_name[[3]]
+      NULL
+      
+      $index_name[[4]]
+      [1] "tf_2__d"    "tf_2__e_e1"
+      
+      $index_name[[5]]
+      [1] "tf_4__j_j1"
+      
+      $index_name[[6]]
+      [1] "tf_5__m" "tf_5__l"
+      
+      
+
+# build_copy_queries avoids duplicate indexes
+
+    Code
+      as.list(queries)
+    Output
+      $name
+      [1] "parent1"  "parent2"  "child"    "child__a"
+      
+      $remote_name
+      $remote_name$parent1
+      <Id> "parent1"
+      
+      $remote_name$parent2
+      <Id> "parent2"
+      
+      $remote_name$child
+      <Id> "child"
+      
+      $remote_name$child__a
+      <Id> "child__a"
+      
+      
+      $columns
+      $columns[[1]]
+      [1] "key"
+      
+      $columns[[2]]
+      [1] "a__key"
+      
+      $columns[[3]]
+      [1] "a__key"
+      
+      $columns[[4]]
+      [1] "key"
+      
+      
+      $sql_table
+      <SQL> CREATE TEMPORARY TABLE parent1 (
+        "key" DOUBLE,
+        PRIMARY KEY ("key")
+      )
+      <SQL> CREATE TEMPORARY TABLE parent2 (
+        a__key DOUBLE,
+        PRIMARY KEY (a__key)
+      )
+      <SQL> CREATE TEMPORARY TABLE child (
+        a__key DOUBLE,
+        FOREIGN KEY (a__key) REFERENCES parent2 (a__key)
+      )
+      <SQL> CREATE TEMPORARY TABLE child__a (
+        "key" DOUBLE,
+        FOREIGN KEY ("key") REFERENCES parent2 (a__key)
+      )
+      
+      $sql_index
+      $sql_index[[1]]
+      NULL
+      
+      $sql_index[[2]]
+      NULL
+      
+      $sql_index[[3]]
+      <SQL> CREATE INDEX child__a__key ON child (a__key)
+      
+      $sql_index[[4]]
+      <SQL> CREATE INDEX child__a__key__1 ON child__a ("key")
+      
+      
+      $index_name
+      $index_name[[1]]
+      NULL
+      
+      $index_name[[2]]
+      NULL
+      
+      $index_name[[3]]
+      [1] "child__a__key"
+      
+      $index_name[[4]]
+      [1] "child__a__key__1"
+      
+      
+

--- a/tests/testthat/_snaps/df/flatten-df.md
+++ b/tests/testthat/_snaps/df/flatten-df.md
@@ -1,0 +1,186 @@
+# `dm_flatten_to_tbl()` does the right things for 'left_join()'
+
+    Code
+      prepare_dm_for_flatten(dm_for_flatten(), tables = c("fact", "dim_1", "dim_2",
+        "dim_3", "dim_4"), gotta_rename = TRUE) %>% dm_get_tables()
+    Message
+      Renaming ambiguous columns: %>%
+        dm_rename(fact, something.fact = something) %>%
+        dm_rename(dim_1, something.dim_1 = something) %>%
+        dm_rename(dim_2, something.dim_2 = something) %>%
+        dm_rename(dim_3, something.dim_3 = something) %>%
+        dm_rename(dim_4, something.dim_4 = something)
+    Output
+      $fact
+      # A tibble: 10 x 7
+         fact     dim_1_key_1 dim_1_key_2 dim_2_key dim_3_key dim_4_key something.fact
+         <chr>          <int> <chr>       <chr>     <chr>         <int>          <int>
+       1 acorn             14 N           c         X                 7              1
+       2 blubber           13 M           d         W                 8              2
+       3 cindere~          12 L           e         V                 9              3
+       4 depth             11 K           f         U                10              4
+       5 elysium           10 J           g         T                11              5
+       6 fantasy            9 I           h         S                12              6
+       7 gorgeous           8 H           i         R                13              7
+       8 halo               7 G           j         Q                14              8
+       9 ill-adv~           6 F           k         P                15              9
+      10 jitter             5 E           l         O                16             10
+      
+      $dim_1
+      # A tibble: 20 x 3
+         dim_1_pk_1 dim_1_pk_2 something.dim_1
+              <int> <chr>      <chr>          
+       1          1 A          c              
+       2          2 B          d              
+       3          3 C          e              
+       4          4 D          f              
+       5          5 E          g              
+       6          6 F          h              
+       7          7 G          i              
+       8          8 H          j              
+       9          9 I          k              
+      10         10 J          l              
+      11         11 K          m              
+      12         12 L          n              
+      13         13 M          o              
+      14         14 N          p              
+      15         15 O          q              
+      16         16 P          r              
+      17         17 Q          s              
+      18         18 R          t              
+      19         19 S          u              
+      20         20 T          v              
+      
+      $dim_2
+      # A tibble: 20 x 2
+         dim_2_pk something.dim_2
+         <chr>    <chr>          
+       1 a        E              
+       2 b        F              
+       3 c        G              
+       4 d        H              
+       5 e        I              
+       6 f        J              
+       7 g        K              
+       8 h        L              
+       9 i        M              
+      10 j        N              
+      11 k        O              
+      12 l        P              
+      13 m        Q              
+      14 n        R              
+      15 o        S              
+      16 p        T              
+      17 q        U              
+      18 r        V              
+      19 s        W              
+      20 t        X              
+      
+      $dim_3
+      # A tibble: 20 x 2
+         dim_3_pk something.dim_3
+         <chr>              <int>
+       1 E                      3
+       2 F                      4
+       3 G                      5
+       4 H                      6
+       5 I                      7
+       6 J                      8
+       7 K                      9
+       8 L                     10
+       9 M                     11
+      10 N                     12
+      11 O                     13
+      12 P                     14
+      13 Q                     15
+      14 R                     16
+      15 S                     17
+      16 T                     18
+      17 U                     19
+      18 V                     20
+      19 W                     21
+      20 X                     22
+      
+      $dim_4
+      # A tibble: 13 x 2
+         dim_4_pk something.dim_4
+            <int>           <int>
+       1       19              19
+       2       18              20
+       3       17              21
+       4       16              22
+       5       15              23
+       6       14              24
+       7       13              25
+       8       12              26
+       9       11              27
+      10       10              28
+      11        9              29
+      12        8              30
+      13        7              31
+      
+    Code
+      dm_flatten_to_tbl(dm_for_flatten(), fact)
+    Message
+      Renaming ambiguous columns: %>%
+        dm_rename(fact, something.fact = something) %>%
+        dm_rename(dim_1, something.dim_1 = something) %>%
+        dm_rename(dim_2, something.dim_2 = something) %>%
+        dm_rename(dim_3, something.dim_3 = something) %>%
+        dm_rename(dim_4, something.dim_4 = something)
+    Output
+      # A tibble: 10 x 11
+         fact     dim_1_key_1 dim_1_key_2 dim_2_key dim_3_key dim_4_key something.fact
+         <chr>          <int> <chr>       <chr>     <chr>         <int>          <int>
+       1 acorn             14 N           c         X                 7              1
+       2 blubber           13 M           d         W                 8              2
+       3 cindere~          12 L           e         V                 9              3
+       4 depth             11 K           f         U                10              4
+       5 elysium           10 J           g         T                11              5
+       6 fantasy            9 I           h         S                12              6
+       7 gorgeous           8 H           i         R                13              7
+       8 halo               7 G           j         Q                14              8
+       9 ill-adv~           6 F           k         P                15              9
+      10 jitter             5 E           l         O                16             10
+      # i 4 more variables: something.dim_1 <chr>, something.dim_2 <chr>,
+      #   something.dim_3 <int>, something.dim_4 <int>
+    Code
+      result_from_flatten_new()
+    Output
+      # A tibble: 10 x 11
+         fact     dim_1_key_1 dim_1_key_2 dim_2_key dim_3_key dim_4_key something.fact
+         <chr>          <int> <chr>       <chr>     <chr>         <int>          <int>
+       1 acorn             14 N           c         X                 7              1
+       2 blubber           13 M           d         W                 8              2
+       3 cindere~          12 L           e         V                 9              3
+       4 depth             11 K           f         U                10              4
+       5 elysium           10 J           g         T                11              5
+       6 fantasy            9 I           h         S                12              6
+       7 gorgeous           8 H           i         R                13              7
+       8 halo               7 G           j         Q                14              8
+       9 ill-adv~           6 F           k         P                15              9
+      10 jitter             5 E           l         O                16             10
+      # i 4 more variables: something.dim_1 <chr>, something.dim_2 <chr>,
+      #   something.dim_3 <int>, something.dim_4 <int>
+
+# `dm_flatten_to_tbl()` does the right things for 'inner_join()'
+
+    Code
+      out
+    Output
+      # A tibble: 10 x 11
+         fact     dim_1_key_1 dim_1_key_2 dim_2_key dim_3_key dim_4_key something.fact
+         <chr>          <int> <chr>       <chr>     <chr>         <int>          <int>
+       1 acorn             14 N           c         X                 7              1
+       2 blubber           13 M           d         W                 8              2
+       3 cindere~          12 L           e         V                 9              3
+       4 depth             11 K           f         U                10              4
+       5 elysium           10 J           g         T                11              5
+       6 fantasy            9 I           h         S                12              6
+       7 gorgeous           8 H           i         R                13              7
+       8 halo               7 G           j         Q                14              8
+       9 ill-adv~           6 F           k         P                15              9
+      10 jitter             5 E           l         O                16             10
+      # i 4 more variables: something.dim_1 <chr>, something.dim_2 <chr>,
+      #   something.dim_3 <int>, something.dim_4 <int>
+

--- a/tests/testthat/_snaps/df/rows-dm-df.md
+++ b/tests/testthat/_snaps/df/rows-dm-df.md
@@ -1,0 +1,112 @@
+# dm_rows_append() works with autoincrement PKs and FKS locally
+
+    Code
+      local_dm$t1
+    Output
+      # A tibble: 3 x 2
+            a o    
+        <int> <chr>
+      1     5 a    
+      2     6 b    
+      3     7 c    
+    Code
+      local_dm$t2
+    Output
+      # A tibble: 3 x 3
+            c     d o    
+        <int> <int> <chr>
+      1    10     7 c    
+      2     9     6 b    
+      3     8     5 a    
+    Code
+      local_dm$t3
+    Output
+      # A tibble: 3 x 2
+            e o    
+        <int> <chr>
+      1     6 b    
+      2     5 a    
+      3     7 c    
+    Code
+      local_dm$t4
+    Output
+      # A tibble: 3 x 3
+            g     h o    
+        <int> <int> <chr>
+      1     1     8 a    
+      2     2     9 b    
+      3     3    10 c    
+    Code
+      filled_dm$t1
+    Output
+      # A tibble: 3 x 2
+            a o    
+        <int> <chr>
+      1     1 a    
+      2     2 b    
+      3     3 c    
+    Code
+      filled_dm$t2
+    Output
+      # A tibble: 3 x 3
+            c     d o    
+        <int> <int> <chr>
+      1     1     3 c    
+      2     2     2 b    
+      3     3     1 a    
+    Code
+      filled_dm$t3
+    Output
+      # A tibble: 0 x 2
+      # i 2 variables: e <int>, o <chr>
+    Code
+      filled_dm$t4
+    Output
+      # A tibble: 3 x 3
+            g     h o    
+        <int> <int> <chr>
+      1     1     3 a    
+      2     2     2 b    
+      3     3     1 c    
+    Code
+      filled_twice_dm$t1
+    Output
+      # A tibble: 6 x 2
+            a o    
+        <int> <chr>
+      1     1 a    
+      2     2 b    
+      3     3 c    
+      4     4 a    
+      5     5 b    
+      6     6 c    
+    Code
+      filled_twice_dm$t2
+    Output
+      # A tibble: 6 x 3
+            c     d o    
+        <int> <int> <chr>
+      1     1     3 c    
+      2     2     2 b    
+      3     3     1 a    
+      4     4     6 c    
+      5     5     5 b    
+      6     6     4 a    
+    Code
+      filled_twice_dm$t3
+    Output
+      # A tibble: 0 x 2
+      # i 2 variables: e <int>, o <chr>
+    Code
+      filled_twice_dm$t4
+    Output
+      # A tibble: 6 x 3
+            g     h o    
+        <int> <int> <chr>
+      1     1     3 a    
+      2     2     2 b    
+      3     3     1 c    
+      4     4     6 a    
+      5     5     5 b    
+      6     6     4 c    
+

--- a/tests/testthat/_snaps/json_nest-df.md
+++ b/tests/testthat/_snaps/json_nest-df.md
@@ -1,0 +1,14 @@
+# `json_nest()` and `json_unnest()` work
+
+    Code
+      df <- tibble::tibble(x = c(1, 1, 1, 2, 2, 3), y = 1:6, z = 6:1)
+      nested <- json_nest(df, data = c(y, z))
+      nested
+    Output
+      # A tibble: 3 x 2
+            x data                                                     
+        <dbl> <chr>                                                    
+      1     1 "[{\"y\":1,\"z\":6},{\"y\":2,\"z\":5},{\"y\":3,\"z\":4}]"
+      2     2 "[{\"y\":4,\"z\":3},{\"y\":5,\"z\":2}]"                  
+      3     3 "[{\"y\":6,\"z\":1}]"                                    
+

--- a/tests/testthat/_snaps/json_pack-df.md
+++ b/tests/testthat/_snaps/json_pack-df.md
@@ -1,0 +1,14 @@
+# `json_pack()` works
+
+    Code
+      df <- tibble::tibble(x1 = 1:3, x2 = 4:6, x3 = 7:9, y = 1:3)
+      packed <- json_pack(df, x = c(x1, x2, x3), y = y)
+      packed
+    Output
+      # A tibble: 3 x 2
+        x                              y          
+        <chr>                          <chr>      
+      1 "{\"x1\":1,\"x2\":4,\"x3\":7}" "{\"y\":1}"
+      2 "{\"x1\":2,\"x2\":5,\"x3\":8}" "{\"y\":2}"
+      3 "{\"x1\":3,\"x2\":6,\"x3\":9}" "{\"y\":3}"
+

--- a/tests/testthat/_snaps/meta-df.md
+++ b/tests/testthat/_snaps/meta-df.md
@@ -1,0 +1,7 @@
+# dummy
+
+    Code
+      TRUE
+    Output
+      [1] TRUE
+

--- a/tests/testthat/_snaps/rows-dm-df.md
+++ b/tests/testthat/_snaps/rows-dm-df.md
@@ -1,0 +1,427 @@
+# dumma
+
+    Code
+      # dummy
+
+# dm_rows_insert()
+
+    Code
+      print(dm_nrow(flights_sqlite))
+    Output
+      airlines airports  flights   planes  weather 
+            15       86        0      945        0 
+    Code
+      flights_hour10 <- dm_nycflights13() %>% dm_select_tbl(flights, weather) %>%
+        dm_zoom_to(flights) %>% filter(month == 1, day == 10, hour == 10) %>%
+        dm_update_zoomed() %>% dm_zoom_to(weather) %>% filter(month == 1, day == 10,
+      hour == 10) %>% dm_update_zoomed()
+      print(dm_nrow(flights_hour10))
+    Output
+      flights weather 
+           43       3 
+    Code
+      flights_hour10_sqlite <- copy_dm_to(sqlite, flights_hour10)
+      out <- dm_rows_append(flights_sqlite, flights_hour10_sqlite)
+    Message
+      Result is returned as a dm object with lazy tables. Use `in_place = FALSE` to mute this message, or `in_place = TRUE` to write to the underlying tables.
+    Code
+      print(dm_nrow(flights_sqlite))
+    Output
+      airlines airports  flights   planes  weather 
+            15       86        0      945        0 
+    Code
+      dm_rows_append(flights_sqlite, flights_hour10_sqlite, in_place = TRUE)
+      print(dm_nrow(flights_sqlite))
+    Output
+      airlines airports  flights   planes  weather 
+            15       86       43      945        3 
+    Code
+      flights_hour11 <- dm_nycflights13() %>% dm_select_tbl(flights, weather) %>%
+        dm_zoom_to(flights) %>% filter(month == 1, day == 10, hour == 11) %>%
+        dm_update_zoomed() %>% dm_zoom_to(weather) %>% filter(month == 1, day == 10,
+      hour == 11) %>% dm_update_zoomed()
+      flights_hour11_sqlite <- copy_dm_to(sqlite, flights_hour11)
+      flights_new <- dm_rows_append(flights_sqlite, flights_hour11_sqlite, in_place = FALSE)
+      print(dm_nrow(flights_new))
+    Output
+      airlines airports  flights   planes  weather 
+            15       86       88      945        6 
+    Code
+      print(dm_nrow(flights_sqlite))
+    Output
+      airlines airports  flights   planes  weather 
+            15       86       43      945        3 
+    Code
+      flights_new %>% dm_examine_constraints()
+    Message
+      ! Unsatisfied constraints:
+    Output
+      * Table `flights`: foreign key `tailnum` into table `planes`: values of `flights$tailnum` not in `planes$tailnum`: N0EGMQ (1), N3BCAA (1), N3CCAA (1), N3CFAA (1), N3EHAA (1), ...
+    Code
+      dm_rows_append(flights_sqlite, flights_hour11_sqlite, in_place = TRUE)
+      print(dm_nrow(flights_sqlite))
+    Output
+      airlines airports  flights   planes  weather 
+            15       86       88      945        6 
+    Code
+      DBI::dbDisconnect(sqlite)
+
+# dm_rows_update()
+
+    Code
+      dm_copy %>% pull_tbl(tf_2) %>% arrange_all()
+    Output
+            d c        e        e1
+        <int> <chr>    <chr> <int>
+      1     2 elephant D         4
+      2     3 lion     E         5
+      3     4 seal     F         6
+      4     5 worm     G         7
+      5     6 dog      E         5
+      6     7 cat      F         6
+    Code
+      dm_copy %>% dm_rows_update(dm_update_copy) %>% pull_tbl(tf_2) %>% arrange_all()
+    Message
+      Result is returned as a dm object with lazy tables. Use `in_place = FALSE` to mute this message, or `in_place = TRUE` to write to the underlying tables.
+    Output
+            d c        e        e1
+        <int> <chr>    <chr> <int>
+      1     2 elephant D         4
+      2     3 lion     E         5
+      3     4 seal     F         6
+      4     5 worm     G         7
+      5     6 dog      E         5
+      6     7 cat      F         6
+    Code
+      dm_copy %>% pull_tbl(tf_2) %>% arrange_all()
+    Output
+            d c        e        e1
+        <int> <chr>    <chr> <int>
+      1     2 elephant D         4
+      2     3 lion     E         5
+      3     4 seal     F         6
+      4     5 worm     G         7
+      5     6 dog      E         5
+      6     7 cat      F         6
+    Code
+      dm_copy %>% dm_rows_update(dm_update_copy, in_place = FALSE) %>% pull_tbl(tf_2) %>%
+        arrange_all()
+    Output
+            d c        e        e1
+        <int> <chr>    <chr> <int>
+      1     2 elephant D         4
+      2     3 lion     E         5
+      3     4 seal     F         6
+      4     5 worm     G         7
+      5     6 dog      E         5
+      6     7 cat      F         6
+    Code
+      dm_copy %>% dm_get_tables() %>% map(arrange_all)
+    Output
+      $tf_1
+             a b    
+         <int> <chr>
+       1     1 A    
+       2     2 B    
+       3     3 C    
+       4     4 D    
+       5     5 E    
+       6     6 F    
+       7     7 G    
+       8     8 H    
+       9     9 I    
+      10    10 J    
+      
+      $tf_2
+            d c        e        e1
+        <int> <chr>    <chr> <int>
+      1     2 elephant D         4
+      2     3 lion     E         5
+      3     4 seal     F         6
+      4     5 worm     G         7
+      5     6 dog      E         5
+      6     7 cat      F         6
+      
+      $tf_3
+         f        f1 g    
+         <chr> <int> <chr>
+       1 C         2 one  
+       2 C         3 two  
+       3 D         4 three
+       4 E         5 four 
+       5 F         6 five 
+       6 G         7 six  
+       7 H         7 seven
+       8 I         7 eight
+       9 J        10 nine 
+      10 K        11 ten  
+      
+      $tf_4
+        i     h     j        j1
+        <chr> <chr> <chr> <int>
+      1 five  c     E         5
+      2 four  b     D         4
+      3 seven e     F         6
+      4 six   d     F         6
+      5 three a     C         3
+      
+      $tf_5
+        l     m             ww     k
+        <chr> <chr>      <int> <int>
+      1 b     house          2     1
+      2 c     tree           2     2
+      3 d     streetlamp     2     3
+      4 e     streetlamp     2     4
+      
+      $tf_6
+           zz n          o    
+        <int> <chr>      <chr>
+      1     1 garden     i    
+      2     1 hill       g    
+      3     1 house      e    
+      4     1 streetlamp h    
+      5     1 tree       f    
+      
+    Code
+      dm_copy %>% dm_rows_update(dm_update_copy, in_place = TRUE)
+      dm_copy %>% dm_get_tables() %>% map(arrange_all)
+    Output
+      $tf_1
+             a b    
+         <int> <chr>
+       1     1 A    
+       2     2 q    
+       3     3 C    
+       4     4 D    
+       5     5 E    
+       6     6 F    
+       7     7 G    
+       8     8 H    
+       9     9 I    
+      10    10 J    
+      
+      $tf_2
+            d c        e        e1
+        <int> <chr>    <chr> <int>
+      1     2 elephant D         4
+      2     3 lion     E         5
+      3     4 seal     F         6
+      4     5 worm     G         7
+      5     6 dog      E         5
+      6     7 cat      F         6
+      
+      $tf_3
+         f        f1 g    
+         <chr> <int> <chr>
+       1 C         2 one  
+       2 C         3 two  
+       3 D         4 three
+       4 E         5 four 
+       5 F         6 five 
+       6 G         7 six  
+       7 H         7 seven
+       8 I         7 eight
+       9 J        10 nine 
+      10 K        11 ten  
+      
+      $tf_4
+        i      h     j        j1
+        <chr>  <chr> <chr> <int>
+      1 five   c     E         5
+      2 four   b     D         4
+      3 sieben e     F         6
+      4 six    d     F         6
+      5 three  a     C         3
+      
+      $tf_5
+        l     m             ww     k
+        <chr> <chr>      <int> <int>
+      1 b     house          2     1
+      2 c     tree           2     2
+      3 d     streetlamp     3     3
+      4 e     streetlamp     2     4
+      
+      $tf_6
+           zz n          o    
+        <int> <chr>      <chr>
+      1     1 garden     i    
+      2     1 hill       g    
+      3     1 house      e    
+      4     1 streetlamp h    
+      5     1 tree       f    
+      
+
+# dm_rows_truncate()
+
+    Code
+      dm_copy %>% pull_tbl(tf_2) %>% arrange_all()
+    Output
+        c            d e        e1
+        <chr>    <int> <chr> <int>
+      1 cat          7 F         6
+      2 dog          6 E         5
+      3 elephant     2 D         4
+      4 lion         3 E         5
+      5 seal         4 F         6
+      6 worm         5 G         7
+    Code
+      dm_copy %>% dm_rows_truncate(dm_truncate_copy) %>% pull_tbl(tf_2) %>%
+        arrange_all()
+    Condition
+      Warning:
+      `dm_rows_truncate()` was deprecated in dm 1.0.0.
+    Message
+      Result is returned as a dm object with lazy tables. Use `in_place = FALSE` to mute this message, or `in_place = TRUE` to write to the underlying tables.
+    Output
+      # i 4 variables: c <chr>, d <int>, e <chr>, e1 <int>
+    Code
+      dm_copy %>% pull_tbl(tf_2) %>% arrange_all()
+    Output
+        c            d e        e1
+        <chr>    <int> <chr> <int>
+      1 cat          7 F         6
+      2 dog          6 E         5
+      3 elephant     2 D         4
+      4 lion         3 E         5
+      5 seal         4 F         6
+      6 worm         5 G         7
+    Code
+      dm_copy %>% dm_rows_truncate(dm_truncate_copy, in_place = FALSE) %>% pull_tbl(
+        tf_2) %>% arrange_all()
+    Condition
+      Warning:
+      `dm_rows_truncate()` was deprecated in dm 1.0.0.
+    Output
+      # i 4 variables: c <chr>, d <int>, e <chr>, e1 <int>
+    Code
+      dm_copy %>% dm_get_tables() %>% map(arrange_all)
+    Output
+      $tf_1
+             a b    
+         <int> <chr>
+       1     1 A    
+       2     2 B    
+       3     3 C    
+       4     4 D    
+       5     5 E    
+       6     6 F    
+       7     7 G    
+       8     8 H    
+       9     9 I    
+      10    10 J    
+      
+      $tf_2
+        c            d e        e1
+        <chr>    <int> <chr> <int>
+      1 cat          7 F         6
+      2 dog          6 E         5
+      3 elephant     2 D         4
+      4 lion         3 E         5
+      5 seal         4 F         6
+      6 worm         5 G         7
+      
+      $tf_3
+         f        f1 g    
+         <chr> <int> <chr>
+       1 C         2 one  
+       2 C         3 two  
+       3 D         4 three
+       4 E         5 four 
+       5 F         6 five 
+       6 G         7 six  
+       7 H         7 seven
+       8 I         7 eight
+       9 J        10 nine 
+      10 K        11 ten  
+      
+      $tf_4
+        h     i     j        j1
+        <chr> <chr> <chr> <int>
+      1 a     three C         3
+      2 b     four  D         4
+      3 c     five  E         5
+      4 d     six   F         6
+      5 e     seven F         6
+      
+      $tf_5
+           ww     k l     m         
+        <int> <int> <chr> <chr>     
+      1     2     1 b     house     
+      2     2     2 c     tree      
+      3     2     3 d     streetlamp
+      4     2     4 e     streetlamp
+      
+      $tf_6
+           zz n          o    
+        <int> <chr>      <chr>
+      1     1 garden     i    
+      2     1 hill       g    
+      3     1 house      e    
+      4     1 streetlamp h    
+      5     1 tree       f    
+      
+    Code
+      dm_copy %>% dm_rows_truncate(dm_truncate_copy, in_place = TRUE)
+    Condition
+      Warning:
+      `dm_rows_truncate()` was deprecated in dm 1.0.0.
+      Warning:
+      `sql_rows_truncate()` was deprecated in dm 1.0.0.
+      Warning:
+      `sql_rows_truncate()` was deprecated in dm 1.0.0.
+    Code
+      dm_copy %>% dm_get_tables() %>% map(arrange_all)
+    Output
+      $tf_1
+             a b    
+         <int> <chr>
+       1     1 A    
+       2     2 B    
+       3     3 C    
+       4     4 D    
+       5     5 E    
+       6     6 F    
+       7     7 G    
+       8     8 H    
+       9     9 I    
+      10    10 J    
+      
+      $tf_2
+      # i 4 variables: c <chr>, d <int>, e <chr>, e1 <int>
+      
+      $tf_3
+         f        f1 g    
+         <chr> <int> <chr>
+       1 C         2 one  
+       2 C         3 two  
+       3 D         4 three
+       4 E         5 four 
+       5 F         6 five 
+       6 G         7 six  
+       7 H         7 seven
+       8 I         7 eight
+       9 J        10 nine 
+      10 K        11 ten  
+      
+      $tf_4
+        h     i     j        j1
+        <chr> <chr> <chr> <int>
+      1 a     three C         3
+      2 b     four  D         4
+      3 c     five  E         5
+      4 d     six   F         6
+      5 e     seven F         6
+      
+      $tf_5
+      # i 4 variables: ww <int>, k <int>, l <chr>, m <chr>
+      
+      $tf_6
+           zz n          o    
+        <int> <chr>      <chr>
+      1     1 garden     i    
+      2     1 hill       g    
+      3     1 house      e    
+      4     1 streetlamp h    
+      5     1 tree       f    
+      
+

--- a/tests/testthat/test-build_copy_queries-df.R
+++ b/tests/testthat/test-build_copy_queries-df.R
@@ -1,0 +1,86 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for data frames
+test_that("build_copy_queries snapshot test for pixarfilms", {
+  src_db <- test_src_duckdb()
+
+  # build regular dm from `dm_pixarfilms()`
+  pixar_dm <-
+    # fetch sample dm
+    dm_pixarfilms() %>%
+    # make it regular
+    dm_filter(pixar_films = (!is.na(film))) %>%
+    dm_select_tbl(-pixar_people)
+
+  skip_if_not_installed("testthat", "3.1.1")
+
+  expect_snapshot(
+    variant = "df",
+    {
+      pixar_dm %>%
+        build_copy_queries(
+          src_db,
+          .
+        ) %>%
+        as.list() # to print full queries
+    }
+  )
+})
+
+
+test_that("build_copy_queries snapshot test for dm_for_filter()", {
+  src_db <- test_src_duckdb()
+
+  skip_if_not_installed("testthat", "3.1.1")
+
+  expect_snapshot(
+    variant = "df",
+    {
+      dm_for_filter() %>%
+        collect() %>%
+        build_copy_queries(
+          src_db,
+          .
+        ) %>%
+        as.list() # to print full queries
+    }
+  )
+})
+
+
+test_that("build_copy_queries avoids duplicate indexes", {
+  src_db <- test_src_duckdb()
+
+  # build a dm whose index might be duplicated if naively build (child__a__key)
+  ambiguous_dm <- dm(
+    parent1 = tibble(key = 1),
+    parent2 = tibble(a__key = 1),
+    child = tibble(a__key = 1),
+    child__a = tibble(key = 1)
+  ) %>%
+    dm_add_pk(parent1, key) %>%
+    dm_add_pk(parent2, a__key) %>%
+    dm_add_fk(child, a__key, parent2) %>%
+    dm_add_fk(child__a, key, parent2)
+
+  queries <-
+    build_copy_queries(
+      src_db,
+      ambiguous_dm,
+      table_names =
+        names(ambiguous_dm) %>%
+          repair_table_names_for_db(temporary = FALSE, con = src_db, schema = NULL)
+    )
+
+  expect_equal(anyDuplicated(unlist(queries$index_name)), 0)
+
+  skip_if_not_installed("testthat", "3.1.1")
+
+  expect_snapshot(
+    variant = "df",
+    {
+      as.list(queries)
+    }
+  )
+})

--- a/tests/testthat/test-build_copy_queries-duckdb.R
+++ b/tests/testthat/test-build_copy_queries-duckdb.R
@@ -1,0 +1,86 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for DuckDB
+test_that("build_copy_queries snapshot test for pixarfilms", {
+  src_db <- test_src_duckdb()
+
+  # build regular dm from `dm_pixarfilms()`
+  pixar_dm <-
+    # fetch sample dm
+    dm_pixarfilms() %>%
+    # make it regular
+    dm_filter(pixar_films = (!is.na(film))) %>%
+    dm_select_tbl(-pixar_people)
+
+  skip_if_not_installed("testthat", "3.1.1")
+
+  expect_snapshot(
+    variant = "duckdb",
+    {
+      pixar_dm %>%
+        build_copy_queries(
+          src_db,
+          .
+        ) %>%
+        as.list() # to print full queries
+    }
+  )
+})
+
+
+test_that("build_copy_queries snapshot test for dm_for_filter()", {
+  src_db <- test_src_duckdb()
+
+  skip_if_not_installed("testthat", "3.1.1")
+
+  expect_snapshot(
+    variant = "duckdb",
+    {
+      dm_for_filter() %>%
+        collect() %>%
+        build_copy_queries(
+          src_db,
+          .
+        ) %>%
+        as.list() # to print full queries
+    }
+  )
+})
+
+
+test_that("build_copy_queries avoids duplicate indexes", {
+  src_db <- test_src_duckdb()
+
+  # build a dm whose index might be duplicated if naively build (child__a__key)
+  ambiguous_dm <- dm(
+    parent1 = tibble(key = 1),
+    parent2 = tibble(a__key = 1),
+    child = tibble(a__key = 1),
+    child__a = tibble(key = 1)
+  ) %>%
+    dm_add_pk(parent1, key) %>%
+    dm_add_pk(parent2, a__key) %>%
+    dm_add_fk(child, a__key, parent2) %>%
+    dm_add_fk(child__a, key, parent2)
+
+  queries <-
+    build_copy_queries(
+      src_db,
+      ambiguous_dm,
+      table_names =
+        names(ambiguous_dm) %>%
+          repair_table_names_for_db(temporary = FALSE, con = src_db, schema = NULL)
+    )
+
+  expect_equal(anyDuplicated(unlist(queries$index_name)), 0)
+
+  skip_if_not_installed("testthat", "3.1.1")
+
+  expect_snapshot(
+    variant = "duckdb",
+    {
+      as.list(queries)
+    }
+  )
+})

--- a/tests/testthat/test-build_copy_queries-maria.R
+++ b/tests/testthat/test-build_copy_queries-maria.R
@@ -1,0 +1,86 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for MariaDB
+test_that("build_copy_queries snapshot test for pixarfilms", {
+  src_db <- test_src_maria()
+
+  # build regular dm from `dm_pixarfilms()`
+  pixar_dm <-
+    # fetch sample dm
+    dm_pixarfilms() %>%
+    # make it regular
+    dm_filter(pixar_films = (!is.na(film))) %>%
+    dm_select_tbl(-pixar_people)
+
+  skip_if_not_installed("testthat", "3.1.1")
+
+  expect_snapshot(
+    variant = "maria",
+    {
+      pixar_dm %>%
+        build_copy_queries(
+          src_db,
+          .
+        ) %>%
+        as.list() # to print full queries
+    }
+  )
+})
+
+
+test_that("build_copy_queries snapshot test for dm_for_filter()", {
+  src_db <- test_src_maria()
+
+  skip_if_not_installed("testthat", "3.1.1")
+
+  expect_snapshot(
+    variant = "maria",
+    {
+      dm_for_filter() %>%
+        collect() %>%
+        build_copy_queries(
+          src_db,
+          .
+        ) %>%
+        as.list() # to print full queries
+    }
+  )
+})
+
+
+test_that("build_copy_queries avoids duplicate indexes", {
+  src_db <- test_src_maria()
+
+  # build a dm whose index might be duplicated if naively build (child__a__key)
+  ambiguous_dm <- dm(
+    parent1 = tibble(key = 1),
+    parent2 = tibble(a__key = 1),
+    child = tibble(a__key = 1),
+    child__a = tibble(key = 1)
+  ) %>%
+    dm_add_pk(parent1, key) %>%
+    dm_add_pk(parent2, a__key) %>%
+    dm_add_fk(child, a__key, parent2) %>%
+    dm_add_fk(child__a, key, parent2)
+
+  queries <-
+    build_copy_queries(
+      src_db,
+      ambiguous_dm,
+      table_names =
+        names(ambiguous_dm) %>%
+          repair_table_names_for_db(temporary = FALSE, con = src_db, schema = NULL)
+    )
+
+  expect_equal(anyDuplicated(unlist(queries$index_name)), 0)
+
+  skip_if_not_installed("testthat", "3.1.1")
+
+  expect_snapshot(
+    variant = "maria",
+    {
+      as.list(queries)
+    }
+  )
+})

--- a/tests/testthat/test-build_copy_queries-mssql.R
+++ b/tests/testthat/test-build_copy_queries-mssql.R
@@ -1,0 +1,86 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for SQL Server
+test_that("build_copy_queries snapshot test for pixarfilms", {
+  src_db <- test_src_mssql()
+
+  # build regular dm from `dm_pixarfilms()`
+  pixar_dm <-
+    # fetch sample dm
+    dm_pixarfilms() %>%
+    # make it regular
+    dm_filter(pixar_films = (!is.na(film))) %>%
+    dm_select_tbl(-pixar_people)
+
+  skip_if_not_installed("testthat", "3.1.1")
+
+  expect_snapshot(
+    variant = "mssql",
+    {
+      pixar_dm %>%
+        build_copy_queries(
+          src_db,
+          .
+        ) %>%
+        as.list() # to print full queries
+    }
+  )
+})
+
+
+test_that("build_copy_queries snapshot test for dm_for_filter()", {
+  src_db <- test_src_mssql()
+
+  skip_if_not_installed("testthat", "3.1.1")
+
+  expect_snapshot(
+    variant = "mssql",
+    {
+      dm_for_filter() %>%
+        collect() %>%
+        build_copy_queries(
+          src_db,
+          .
+        ) %>%
+        as.list() # to print full queries
+    }
+  )
+})
+
+
+test_that("build_copy_queries avoids duplicate indexes", {
+  src_db <- test_src_mssql()
+
+  # build a dm whose index might be duplicated if naively build (child__a__key)
+  ambiguous_dm <- dm(
+    parent1 = tibble(key = 1),
+    parent2 = tibble(a__key = 1),
+    child = tibble(a__key = 1),
+    child__a = tibble(key = 1)
+  ) %>%
+    dm_add_pk(parent1, key) %>%
+    dm_add_pk(parent2, a__key) %>%
+    dm_add_fk(child, a__key, parent2) %>%
+    dm_add_fk(child__a, key, parent2)
+
+  queries <-
+    build_copy_queries(
+      src_db,
+      ambiguous_dm,
+      table_names =
+        names(ambiguous_dm) %>%
+          repair_table_names_for_db(temporary = FALSE, con = src_db, schema = NULL)
+    )
+
+  expect_equal(anyDuplicated(unlist(queries$index_name)), 0)
+
+  skip_if_not_installed("testthat", "3.1.1")
+
+  expect_snapshot(
+    variant = "mssql",
+    {
+      as.list(queries)
+    }
+  )
+})

--- a/tests/testthat/test-build_copy_queries-postgres.R
+++ b/tests/testthat/test-build_copy_queries-postgres.R
@@ -1,5 +1,9 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for PostgreSQL
 test_that("build_copy_queries snapshot test for pixarfilms", {
-  src_db <- my_db_test_src()
+  src_db <- test_src_postgres()
 
   # build regular dm from `dm_pixarfilms()`
   pixar_dm <-
@@ -12,7 +16,7 @@ test_that("build_copy_queries snapshot test for pixarfilms", {
   skip_if_not_installed("testthat", "3.1.1")
 
   expect_snapshot(
-    variant = my_test_src_name,
+    variant = "postgres",
     {
       pixar_dm %>%
         build_copy_queries(
@@ -26,12 +30,12 @@ test_that("build_copy_queries snapshot test for pixarfilms", {
 
 
 test_that("build_copy_queries snapshot test for dm_for_filter()", {
-  src_db <- my_db_test_src()
+  src_db <- test_src_postgres()
 
   skip_if_not_installed("testthat", "3.1.1")
 
   expect_snapshot(
-    variant = my_test_src_name,
+    variant = "postgres",
     {
       dm_for_filter() %>%
         collect() %>%
@@ -46,7 +50,7 @@ test_that("build_copy_queries snapshot test for dm_for_filter()", {
 
 
 test_that("build_copy_queries avoids duplicate indexes", {
-  src_db <- my_db_test_src()
+  src_db <- test_src_postgres()
 
   # build a dm whose index might be duplicated if naively build (child__a__key)
   ambiguous_dm <- dm(
@@ -74,7 +78,7 @@ test_that("build_copy_queries avoids duplicate indexes", {
   skip_if_not_installed("testthat", "3.1.1")
 
   expect_snapshot(
-    variant = my_test_src_name,
+    variant = "postgres",
     {
       as.list(queries)
     }

--- a/tests/testthat/test-build_copy_queries-sqlite.R
+++ b/tests/testthat/test-build_copy_queries-sqlite.R
@@ -1,0 +1,86 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for SQLite
+test_that("build_copy_queries snapshot test for pixarfilms", {
+  src_db <- test_src_sqlite()
+
+  # build regular dm from `dm_pixarfilms()`
+  pixar_dm <-
+    # fetch sample dm
+    dm_pixarfilms() %>%
+    # make it regular
+    dm_filter(pixar_films = (!is.na(film))) %>%
+    dm_select_tbl(-pixar_people)
+
+  skip_if_not_installed("testthat", "3.1.1")
+
+  expect_snapshot(
+    variant = "sqlite",
+    {
+      pixar_dm %>%
+        build_copy_queries(
+          src_db,
+          .
+        ) %>%
+        as.list() # to print full queries
+    }
+  )
+})
+
+
+test_that("build_copy_queries snapshot test for dm_for_filter()", {
+  src_db <- test_src_sqlite()
+
+  skip_if_not_installed("testthat", "3.1.1")
+
+  expect_snapshot(
+    variant = "sqlite",
+    {
+      dm_for_filter() %>%
+        collect() %>%
+        build_copy_queries(
+          src_db,
+          .
+        ) %>%
+        as.list() # to print full queries
+    }
+  )
+})
+
+
+test_that("build_copy_queries avoids duplicate indexes", {
+  src_db <- test_src_sqlite()
+
+  # build a dm whose index might be duplicated if naively build (child__a__key)
+  ambiguous_dm <- dm(
+    parent1 = tibble(key = 1),
+    parent2 = tibble(a__key = 1),
+    child = tibble(a__key = 1),
+    child__a = tibble(key = 1)
+  ) %>%
+    dm_add_pk(parent1, key) %>%
+    dm_add_pk(parent2, a__key) %>%
+    dm_add_fk(child, a__key, parent2) %>%
+    dm_add_fk(child__a, key, parent2)
+
+  queries <-
+    build_copy_queries(
+      src_db,
+      ambiguous_dm,
+      table_names =
+        names(ambiguous_dm) %>%
+          repair_table_names_for_db(temporary = FALSE, con = src_db, schema = NULL)
+    )
+
+  expect_equal(anyDuplicated(unlist(queries$index_name)), 0)
+
+  skip_if_not_installed("testthat", "3.1.1")
+
+  expect_snapshot(
+    variant = "sqlite",
+    {
+      as.list(queries)
+    }
+  )
+})

--- a/tests/testthat/test-flatten-df.R
+++ b/tests/testthat/test-flatten-df.R
@@ -1,0 +1,419 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for data frames
+test_that("`dm_flatten_to_tbl()` does the right things for 'left_join()'", {
+  skip_if_src_not(c("df", "duckdb"))
+
+  local_options(
+    pillar.min_title_chars = NULL,
+    pillar.max_title_chars = NULL,
+    pillar.max_footer_lines = NULL,
+    pillar.bold = NULL,
+  )
+
+  # FIXME: Debug GHA fail
+  # for left join test the basic flattening also on all DBs
+  # expect_equivalent_tbl(
+  #   expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact)),
+  #   result_from_flatten_new()
+  # )
+
+  expect_snapshot(
+    {
+      prepare_dm_for_flatten(dm_for_flatten(), tables = c("fact", "dim_1", "dim_2", "dim_3", "dim_4"), gotta_rename = TRUE) %>%
+        dm_get_tables()
+      dm_flatten_to_tbl(dm_for_flatten(), fact)
+      result_from_flatten_new()
+    },
+    variant = "df"
+  )
+
+  # a one-table-dm
+  expect_equivalent_tbl(
+    dm_for_flatten() %>%
+      dm_select_tbl(fact) %>%
+      dm_flatten_to_tbl(fact),
+    fact()
+  )
+
+  # explicitly choose parent tables
+  out <- expect_message_obj(dm_flatten_to_tbl(
+    dm_for_flatten(), fact, dim_1, dim_2
+  ))
+  expect_equivalent_tbl(
+    out,
+    left_join(
+      fact_clean_new(),
+      dim_1_clean_new(),
+      by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2")
+    ) %>%
+      left_join(dim_2_clean_new(), by = c("dim_2_key" = "dim_2_pk"))
+  )
+
+  # change order of parent tables
+  out <- expect_message_obj(dm_flatten_to_tbl(
+    dm_for_flatten(), fact, dim_2, dim_1
+  ))
+  expect_equivalent_tbl(
+    out,
+    left_join(
+      fact_clean_new(), dim_2_clean_new(),
+      by = c("dim_2_key" = "dim_2_pk")
+    ) %>%
+      left_join(dim_1_clean_new(), by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2"))
+  )
+
+  # with grandparent table
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3),
+    class = "only_parents"
+  )
+
+  # table unreachable
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_for_filter(), tf_2, tf_3, tf_4),
+    class = "tables_not_reachable_from_start"
+  )
+
+  # deeper hierarchy available and `auto_detect = TRUE`
+  # for flatten: columns from tf_5 + tf_4 + tf_4_2 + tf_6 are combined in one table, 8 cols in total
+  expect_identical(
+    ncol(dm_flatten_to_tbl(dm_more_complex(), tf_5)),
+    11L
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'inner_join()'", {
+  local_options(
+    pillar.min_title_chars = NULL,
+    pillar.max_title_chars = NULL,
+    pillar.max_footer_lines = NULL,
+    pillar.bold = NULL,
+  )
+
+  out <- expect_message_obj(
+    arrange(
+      dm_flatten_to_tbl(dm_for_flatten(), fact, .join = inner_join),
+      pick(everything())
+    )
+  )
+  # FIXME: Debug GHA fail
+  # expect_equivalent_tbl(out, result_from_flatten_new())
+  expect_snapshot(
+    {
+      out
+    },
+    variant = "df"
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'full_join()'", {
+  skip_if_src("sqlite")
+  skip_if_src("maria")
+  out <- expect_message_obj(dm_flatten_to_tbl(
+    dm_for_flatten(), fact,
+    .join = full_join
+  ))
+  expect_equivalent_tbl(
+    out,
+    fact_clean_new() %>%
+      full_join(dim_1_clean_new(), by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2")) %>%
+      full_join(dim_2_clean_new(), by = c("dim_2_key" = "dim_2_pk")) %>%
+      full_join(dim_3_clean_new(), by = c("dim_3_key" = "dim_3_pk")) %>%
+      full_join(dim_4_clean_new(), by = c("dim_4_key" = "dim_4_pk"))
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'semi_join()'", {
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(dm_for_flatten(), fact, .join = semi_join),
+    fact()
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'anti_join()'", {
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(dm_for_flatten(), fact, .join = anti_join),
+    fact() %>% filter(1 == 0)
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'nest_join()'", {
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_for_flatten(), fact, .join = nest_join),
+    class = "no_flatten_with_nest_join"
+  )
+})
+
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'right_join()'", {
+  skip_if_src("sqlite")
+  expect_equivalent_tbl(
+    expect_message_obj(expect_warning_obj(
+      dm_flatten_to_tbl(dm_for_flatten(), fact, .join = right_join),
+      "right_join"
+    )),
+    fact_clean_new() %>%
+      right_join(dim_1_clean_new(), by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2")) %>%
+      right_join(dim_2_clean_new(), by = c("dim_2_key" = "dim_2_pk")) %>%
+      right_join(dim_3_clean_new(), by = c("dim_3_key" = "dim_3_pk")) %>%
+      right_join(dim_4_clean_new(), by = c("dim_4_key" = "dim_4_pk"))
+  )
+
+  # change order of parent tables
+  out <- expect_message_obj(dm_flatten_to_tbl(
+    dm_for_flatten(), fact, dim_2, dim_1,
+    .join = right_join
+  ))
+  expect_equivalent_tbl(
+    out,
+    right_join(
+      fact_clean_new(),
+      dim_2_clean_new(),
+      by = c("dim_2_key" = "dim_2_pk")
+    ) %>%
+      right_join(dim_1_clean_new(), by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2"))
+  )
+})
+
+test_that("`dm_squash_to_tbl()` is deprecated but still works", {
+  # with grandparent table
+  # left_join:
+  expect_deprecated(
+    expect_equivalent_tbl(
+      dm_squash_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3),
+      tf_5() %>%
+        left_join(tf_4(), by = c("l" = "h")) %>%
+        left_join(tf_3(), by = c("j" = "f", "j1" = "f1"))
+    )
+  )
+})
+
+test_that("`dm_flatten_to_tbl(.recursive = TRUE)` does the right things", {
+  # with grandparent table
+  # left_join:
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .recursive = TRUE),
+    tf_5() %>%
+      left_join(tf_4(), by = c("l" = "h")) %>%
+      left_join(tf_3(), by = c("j" = "f", "j1" = "f1"))
+  )
+
+  # deeper hierarchy available and `auto_detect = TRUE`
+  # for flatten: columns from tf_5 + tf_4 + tf_3 + tf_4_2 + tf_6 are combined in one table, 10 cols in total
+  expect_identical(
+    ncol(dm_flatten_to_tbl(dm_more_complex(), tf_5, .recursive = TRUE)),
+    12L
+  )
+
+
+  # semi_join:
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .join = semi_join, .recursive = TRUE),
+    class = "squash_limited"
+  )
+
+  # anti_join:
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .join = anti_join, .recursive = TRUE),
+    class = "squash_limited"
+  )
+
+  # fails when there is a cycle:
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_for_filter_w_cycle(), tf_5, .recursive = TRUE),
+    "no_cycles"
+  )
+
+  skip_if_src("sqlite")
+  skip_if_src("maria")
+
+  # full_join:
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .join = full_join, .recursive = TRUE),
+    tf_5() %>%
+      full_join(tf_4(), by = c("l" = "h")) %>%
+      full_join(tf_3(), by = c("j" = "f", "j1" = "f1"))
+  )
+
+  # skipping inner_join, not gaining new info
+
+  # right_join:
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .join = right_join, .recursive = TRUE),
+    class = "squash_limited"
+  )
+})
+
+test_that("prepare_dm_for_flatten() works", {
+  # with rename
+  out <- expect_message_obj(prepare_dm_for_flatten(
+    dm_for_flatten(),
+    c("fact", "dim_1", "dim_3"),
+    gotta_rename = TRUE
+  ))
+  expect_equivalent_dm(
+    out,
+    dm_select_tbl(dm_for_flatten(), fact, dim_1, dim_3) %>% dm_disambiguate_cols(.quiet = TRUE)
+  )
+
+  # without rename
+  expect_equivalent_dm(
+    prepare_dm_for_flatten(dm_for_flatten(), c("fact", "dim_1", "dim_3"), gotta_rename = FALSE),
+    dm_select_tbl(dm_for_flatten(), fact, dim_1, dim_3)
+  )
+})
+
+test_that("tidyselect works for flatten", {
+  # test if deselecting works
+  expect_equivalent_tbl(
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, -dim_2, dim_3, -dim_4, dim_1)),
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, dim_1, dim_3))
+  )
+
+  # test if select helpers work
+  expect_equivalent_tbl(
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, ends_with("3"), ends_with("1"))),
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, dim_3, dim_1))
+  )
+
+  expect_equivalent_tbl(
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, everything())),
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact))
+  )
+
+  # if only deselecting one potential candidate for flattening, the tables that are not
+  # candidates will generally be part of the choice
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_for_filter(), tf_2, -tf_1),
+    class = "tables_not_reachable_from_start"
+  )
+
+  # trying to deselect table that doesn't exist:
+  expect_error(
+    dm_flatten_to_tbl(dm_for_filter(), tf_2, -tf_101),
+    class = "vctrs_error_subscript"
+  )
+})
+
+test_that("`dm_join_to_tbl()` works", {
+  expect_deprecated(
+    expect_equivalent_tbl(
+      expect_message_obj(dm_join_to_tbl(dm_for_flatten(), fact, dim_3), "Renaming"),
+      left_join(
+        fact_clean(),
+        dim_3_clean(),
+        by = c("dim_3_key" = "dim_3_pk")
+      )
+    )
+  )
+
+  expect_dm_error(
+    expect_deprecated(dm_join_to_tbl(dm_for_filter(), tf_7, tf_8)),
+    "table_not_in_dm"
+  )
+})
+
+# tests that do not work on DB when keys are set ('bad_dm' and 'nycflights'; currently PG and MSSQL)
+test_that("tests with 'bad_dm' work", {
+  # can't create bad_dm() on Postgres due to strict constraint checks
+  skip_if_src("postgres")
+
+  # duckdb doesn't work before R 4.0
+  skip_if(getRversion() < "4.0")
+
+
+  # flatten bad_dm() (no referential integrity)
+  if (is_db(test_src_df()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+    expect_equivalent_tbl(
+      dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3),
+      tbl_1() %>%
+        left_join(tbl_2(), by = c("a" = "id", "x")) %>%
+        left_join(tbl_3(), by = c("b" = "id"))
+    )
+  }
+
+
+  skip_if_src("maria")
+
+  # filtered `dm`
+  bad_filtered_dm <- dm_filter(bad_dm(), tbl_1 = (a != 4))
+
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(bad_filtered_dm, tbl_1),
+    bad_filtered_dm %>% dm_flatten_to_tbl(tbl_1)
+  )
+
+
+  # filtered `dm`
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(bad_filtered_dm, tbl_1, .join = semi_join),
+    bad_filtered_dm %>% dm_flatten_to_tbl(tbl_1, .join = semi_join)
+  )
+
+  # fails when there is a cycle
+  expect_dm_error(
+    dm_nycflights_small() %>%
+      dm_add_fk(flights, origin, airports) %>%
+      dm_flatten_to_tbl(flights),
+    "no_cycles"
+  )
+})
+
+test_that("tests with 'bad_dm' work (2)", {
+  # can't create bad_dm() on Postgres due to strict constraint checks
+  skip_if_src("postgres")
+
+  # full & right join not available on SQLite and MariaDB
+  skip_if_src("sqlite", "maria")
+
+  # duckdb doesn't work before R 4.0
+  skip_if(getRversion() < "4.0")
+
+  bad_filtered_dm <- dm_filter(bad_dm(), tbl_1 = (a != 4))
+
+  # flatten bad_dm() (no referential integrity)
+  if (is_db(test_src_df()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+    expect_equivalent_tbl(
+      dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3, .join = full_join),
+      tbl_1() %>%
+        full_join(tbl_2(), by = c("a" = "id", "x")) %>%
+        full_join(tbl_3(), by = c("b" = "id"))
+    )
+  }
+})
+
+test_that("tests with 'bad_dm' work (3)", {
+  # can't create bad_dm() on Postgres due to strict constraint checks
+  skip_if_src("postgres")
+
+  # full & right join not available on SQLite
+  skip_if_src("sqlite")
+
+  # duckdb doesn't work before R 4.0
+  skip_if(getRversion() < "4.0")
+
+  bad_filtered_dm <- dm_filter(bad_dm(), tbl_1 = (a != 4))
+
+  # flatten bad_dm() (no referential integrity)
+  if (is_db(test_src_df()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+    expect_equivalent_tbl(
+      dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3, .join = right_join),
+      tbl_1() %>%
+        right_join(tbl_2(), by = c("a" = "id", "x")) %>%
+        right_join(tbl_3(), by = c("b" = "id"))
+    )
+  }
+
+
+  # flatten bad_dm() (no referential integrity); different order
+  if (is_db(test_src_df()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+    expect_equivalent_tbl(
+      dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_3, tbl_2, .join = right_join),
+      tbl_1() %>%
+        right_join(tbl_3(), by = c("b" = "id")) %>%
+        right_join(tbl_2(), by = c("a" = "id", "x"))
+    )
+  }
+})

--- a/tests/testthat/test-flatten-duckdb.R
+++ b/tests/testthat/test-flatten-duckdb.R
@@ -1,0 +1,419 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for DuckDB
+test_that("`dm_flatten_to_tbl()` does the right things for 'left_join()'", {
+  skip_if_src_not(c("df", "duckdb"))
+
+  local_options(
+    pillar.min_title_chars = NULL,
+    pillar.max_title_chars = NULL,
+    pillar.max_footer_lines = NULL,
+    pillar.bold = NULL,
+  )
+
+  # FIXME: Debug GHA fail
+  # for left join test the basic flattening also on all DBs
+  # expect_equivalent_tbl(
+  #   expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact)),
+  #   result_from_flatten_new()
+  # )
+
+  expect_snapshot(
+    {
+      prepare_dm_for_flatten(dm_for_flatten(), tables = c("fact", "dim_1", "dim_2", "dim_3", "dim_4"), gotta_rename = TRUE) %>%
+        dm_get_tables()
+      dm_flatten_to_tbl(dm_for_flatten(), fact)
+      result_from_flatten_new()
+    },
+    variant = "duckdb"
+  )
+
+  # a one-table-dm
+  expect_equivalent_tbl(
+    dm_for_flatten() %>%
+      dm_select_tbl(fact) %>%
+      dm_flatten_to_tbl(fact),
+    fact()
+  )
+
+  # explicitly choose parent tables
+  out <- expect_message_obj(dm_flatten_to_tbl(
+    dm_for_flatten(), fact, dim_1, dim_2
+  ))
+  expect_equivalent_tbl(
+    out,
+    left_join(
+      fact_clean_new(),
+      dim_1_clean_new(),
+      by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2")
+    ) %>%
+      left_join(dim_2_clean_new(), by = c("dim_2_key" = "dim_2_pk"))
+  )
+
+  # change order of parent tables
+  out <- expect_message_obj(dm_flatten_to_tbl(
+    dm_for_flatten(), fact, dim_2, dim_1
+  ))
+  expect_equivalent_tbl(
+    out,
+    left_join(
+      fact_clean_new(), dim_2_clean_new(),
+      by = c("dim_2_key" = "dim_2_pk")
+    ) %>%
+      left_join(dim_1_clean_new(), by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2"))
+  )
+
+  # with grandparent table
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3),
+    class = "only_parents"
+  )
+
+  # table unreachable
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_for_filter(), tf_2, tf_3, tf_4),
+    class = "tables_not_reachable_from_start"
+  )
+
+  # deeper hierarchy available and `auto_detect = TRUE`
+  # for flatten: columns from tf_5 + tf_4 + tf_4_2 + tf_6 are combined in one table, 8 cols in total
+  expect_identical(
+    ncol(dm_flatten_to_tbl(dm_more_complex(), tf_5)),
+    11L
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'inner_join()'", {
+  local_options(
+    pillar.min_title_chars = NULL,
+    pillar.max_title_chars = NULL,
+    pillar.max_footer_lines = NULL,
+    pillar.bold = NULL,
+  )
+
+  out <- expect_message_obj(
+    arrange(
+      dm_flatten_to_tbl(dm_for_flatten(), fact, .join = inner_join),
+      pick(everything())
+    )
+  )
+  # FIXME: Debug GHA fail
+  # expect_equivalent_tbl(out, result_from_flatten_new())
+  expect_snapshot(
+    {
+      out
+    },
+    variant = "duckdb"
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'full_join()'", {
+  skip_if_src("sqlite")
+  skip_if_src("maria")
+  out <- expect_message_obj(dm_flatten_to_tbl(
+    dm_for_flatten(), fact,
+    .join = full_join
+  ))
+  expect_equivalent_tbl(
+    out,
+    fact_clean_new() %>%
+      full_join(dim_1_clean_new(), by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2")) %>%
+      full_join(dim_2_clean_new(), by = c("dim_2_key" = "dim_2_pk")) %>%
+      full_join(dim_3_clean_new(), by = c("dim_3_key" = "dim_3_pk")) %>%
+      full_join(dim_4_clean_new(), by = c("dim_4_key" = "dim_4_pk"))
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'semi_join()'", {
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(dm_for_flatten(), fact, .join = semi_join),
+    fact()
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'anti_join()'", {
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(dm_for_flatten(), fact, .join = anti_join),
+    fact() %>% filter(1 == 0)
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'nest_join()'", {
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_for_flatten(), fact, .join = nest_join),
+    class = "no_flatten_with_nest_join"
+  )
+})
+
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'right_join()'", {
+  skip_if_src("sqlite")
+  expect_equivalent_tbl(
+    expect_message_obj(expect_warning_obj(
+      dm_flatten_to_tbl(dm_for_flatten(), fact, .join = right_join),
+      "right_join"
+    )),
+    fact_clean_new() %>%
+      right_join(dim_1_clean_new(), by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2")) %>%
+      right_join(dim_2_clean_new(), by = c("dim_2_key" = "dim_2_pk")) %>%
+      right_join(dim_3_clean_new(), by = c("dim_3_key" = "dim_3_pk")) %>%
+      right_join(dim_4_clean_new(), by = c("dim_4_key" = "dim_4_pk"))
+  )
+
+  # change order of parent tables
+  out <- expect_message_obj(dm_flatten_to_tbl(
+    dm_for_flatten(), fact, dim_2, dim_1,
+    .join = right_join
+  ))
+  expect_equivalent_tbl(
+    out,
+    right_join(
+      fact_clean_new(),
+      dim_2_clean_new(),
+      by = c("dim_2_key" = "dim_2_pk")
+    ) %>%
+      right_join(dim_1_clean_new(), by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2"))
+  )
+})
+
+test_that("`dm_squash_to_tbl()` is deprecated but still works", {
+  # with grandparent table
+  # left_join:
+  expect_deprecated(
+    expect_equivalent_tbl(
+      dm_squash_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3),
+      tf_5() %>%
+        left_join(tf_4(), by = c("l" = "h")) %>%
+        left_join(tf_3(), by = c("j" = "f", "j1" = "f1"))
+    )
+  )
+})
+
+test_that("`dm_flatten_to_tbl(.recursive = TRUE)` does the right things", {
+  # with grandparent table
+  # left_join:
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .recursive = TRUE),
+    tf_5() %>%
+      left_join(tf_4(), by = c("l" = "h")) %>%
+      left_join(tf_3(), by = c("j" = "f", "j1" = "f1"))
+  )
+
+  # deeper hierarchy available and `auto_detect = TRUE`
+  # for flatten: columns from tf_5 + tf_4 + tf_3 + tf_4_2 + tf_6 are combined in one table, 10 cols in total
+  expect_identical(
+    ncol(dm_flatten_to_tbl(dm_more_complex(), tf_5, .recursive = TRUE)),
+    12L
+  )
+
+
+  # semi_join:
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .join = semi_join, .recursive = TRUE),
+    class = "squash_limited"
+  )
+
+  # anti_join:
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .join = anti_join, .recursive = TRUE),
+    class = "squash_limited"
+  )
+
+  # fails when there is a cycle:
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_for_filter_w_cycle(), tf_5, .recursive = TRUE),
+    "no_cycles"
+  )
+
+  skip_if_src("sqlite")
+  skip_if_src("maria")
+
+  # full_join:
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .join = full_join, .recursive = TRUE),
+    tf_5() %>%
+      full_join(tf_4(), by = c("l" = "h")) %>%
+      full_join(tf_3(), by = c("j" = "f", "j1" = "f1"))
+  )
+
+  # skipping inner_join, not gaining new info
+
+  # right_join:
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .join = right_join, .recursive = TRUE),
+    class = "squash_limited"
+  )
+})
+
+test_that("prepare_dm_for_flatten() works", {
+  # with rename
+  out <- expect_message_obj(prepare_dm_for_flatten(
+    dm_for_flatten(),
+    c("fact", "dim_1", "dim_3"),
+    gotta_rename = TRUE
+  ))
+  expect_equivalent_dm(
+    out,
+    dm_select_tbl(dm_for_flatten(), fact, dim_1, dim_3) %>% dm_disambiguate_cols(.quiet = TRUE)
+  )
+
+  # without rename
+  expect_equivalent_dm(
+    prepare_dm_for_flatten(dm_for_flatten(), c("fact", "dim_1", "dim_3"), gotta_rename = FALSE),
+    dm_select_tbl(dm_for_flatten(), fact, dim_1, dim_3)
+  )
+})
+
+test_that("tidyselect works for flatten", {
+  # test if deselecting works
+  expect_equivalent_tbl(
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, -dim_2, dim_3, -dim_4, dim_1)),
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, dim_1, dim_3))
+  )
+
+  # test if select helpers work
+  expect_equivalent_tbl(
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, ends_with("3"), ends_with("1"))),
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, dim_3, dim_1))
+  )
+
+  expect_equivalent_tbl(
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, everything())),
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact))
+  )
+
+  # if only deselecting one potential candidate for flattening, the tables that are not
+  # candidates will generally be part of the choice
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_for_filter(), tf_2, -tf_1),
+    class = "tables_not_reachable_from_start"
+  )
+
+  # trying to deselect table that doesn't exist:
+  expect_error(
+    dm_flatten_to_tbl(dm_for_filter(), tf_2, -tf_101),
+    class = "vctrs_error_subscript"
+  )
+})
+
+test_that("`dm_join_to_tbl()` works", {
+  expect_deprecated(
+    expect_equivalent_tbl(
+      expect_message_obj(dm_join_to_tbl(dm_for_flatten(), fact, dim_3), "Renaming"),
+      left_join(
+        fact_clean(),
+        dim_3_clean(),
+        by = c("dim_3_key" = "dim_3_pk")
+      )
+    )
+  )
+
+  expect_dm_error(
+    expect_deprecated(dm_join_to_tbl(dm_for_filter(), tf_7, tf_8)),
+    "table_not_in_dm"
+  )
+})
+
+# tests that do not work on DB when keys are set ('bad_dm' and 'nycflights'; currently PG and MSSQL)
+test_that("tests with 'bad_dm' work", {
+  # can't create bad_dm() on Postgres due to strict constraint checks
+  skip_if_src("postgres")
+
+  # duckdb doesn't work before R 4.0
+  skip_if(getRversion() < "4.0")
+
+
+  # flatten bad_dm() (no referential integrity)
+  if (is_db(test_src_duckdb()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+    expect_equivalent_tbl(
+      dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3),
+      tbl_1() %>%
+        left_join(tbl_2(), by = c("a" = "id", "x")) %>%
+        left_join(tbl_3(), by = c("b" = "id"))
+    )
+  }
+
+
+  skip_if_src("maria")
+
+  # filtered `dm`
+  bad_filtered_dm <- dm_filter(bad_dm(), tbl_1 = (a != 4))
+
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(bad_filtered_dm, tbl_1),
+    bad_filtered_dm %>% dm_flatten_to_tbl(tbl_1)
+  )
+
+
+  # filtered `dm`
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(bad_filtered_dm, tbl_1, .join = semi_join),
+    bad_filtered_dm %>% dm_flatten_to_tbl(tbl_1, .join = semi_join)
+  )
+
+  # fails when there is a cycle
+  expect_dm_error(
+    dm_nycflights_small() %>%
+      dm_add_fk(flights, origin, airports) %>%
+      dm_flatten_to_tbl(flights),
+    "no_cycles"
+  )
+})
+
+test_that("tests with 'bad_dm' work (2)", {
+  # can't create bad_dm() on Postgres due to strict constraint checks
+  skip_if_src("postgres")
+
+  # full & right join not available on SQLite and MariaDB
+  skip_if_src("sqlite", "maria")
+
+  # duckdb doesn't work before R 4.0
+  skip_if(getRversion() < "4.0")
+
+  bad_filtered_dm <- dm_filter(bad_dm(), tbl_1 = (a != 4))
+
+  # flatten bad_dm() (no referential integrity)
+  if (is_db(test_src_duckdb()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+    expect_equivalent_tbl(
+      dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3, .join = full_join),
+      tbl_1() %>%
+        full_join(tbl_2(), by = c("a" = "id", "x")) %>%
+        full_join(tbl_3(), by = c("b" = "id"))
+    )
+  }
+})
+
+test_that("tests with 'bad_dm' work (3)", {
+  # can't create bad_dm() on Postgres due to strict constraint checks
+  skip_if_src("postgres")
+
+  # full & right join not available on SQLite
+  skip_if_src("sqlite")
+
+  # duckdb doesn't work before R 4.0
+  skip_if(getRversion() < "4.0")
+
+  bad_filtered_dm <- dm_filter(bad_dm(), tbl_1 = (a != 4))
+
+  # flatten bad_dm() (no referential integrity)
+  if (is_db(test_src_duckdb()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+    expect_equivalent_tbl(
+      dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3, .join = right_join),
+      tbl_1() %>%
+        right_join(tbl_2(), by = c("a" = "id", "x")) %>%
+        right_join(tbl_3(), by = c("b" = "id"))
+    )
+  }
+
+
+  # flatten bad_dm() (no referential integrity); different order
+  if (is_db(test_src_duckdb()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+    expect_equivalent_tbl(
+      dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_3, tbl_2, .join = right_join),
+      tbl_1() %>%
+        right_join(tbl_3(), by = c("b" = "id")) %>%
+        right_join(tbl_2(), by = c("a" = "id", "x"))
+    )
+  }
+})

--- a/tests/testthat/test-flatten-maria.R
+++ b/tests/testthat/test-flatten-maria.R
@@ -1,0 +1,419 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for MariaDB
+test_that("`dm_flatten_to_tbl()` does the right things for 'left_join()'", {
+  skip_if_src_not(c("df", "duckdb"))
+
+  local_options(
+    pillar.min_title_chars = NULL,
+    pillar.max_title_chars = NULL,
+    pillar.max_footer_lines = NULL,
+    pillar.bold = NULL,
+  )
+
+  # FIXME: Debug GHA fail
+  # for left join test the basic flattening also on all DBs
+  # expect_equivalent_tbl(
+  #   expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact)),
+  #   result_from_flatten_new()
+  # )
+
+  expect_snapshot(
+    {
+      prepare_dm_for_flatten(dm_for_flatten(), tables = c("fact", "dim_1", "dim_2", "dim_3", "dim_4"), gotta_rename = TRUE) %>%
+        dm_get_tables()
+      dm_flatten_to_tbl(dm_for_flatten(), fact)
+      result_from_flatten_new()
+    },
+    variant = "maria"
+  )
+
+  # a one-table-dm
+  expect_equivalent_tbl(
+    dm_for_flatten() %>%
+      dm_select_tbl(fact) %>%
+      dm_flatten_to_tbl(fact),
+    fact()
+  )
+
+  # explicitly choose parent tables
+  out <- expect_message_obj(dm_flatten_to_tbl(
+    dm_for_flatten(), fact, dim_1, dim_2
+  ))
+  expect_equivalent_tbl(
+    out,
+    left_join(
+      fact_clean_new(),
+      dim_1_clean_new(),
+      by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2")
+    ) %>%
+      left_join(dim_2_clean_new(), by = c("dim_2_key" = "dim_2_pk"))
+  )
+
+  # change order of parent tables
+  out <- expect_message_obj(dm_flatten_to_tbl(
+    dm_for_flatten(), fact, dim_2, dim_1
+  ))
+  expect_equivalent_tbl(
+    out,
+    left_join(
+      fact_clean_new(), dim_2_clean_new(),
+      by = c("dim_2_key" = "dim_2_pk")
+    ) %>%
+      left_join(dim_1_clean_new(), by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2"))
+  )
+
+  # with grandparent table
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3),
+    class = "only_parents"
+  )
+
+  # table unreachable
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_for_filter(), tf_2, tf_3, tf_4),
+    class = "tables_not_reachable_from_start"
+  )
+
+  # deeper hierarchy available and `auto_detect = TRUE`
+  # for flatten: columns from tf_5 + tf_4 + tf_4_2 + tf_6 are combined in one table, 8 cols in total
+  expect_identical(
+    ncol(dm_flatten_to_tbl(dm_more_complex(), tf_5)),
+    11L
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'inner_join()'", {
+  local_options(
+    pillar.min_title_chars = NULL,
+    pillar.max_title_chars = NULL,
+    pillar.max_footer_lines = NULL,
+    pillar.bold = NULL,
+  )
+
+  out <- expect_message_obj(
+    arrange(
+      dm_flatten_to_tbl(dm_for_flatten(), fact, .join = inner_join),
+      pick(everything())
+    )
+  )
+  # FIXME: Debug GHA fail
+  # expect_equivalent_tbl(out, result_from_flatten_new())
+  expect_snapshot(
+    {
+      out
+    },
+    variant = "maria"
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'full_join()'", {
+  skip_if_src("sqlite")
+  skip_if_src("maria")
+  out <- expect_message_obj(dm_flatten_to_tbl(
+    dm_for_flatten(), fact,
+    .join = full_join
+  ))
+  expect_equivalent_tbl(
+    out,
+    fact_clean_new() %>%
+      full_join(dim_1_clean_new(), by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2")) %>%
+      full_join(dim_2_clean_new(), by = c("dim_2_key" = "dim_2_pk")) %>%
+      full_join(dim_3_clean_new(), by = c("dim_3_key" = "dim_3_pk")) %>%
+      full_join(dim_4_clean_new(), by = c("dim_4_key" = "dim_4_pk"))
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'semi_join()'", {
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(dm_for_flatten(), fact, .join = semi_join),
+    fact()
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'anti_join()'", {
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(dm_for_flatten(), fact, .join = anti_join),
+    fact() %>% filter(1 == 0)
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'nest_join()'", {
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_for_flatten(), fact, .join = nest_join),
+    class = "no_flatten_with_nest_join"
+  )
+})
+
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'right_join()'", {
+  skip_if_src("sqlite")
+  expect_equivalent_tbl(
+    expect_message_obj(expect_warning_obj(
+      dm_flatten_to_tbl(dm_for_flatten(), fact, .join = right_join),
+      "right_join"
+    )),
+    fact_clean_new() %>%
+      right_join(dim_1_clean_new(), by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2")) %>%
+      right_join(dim_2_clean_new(), by = c("dim_2_key" = "dim_2_pk")) %>%
+      right_join(dim_3_clean_new(), by = c("dim_3_key" = "dim_3_pk")) %>%
+      right_join(dim_4_clean_new(), by = c("dim_4_key" = "dim_4_pk"))
+  )
+
+  # change order of parent tables
+  out <- expect_message_obj(dm_flatten_to_tbl(
+    dm_for_flatten(), fact, dim_2, dim_1,
+    .join = right_join
+  ))
+  expect_equivalent_tbl(
+    out,
+    right_join(
+      fact_clean_new(),
+      dim_2_clean_new(),
+      by = c("dim_2_key" = "dim_2_pk")
+    ) %>%
+      right_join(dim_1_clean_new(), by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2"))
+  )
+})
+
+test_that("`dm_squash_to_tbl()` is deprecated but still works", {
+  # with grandparent table
+  # left_join:
+  expect_deprecated(
+    expect_equivalent_tbl(
+      dm_squash_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3),
+      tf_5() %>%
+        left_join(tf_4(), by = c("l" = "h")) %>%
+        left_join(tf_3(), by = c("j" = "f", "j1" = "f1"))
+    )
+  )
+})
+
+test_that("`dm_flatten_to_tbl(.recursive = TRUE)` does the right things", {
+  # with grandparent table
+  # left_join:
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .recursive = TRUE),
+    tf_5() %>%
+      left_join(tf_4(), by = c("l" = "h")) %>%
+      left_join(tf_3(), by = c("j" = "f", "j1" = "f1"))
+  )
+
+  # deeper hierarchy available and `auto_detect = TRUE`
+  # for flatten: columns from tf_5 + tf_4 + tf_3 + tf_4_2 + tf_6 are combined in one table, 10 cols in total
+  expect_identical(
+    ncol(dm_flatten_to_tbl(dm_more_complex(), tf_5, .recursive = TRUE)),
+    12L
+  )
+
+
+  # semi_join:
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .join = semi_join, .recursive = TRUE),
+    class = "squash_limited"
+  )
+
+  # anti_join:
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .join = anti_join, .recursive = TRUE),
+    class = "squash_limited"
+  )
+
+  # fails when there is a cycle:
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_for_filter_w_cycle(), tf_5, .recursive = TRUE),
+    "no_cycles"
+  )
+
+  skip_if_src("sqlite")
+  skip_if_src("maria")
+
+  # full_join:
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .join = full_join, .recursive = TRUE),
+    tf_5() %>%
+      full_join(tf_4(), by = c("l" = "h")) %>%
+      full_join(tf_3(), by = c("j" = "f", "j1" = "f1"))
+  )
+
+  # skipping inner_join, not gaining new info
+
+  # right_join:
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .join = right_join, .recursive = TRUE),
+    class = "squash_limited"
+  )
+})
+
+test_that("prepare_dm_for_flatten() works", {
+  # with rename
+  out <- expect_message_obj(prepare_dm_for_flatten(
+    dm_for_flatten(),
+    c("fact", "dim_1", "dim_3"),
+    gotta_rename = TRUE
+  ))
+  expect_equivalent_dm(
+    out,
+    dm_select_tbl(dm_for_flatten(), fact, dim_1, dim_3) %>% dm_disambiguate_cols(.quiet = TRUE)
+  )
+
+  # without rename
+  expect_equivalent_dm(
+    prepare_dm_for_flatten(dm_for_flatten(), c("fact", "dim_1", "dim_3"), gotta_rename = FALSE),
+    dm_select_tbl(dm_for_flatten(), fact, dim_1, dim_3)
+  )
+})
+
+test_that("tidyselect works for flatten", {
+  # test if deselecting works
+  expect_equivalent_tbl(
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, -dim_2, dim_3, -dim_4, dim_1)),
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, dim_1, dim_3))
+  )
+
+  # test if select helpers work
+  expect_equivalent_tbl(
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, ends_with("3"), ends_with("1"))),
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, dim_3, dim_1))
+  )
+
+  expect_equivalent_tbl(
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, everything())),
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact))
+  )
+
+  # if only deselecting one potential candidate for flattening, the tables that are not
+  # candidates will generally be part of the choice
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_for_filter(), tf_2, -tf_1),
+    class = "tables_not_reachable_from_start"
+  )
+
+  # trying to deselect table that doesn't exist:
+  expect_error(
+    dm_flatten_to_tbl(dm_for_filter(), tf_2, -tf_101),
+    class = "vctrs_error_subscript"
+  )
+})
+
+test_that("`dm_join_to_tbl()` works", {
+  expect_deprecated(
+    expect_equivalent_tbl(
+      expect_message_obj(dm_join_to_tbl(dm_for_flatten(), fact, dim_3), "Renaming"),
+      left_join(
+        fact_clean(),
+        dim_3_clean(),
+        by = c("dim_3_key" = "dim_3_pk")
+      )
+    )
+  )
+
+  expect_dm_error(
+    expect_deprecated(dm_join_to_tbl(dm_for_filter(), tf_7, tf_8)),
+    "table_not_in_dm"
+  )
+})
+
+# tests that do not work on DB when keys are set ('bad_dm' and 'nycflights'; currently PG and MSSQL)
+test_that("tests with 'bad_dm' work", {
+  # can't create bad_dm() on Postgres due to strict constraint checks
+  skip_if_src("postgres")
+
+  # duckdb doesn't work before R 4.0
+  skip_if(getRversion() < "4.0")
+
+
+  # flatten bad_dm() (no referential integrity)
+  if (is_db(test_src_maria()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+    expect_equivalent_tbl(
+      dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3),
+      tbl_1() %>%
+        left_join(tbl_2(), by = c("a" = "id", "x")) %>%
+        left_join(tbl_3(), by = c("b" = "id"))
+    )
+  }
+
+
+  skip_if_src("maria")
+
+  # filtered `dm`
+  bad_filtered_dm <- dm_filter(bad_dm(), tbl_1 = (a != 4))
+
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(bad_filtered_dm, tbl_1),
+    bad_filtered_dm %>% dm_flatten_to_tbl(tbl_1)
+  )
+
+
+  # filtered `dm`
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(bad_filtered_dm, tbl_1, .join = semi_join),
+    bad_filtered_dm %>% dm_flatten_to_tbl(tbl_1, .join = semi_join)
+  )
+
+  # fails when there is a cycle
+  expect_dm_error(
+    dm_nycflights_small() %>%
+      dm_add_fk(flights, origin, airports) %>%
+      dm_flatten_to_tbl(flights),
+    "no_cycles"
+  )
+})
+
+test_that("tests with 'bad_dm' work (2)", {
+  # can't create bad_dm() on Postgres due to strict constraint checks
+  skip_if_src("postgres")
+
+  # full & right join not available on SQLite and MariaDB
+  skip_if_src("sqlite", "maria")
+
+  # duckdb doesn't work before R 4.0
+  skip_if(getRversion() < "4.0")
+
+  bad_filtered_dm <- dm_filter(bad_dm(), tbl_1 = (a != 4))
+
+  # flatten bad_dm() (no referential integrity)
+  if (is_db(test_src_maria()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+    expect_equivalent_tbl(
+      dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3, .join = full_join),
+      tbl_1() %>%
+        full_join(tbl_2(), by = c("a" = "id", "x")) %>%
+        full_join(tbl_3(), by = c("b" = "id"))
+    )
+  }
+})
+
+test_that("tests with 'bad_dm' work (3)", {
+  # can't create bad_dm() on Postgres due to strict constraint checks
+  skip_if_src("postgres")
+
+  # full & right join not available on SQLite
+  skip_if_src("sqlite")
+
+  # duckdb doesn't work before R 4.0
+  skip_if(getRversion() < "4.0")
+
+  bad_filtered_dm <- dm_filter(bad_dm(), tbl_1 = (a != 4))
+
+  # flatten bad_dm() (no referential integrity)
+  if (is_db(test_src_maria()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+    expect_equivalent_tbl(
+      dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3, .join = right_join),
+      tbl_1() %>%
+        right_join(tbl_2(), by = c("a" = "id", "x")) %>%
+        right_join(tbl_3(), by = c("b" = "id"))
+    )
+  }
+
+
+  # flatten bad_dm() (no referential integrity); different order
+  if (is_db(test_src_maria()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+    expect_equivalent_tbl(
+      dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_3, tbl_2, .join = right_join),
+      tbl_1() %>%
+        right_join(tbl_3(), by = c("b" = "id")) %>%
+        right_join(tbl_2(), by = c("a" = "id", "x"))
+    )
+  }
+})

--- a/tests/testthat/test-flatten-mssql.R
+++ b/tests/testthat/test-flatten-mssql.R
@@ -1,0 +1,419 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for SQL Server
+test_that("`dm_flatten_to_tbl()` does the right things for 'left_join()'", {
+  skip_if_src_not(c("df", "duckdb"))
+
+  local_options(
+    pillar.min_title_chars = NULL,
+    pillar.max_title_chars = NULL,
+    pillar.max_footer_lines = NULL,
+    pillar.bold = NULL,
+  )
+
+  # FIXME: Debug GHA fail
+  # for left join test the basic flattening also on all DBs
+  # expect_equivalent_tbl(
+  #   expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact)),
+  #   result_from_flatten_new()
+  # )
+
+  expect_snapshot(
+    {
+      prepare_dm_for_flatten(dm_for_flatten(), tables = c("fact", "dim_1", "dim_2", "dim_3", "dim_4"), gotta_rename = TRUE) %>%
+        dm_get_tables()
+      dm_flatten_to_tbl(dm_for_flatten(), fact)
+      result_from_flatten_new()
+    },
+    variant = "mssql"
+  )
+
+  # a one-table-dm
+  expect_equivalent_tbl(
+    dm_for_flatten() %>%
+      dm_select_tbl(fact) %>%
+      dm_flatten_to_tbl(fact),
+    fact()
+  )
+
+  # explicitly choose parent tables
+  out <- expect_message_obj(dm_flatten_to_tbl(
+    dm_for_flatten(), fact, dim_1, dim_2
+  ))
+  expect_equivalent_tbl(
+    out,
+    left_join(
+      fact_clean_new(),
+      dim_1_clean_new(),
+      by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2")
+    ) %>%
+      left_join(dim_2_clean_new(), by = c("dim_2_key" = "dim_2_pk"))
+  )
+
+  # change order of parent tables
+  out <- expect_message_obj(dm_flatten_to_tbl(
+    dm_for_flatten(), fact, dim_2, dim_1
+  ))
+  expect_equivalent_tbl(
+    out,
+    left_join(
+      fact_clean_new(), dim_2_clean_new(),
+      by = c("dim_2_key" = "dim_2_pk")
+    ) %>%
+      left_join(dim_1_clean_new(), by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2"))
+  )
+
+  # with grandparent table
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3),
+    class = "only_parents"
+  )
+
+  # table unreachable
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_for_filter(), tf_2, tf_3, tf_4),
+    class = "tables_not_reachable_from_start"
+  )
+
+  # deeper hierarchy available and `auto_detect = TRUE`
+  # for flatten: columns from tf_5 + tf_4 + tf_4_2 + tf_6 are combined in one table, 8 cols in total
+  expect_identical(
+    ncol(dm_flatten_to_tbl(dm_more_complex(), tf_5)),
+    11L
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'inner_join()'", {
+  local_options(
+    pillar.min_title_chars = NULL,
+    pillar.max_title_chars = NULL,
+    pillar.max_footer_lines = NULL,
+    pillar.bold = NULL,
+  )
+
+  out <- expect_message_obj(
+    arrange(
+      dm_flatten_to_tbl(dm_for_flatten(), fact, .join = inner_join),
+      pick(everything())
+    )
+  )
+  # FIXME: Debug GHA fail
+  # expect_equivalent_tbl(out, result_from_flatten_new())
+  expect_snapshot(
+    {
+      out
+    },
+    variant = "mssql"
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'full_join()'", {
+  skip_if_src("sqlite")
+  skip_if_src("maria")
+  out <- expect_message_obj(dm_flatten_to_tbl(
+    dm_for_flatten(), fact,
+    .join = full_join
+  ))
+  expect_equivalent_tbl(
+    out,
+    fact_clean_new() %>%
+      full_join(dim_1_clean_new(), by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2")) %>%
+      full_join(dim_2_clean_new(), by = c("dim_2_key" = "dim_2_pk")) %>%
+      full_join(dim_3_clean_new(), by = c("dim_3_key" = "dim_3_pk")) %>%
+      full_join(dim_4_clean_new(), by = c("dim_4_key" = "dim_4_pk"))
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'semi_join()'", {
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(dm_for_flatten(), fact, .join = semi_join),
+    fact()
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'anti_join()'", {
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(dm_for_flatten(), fact, .join = anti_join),
+    fact() %>% filter(1 == 0)
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'nest_join()'", {
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_for_flatten(), fact, .join = nest_join),
+    class = "no_flatten_with_nest_join"
+  )
+})
+
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'right_join()'", {
+  skip_if_src("sqlite")
+  expect_equivalent_tbl(
+    expect_message_obj(expect_warning_obj(
+      dm_flatten_to_tbl(dm_for_flatten(), fact, .join = right_join),
+      "right_join"
+    )),
+    fact_clean_new() %>%
+      right_join(dim_1_clean_new(), by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2")) %>%
+      right_join(dim_2_clean_new(), by = c("dim_2_key" = "dim_2_pk")) %>%
+      right_join(dim_3_clean_new(), by = c("dim_3_key" = "dim_3_pk")) %>%
+      right_join(dim_4_clean_new(), by = c("dim_4_key" = "dim_4_pk"))
+  )
+
+  # change order of parent tables
+  out <- expect_message_obj(dm_flatten_to_tbl(
+    dm_for_flatten(), fact, dim_2, dim_1,
+    .join = right_join
+  ))
+  expect_equivalent_tbl(
+    out,
+    right_join(
+      fact_clean_new(),
+      dim_2_clean_new(),
+      by = c("dim_2_key" = "dim_2_pk")
+    ) %>%
+      right_join(dim_1_clean_new(), by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2"))
+  )
+})
+
+test_that("`dm_squash_to_tbl()` is deprecated but still works", {
+  # with grandparent table
+  # left_join:
+  expect_deprecated(
+    expect_equivalent_tbl(
+      dm_squash_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3),
+      tf_5() %>%
+        left_join(tf_4(), by = c("l" = "h")) %>%
+        left_join(tf_3(), by = c("j" = "f", "j1" = "f1"))
+    )
+  )
+})
+
+test_that("`dm_flatten_to_tbl(.recursive = TRUE)` does the right things", {
+  # with grandparent table
+  # left_join:
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .recursive = TRUE),
+    tf_5() %>%
+      left_join(tf_4(), by = c("l" = "h")) %>%
+      left_join(tf_3(), by = c("j" = "f", "j1" = "f1"))
+  )
+
+  # deeper hierarchy available and `auto_detect = TRUE`
+  # for flatten: columns from tf_5 + tf_4 + tf_3 + tf_4_2 + tf_6 are combined in one table, 10 cols in total
+  expect_identical(
+    ncol(dm_flatten_to_tbl(dm_more_complex(), tf_5, .recursive = TRUE)),
+    12L
+  )
+
+
+  # semi_join:
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .join = semi_join, .recursive = TRUE),
+    class = "squash_limited"
+  )
+
+  # anti_join:
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .join = anti_join, .recursive = TRUE),
+    class = "squash_limited"
+  )
+
+  # fails when there is a cycle:
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_for_filter_w_cycle(), tf_5, .recursive = TRUE),
+    "no_cycles"
+  )
+
+  skip_if_src("sqlite")
+  skip_if_src("maria")
+
+  # full_join:
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .join = full_join, .recursive = TRUE),
+    tf_5() %>%
+      full_join(tf_4(), by = c("l" = "h")) %>%
+      full_join(tf_3(), by = c("j" = "f", "j1" = "f1"))
+  )
+
+  # skipping inner_join, not gaining new info
+
+  # right_join:
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .join = right_join, .recursive = TRUE),
+    class = "squash_limited"
+  )
+})
+
+test_that("prepare_dm_for_flatten() works", {
+  # with rename
+  out <- expect_message_obj(prepare_dm_for_flatten(
+    dm_for_flatten(),
+    c("fact", "dim_1", "dim_3"),
+    gotta_rename = TRUE
+  ))
+  expect_equivalent_dm(
+    out,
+    dm_select_tbl(dm_for_flatten(), fact, dim_1, dim_3) %>% dm_disambiguate_cols(.quiet = TRUE)
+  )
+
+  # without rename
+  expect_equivalent_dm(
+    prepare_dm_for_flatten(dm_for_flatten(), c("fact", "dim_1", "dim_3"), gotta_rename = FALSE),
+    dm_select_tbl(dm_for_flatten(), fact, dim_1, dim_3)
+  )
+})
+
+test_that("tidyselect works for flatten", {
+  # test if deselecting works
+  expect_equivalent_tbl(
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, -dim_2, dim_3, -dim_4, dim_1)),
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, dim_1, dim_3))
+  )
+
+  # test if select helpers work
+  expect_equivalent_tbl(
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, ends_with("3"), ends_with("1"))),
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, dim_3, dim_1))
+  )
+
+  expect_equivalent_tbl(
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, everything())),
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact))
+  )
+
+  # if only deselecting one potential candidate for flattening, the tables that are not
+  # candidates will generally be part of the choice
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_for_filter(), tf_2, -tf_1),
+    class = "tables_not_reachable_from_start"
+  )
+
+  # trying to deselect table that doesn't exist:
+  expect_error(
+    dm_flatten_to_tbl(dm_for_filter(), tf_2, -tf_101),
+    class = "vctrs_error_subscript"
+  )
+})
+
+test_that("`dm_join_to_tbl()` works", {
+  expect_deprecated(
+    expect_equivalent_tbl(
+      expect_message_obj(dm_join_to_tbl(dm_for_flatten(), fact, dim_3), "Renaming"),
+      left_join(
+        fact_clean(),
+        dim_3_clean(),
+        by = c("dim_3_key" = "dim_3_pk")
+      )
+    )
+  )
+
+  expect_dm_error(
+    expect_deprecated(dm_join_to_tbl(dm_for_filter(), tf_7, tf_8)),
+    "table_not_in_dm"
+  )
+})
+
+# tests that do not work on DB when keys are set ('bad_dm' and 'nycflights'; currently PG and MSSQL)
+test_that("tests with 'bad_dm' work", {
+  # can't create bad_dm() on Postgres due to strict constraint checks
+  skip_if_src("postgres")
+
+  # duckdb doesn't work before R 4.0
+  skip_if(getRversion() < "4.0")
+
+
+  # flatten bad_dm() (no referential integrity)
+  if (is_db(test_src_mssql()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+    expect_equivalent_tbl(
+      dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3),
+      tbl_1() %>%
+        left_join(tbl_2(), by = c("a" = "id", "x")) %>%
+        left_join(tbl_3(), by = c("b" = "id"))
+    )
+  }
+
+
+  skip_if_src("maria")
+
+  # filtered `dm`
+  bad_filtered_dm <- dm_filter(bad_dm(), tbl_1 = (a != 4))
+
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(bad_filtered_dm, tbl_1),
+    bad_filtered_dm %>% dm_flatten_to_tbl(tbl_1)
+  )
+
+
+  # filtered `dm`
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(bad_filtered_dm, tbl_1, .join = semi_join),
+    bad_filtered_dm %>% dm_flatten_to_tbl(tbl_1, .join = semi_join)
+  )
+
+  # fails when there is a cycle
+  expect_dm_error(
+    dm_nycflights_small() %>%
+      dm_add_fk(flights, origin, airports) %>%
+      dm_flatten_to_tbl(flights),
+    "no_cycles"
+  )
+})
+
+test_that("tests with 'bad_dm' work (2)", {
+  # can't create bad_dm() on Postgres due to strict constraint checks
+  skip_if_src("postgres")
+
+  # full & right join not available on SQLite and MariaDB
+  skip_if_src("sqlite", "maria")
+
+  # duckdb doesn't work before R 4.0
+  skip_if(getRversion() < "4.0")
+
+  bad_filtered_dm <- dm_filter(bad_dm(), tbl_1 = (a != 4))
+
+  # flatten bad_dm() (no referential integrity)
+  if (is_db(test_src_mssql()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+    expect_equivalent_tbl(
+      dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3, .join = full_join),
+      tbl_1() %>%
+        full_join(tbl_2(), by = c("a" = "id", "x")) %>%
+        full_join(tbl_3(), by = c("b" = "id"))
+    )
+  }
+})
+
+test_that("tests with 'bad_dm' work (3)", {
+  # can't create bad_dm() on Postgres due to strict constraint checks
+  skip_if_src("postgres")
+
+  # full & right join not available on SQLite
+  skip_if_src("sqlite")
+
+  # duckdb doesn't work before R 4.0
+  skip_if(getRversion() < "4.0")
+
+  bad_filtered_dm <- dm_filter(bad_dm(), tbl_1 = (a != 4))
+
+  # flatten bad_dm() (no referential integrity)
+  if (is_db(test_src_mssql()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+    expect_equivalent_tbl(
+      dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3, .join = right_join),
+      tbl_1() %>%
+        right_join(tbl_2(), by = c("a" = "id", "x")) %>%
+        right_join(tbl_3(), by = c("b" = "id"))
+    )
+  }
+
+
+  # flatten bad_dm() (no referential integrity); different order
+  if (is_db(test_src_mssql()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+    expect_equivalent_tbl(
+      dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_3, tbl_2, .join = right_join),
+      tbl_1() %>%
+        right_join(tbl_3(), by = c("b" = "id")) %>%
+        right_join(tbl_2(), by = c("a" = "id", "x"))
+    )
+  }
+})

--- a/tests/testthat/test-flatten-postgres.R
+++ b/tests/testthat/test-flatten-postgres.R
@@ -1,0 +1,419 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for PostgreSQL
+test_that("`dm_flatten_to_tbl()` does the right things for 'left_join()'", {
+  skip_if_src_not(c("df", "duckdb"))
+
+  local_options(
+    pillar.min_title_chars = NULL,
+    pillar.max_title_chars = NULL,
+    pillar.max_footer_lines = NULL,
+    pillar.bold = NULL,
+  )
+
+  # FIXME: Debug GHA fail
+  # for left join test the basic flattening also on all DBs
+  # expect_equivalent_tbl(
+  #   expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact)),
+  #   result_from_flatten_new()
+  # )
+
+  expect_snapshot(
+    {
+      prepare_dm_for_flatten(dm_for_flatten(), tables = c("fact", "dim_1", "dim_2", "dim_3", "dim_4"), gotta_rename = TRUE) %>%
+        dm_get_tables()
+      dm_flatten_to_tbl(dm_for_flatten(), fact)
+      result_from_flatten_new()
+    },
+    variant = "postgres"
+  )
+
+  # a one-table-dm
+  expect_equivalent_tbl(
+    dm_for_flatten() %>%
+      dm_select_tbl(fact) %>%
+      dm_flatten_to_tbl(fact),
+    fact()
+  )
+
+  # explicitly choose parent tables
+  out <- expect_message_obj(dm_flatten_to_tbl(
+    dm_for_flatten(), fact, dim_1, dim_2
+  ))
+  expect_equivalent_tbl(
+    out,
+    left_join(
+      fact_clean_new(),
+      dim_1_clean_new(),
+      by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2")
+    ) %>%
+      left_join(dim_2_clean_new(), by = c("dim_2_key" = "dim_2_pk"))
+  )
+
+  # change order of parent tables
+  out <- expect_message_obj(dm_flatten_to_tbl(
+    dm_for_flatten(), fact, dim_2, dim_1
+  ))
+  expect_equivalent_tbl(
+    out,
+    left_join(
+      fact_clean_new(), dim_2_clean_new(),
+      by = c("dim_2_key" = "dim_2_pk")
+    ) %>%
+      left_join(dim_1_clean_new(), by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2"))
+  )
+
+  # with grandparent table
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3),
+    class = "only_parents"
+  )
+
+  # table unreachable
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_for_filter(), tf_2, tf_3, tf_4),
+    class = "tables_not_reachable_from_start"
+  )
+
+  # deeper hierarchy available and `auto_detect = TRUE`
+  # for flatten: columns from tf_5 + tf_4 + tf_4_2 + tf_6 are combined in one table, 8 cols in total
+  expect_identical(
+    ncol(dm_flatten_to_tbl(dm_more_complex(), tf_5)),
+    11L
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'inner_join()'", {
+  local_options(
+    pillar.min_title_chars = NULL,
+    pillar.max_title_chars = NULL,
+    pillar.max_footer_lines = NULL,
+    pillar.bold = NULL,
+  )
+
+  out <- expect_message_obj(
+    arrange(
+      dm_flatten_to_tbl(dm_for_flatten(), fact, .join = inner_join),
+      pick(everything())
+    )
+  )
+  # FIXME: Debug GHA fail
+  # expect_equivalent_tbl(out, result_from_flatten_new())
+  expect_snapshot(
+    {
+      out
+    },
+    variant = "postgres"
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'full_join()'", {
+  skip_if_src("sqlite")
+  skip_if_src("maria")
+  out <- expect_message_obj(dm_flatten_to_tbl(
+    dm_for_flatten(), fact,
+    .join = full_join
+  ))
+  expect_equivalent_tbl(
+    out,
+    fact_clean_new() %>%
+      full_join(dim_1_clean_new(), by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2")) %>%
+      full_join(dim_2_clean_new(), by = c("dim_2_key" = "dim_2_pk")) %>%
+      full_join(dim_3_clean_new(), by = c("dim_3_key" = "dim_3_pk")) %>%
+      full_join(dim_4_clean_new(), by = c("dim_4_key" = "dim_4_pk"))
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'semi_join()'", {
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(dm_for_flatten(), fact, .join = semi_join),
+    fact()
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'anti_join()'", {
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(dm_for_flatten(), fact, .join = anti_join),
+    fact() %>% filter(1 == 0)
+  )
+})
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'nest_join()'", {
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_for_flatten(), fact, .join = nest_join),
+    class = "no_flatten_with_nest_join"
+  )
+})
+
+
+test_that("`dm_flatten_to_tbl()` does the right things for 'right_join()'", {
+  skip_if_src("sqlite")
+  expect_equivalent_tbl(
+    expect_message_obj(expect_warning_obj(
+      dm_flatten_to_tbl(dm_for_flatten(), fact, .join = right_join),
+      "right_join"
+    )),
+    fact_clean_new() %>%
+      right_join(dim_1_clean_new(), by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2")) %>%
+      right_join(dim_2_clean_new(), by = c("dim_2_key" = "dim_2_pk")) %>%
+      right_join(dim_3_clean_new(), by = c("dim_3_key" = "dim_3_pk")) %>%
+      right_join(dim_4_clean_new(), by = c("dim_4_key" = "dim_4_pk"))
+  )
+
+  # change order of parent tables
+  out <- expect_message_obj(dm_flatten_to_tbl(
+    dm_for_flatten(), fact, dim_2, dim_1,
+    .join = right_join
+  ))
+  expect_equivalent_tbl(
+    out,
+    right_join(
+      fact_clean_new(),
+      dim_2_clean_new(),
+      by = c("dim_2_key" = "dim_2_pk")
+    ) %>%
+      right_join(dim_1_clean_new(), by = c("dim_1_key_1" = "dim_1_pk_1", "dim_1_key_2" = "dim_1_pk_2"))
+  )
+})
+
+test_that("`dm_squash_to_tbl()` is deprecated but still works", {
+  # with grandparent table
+  # left_join:
+  expect_deprecated(
+    expect_equivalent_tbl(
+      dm_squash_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3),
+      tf_5() %>%
+        left_join(tf_4(), by = c("l" = "h")) %>%
+        left_join(tf_3(), by = c("j" = "f", "j1" = "f1"))
+    )
+  )
+})
+
+test_that("`dm_flatten_to_tbl(.recursive = TRUE)` does the right things", {
+  # with grandparent table
+  # left_join:
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .recursive = TRUE),
+    tf_5() %>%
+      left_join(tf_4(), by = c("l" = "h")) %>%
+      left_join(tf_3(), by = c("j" = "f", "j1" = "f1"))
+  )
+
+  # deeper hierarchy available and `auto_detect = TRUE`
+  # for flatten: columns from tf_5 + tf_4 + tf_3 + tf_4_2 + tf_6 are combined in one table, 10 cols in total
+  expect_identical(
+    ncol(dm_flatten_to_tbl(dm_more_complex(), tf_5, .recursive = TRUE)),
+    12L
+  )
+
+
+  # semi_join:
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .join = semi_join, .recursive = TRUE),
+    class = "squash_limited"
+  )
+
+  # anti_join:
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .join = anti_join, .recursive = TRUE),
+    class = "squash_limited"
+  )
+
+  # fails when there is a cycle:
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_for_filter_w_cycle(), tf_5, .recursive = TRUE),
+    "no_cycles"
+  )
+
+  skip_if_src("sqlite")
+  skip_if_src("maria")
+
+  # full_join:
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .join = full_join, .recursive = TRUE),
+    tf_5() %>%
+      full_join(tf_4(), by = c("l" = "h")) %>%
+      full_join(tf_3(), by = c("j" = "f", "j1" = "f1"))
+  )
+
+  # skipping inner_join, not gaining new info
+
+  # right_join:
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_more_complex(), tf_5, tf_4, tf_3, .join = right_join, .recursive = TRUE),
+    class = "squash_limited"
+  )
+})
+
+test_that("prepare_dm_for_flatten() works", {
+  # with rename
+  out <- expect_message_obj(prepare_dm_for_flatten(
+    dm_for_flatten(),
+    c("fact", "dim_1", "dim_3"),
+    gotta_rename = TRUE
+  ))
+  expect_equivalent_dm(
+    out,
+    dm_select_tbl(dm_for_flatten(), fact, dim_1, dim_3) %>% dm_disambiguate_cols(.quiet = TRUE)
+  )
+
+  # without rename
+  expect_equivalent_dm(
+    prepare_dm_for_flatten(dm_for_flatten(), c("fact", "dim_1", "dim_3"), gotta_rename = FALSE),
+    dm_select_tbl(dm_for_flatten(), fact, dim_1, dim_3)
+  )
+})
+
+test_that("tidyselect works for flatten", {
+  # test if deselecting works
+  expect_equivalent_tbl(
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, -dim_2, dim_3, -dim_4, dim_1)),
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, dim_1, dim_3))
+  )
+
+  # test if select helpers work
+  expect_equivalent_tbl(
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, ends_with("3"), ends_with("1"))),
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, dim_3, dim_1))
+  )
+
+  expect_equivalent_tbl(
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact, everything())),
+    expect_message_obj(dm_flatten_to_tbl(dm_for_flatten(), fact))
+  )
+
+  # if only deselecting one potential candidate for flattening, the tables that are not
+  # candidates will generally be part of the choice
+  expect_dm_error(
+    dm_flatten_to_tbl(dm_for_filter(), tf_2, -tf_1),
+    class = "tables_not_reachable_from_start"
+  )
+
+  # trying to deselect table that doesn't exist:
+  expect_error(
+    dm_flatten_to_tbl(dm_for_filter(), tf_2, -tf_101),
+    class = "vctrs_error_subscript"
+  )
+})
+
+test_that("`dm_join_to_tbl()` works", {
+  expect_deprecated(
+    expect_equivalent_tbl(
+      expect_message_obj(dm_join_to_tbl(dm_for_flatten(), fact, dim_3), "Renaming"),
+      left_join(
+        fact_clean(),
+        dim_3_clean(),
+        by = c("dim_3_key" = "dim_3_pk")
+      )
+    )
+  )
+
+  expect_dm_error(
+    expect_deprecated(dm_join_to_tbl(dm_for_filter(), tf_7, tf_8)),
+    "table_not_in_dm"
+  )
+})
+
+# tests that do not work on DB when keys are set ('bad_dm' and 'nycflights'; currently PG and MSSQL)
+test_that("tests with 'bad_dm' work", {
+  # can't create bad_dm() on Postgres due to strict constraint checks
+  skip_if_src("postgres")
+
+  # duckdb doesn't work before R 4.0
+  skip_if(getRversion() < "4.0")
+
+
+  # flatten bad_dm() (no referential integrity)
+  if (is_db(test_src_postgres()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+    expect_equivalent_tbl(
+      dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3),
+      tbl_1() %>%
+        left_join(tbl_2(), by = c("a" = "id", "x")) %>%
+        left_join(tbl_3(), by = c("b" = "id"))
+    )
+  }
+
+
+  skip_if_src("maria")
+
+  # filtered `dm`
+  bad_filtered_dm <- dm_filter(bad_dm(), tbl_1 = (a != 4))
+
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(bad_filtered_dm, tbl_1),
+    bad_filtered_dm %>% dm_flatten_to_tbl(tbl_1)
+  )
+
+
+  # filtered `dm`
+  expect_equivalent_tbl(
+    dm_flatten_to_tbl(bad_filtered_dm, tbl_1, .join = semi_join),
+    bad_filtered_dm %>% dm_flatten_to_tbl(tbl_1, .join = semi_join)
+  )
+
+  # fails when there is a cycle
+  expect_dm_error(
+    dm_nycflights_small() %>%
+      dm_add_fk(flights, origin, airports) %>%
+      dm_flatten_to_tbl(flights),
+    "no_cycles"
+  )
+})
+
+test_that("tests with 'bad_dm' work (2)", {
+  # can't create bad_dm() on Postgres due to strict constraint checks
+  skip_if_src("postgres")
+
+  # full & right join not available on SQLite and MariaDB
+  skip_if_src("sqlite", "maria")
+
+  # duckdb doesn't work before R 4.0
+  skip_if(getRversion() < "4.0")
+
+  bad_filtered_dm <- dm_filter(bad_dm(), tbl_1 = (a != 4))
+
+  # flatten bad_dm() (no referential integrity)
+  if (is_db(test_src_postgres()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+    expect_equivalent_tbl(
+      dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3, .join = full_join),
+      tbl_1() %>%
+        full_join(tbl_2(), by = c("a" = "id", "x")) %>%
+        full_join(tbl_3(), by = c("b" = "id"))
+    )
+  }
+})
+
+test_that("tests with 'bad_dm' work (3)", {
+  # can't create bad_dm() on Postgres due to strict constraint checks
+  skip_if_src("postgres")
+
+  # full & right join not available on SQLite
+  skip_if_src("sqlite")
+
+  # duckdb doesn't work before R 4.0
+  skip_if(getRversion() < "4.0")
+
+  bad_filtered_dm <- dm_filter(bad_dm(), tbl_1 = (a != 4))
+
+  # flatten bad_dm() (no referential integrity)
+  if (is_db(test_src_postgres()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+    expect_equivalent_tbl(
+      dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3, .join = right_join),
+      tbl_1() %>%
+        right_join(tbl_2(), by = c("a" = "id", "x")) %>%
+        right_join(tbl_3(), by = c("b" = "id"))
+    )
+  }
+
+
+  # flatten bad_dm() (no referential integrity); different order
+  if (is_db(test_src_postgres()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+    expect_equivalent_tbl(
+      dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_3, tbl_2, .join = right_join),
+      tbl_1() %>%
+        right_join(tbl_3(), by = c("b" = "id")) %>%
+        right_join(tbl_2(), by = c("a" = "id", "x"))
+    )
+  }
+})

--- a/tests/testthat/test-flatten-sqlite.R
+++ b/tests/testthat/test-flatten-sqlite.R
@@ -1,3 +1,7 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for SQLite
 test_that("`dm_flatten_to_tbl()` does the right things for 'left_join()'", {
   skip_if_src_not(c("df", "duckdb"))
 
@@ -22,7 +26,7 @@ test_that("`dm_flatten_to_tbl()` does the right things for 'left_join()'", {
       dm_flatten_to_tbl(dm_for_flatten(), fact)
       result_from_flatten_new()
     },
-    variant = my_test_src_name
+    variant = "sqlite"
   )
 
   # a one-table-dm
@@ -100,7 +104,7 @@ test_that("`dm_flatten_to_tbl()` does the right things for 'inner_join()'", {
     {
       out
     },
-    variant = my_test_src_name
+    variant = "sqlite"
   )
 })
 
@@ -321,7 +325,7 @@ test_that("tests with 'bad_dm' work", {
 
 
   # flatten bad_dm() (no referential integrity)
-  if (is_db(my_test_src()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+  if (is_db(test_src_sqlite()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
     expect_equivalent_tbl(
       dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3),
       tbl_1() %>%
@@ -370,7 +374,7 @@ test_that("tests with 'bad_dm' work (2)", {
   bad_filtered_dm <- dm_filter(bad_dm(), tbl_1 = (a != 4))
 
   # flatten bad_dm() (no referential integrity)
-  if (is_db(my_test_src()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+  if (is_db(test_src_sqlite()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
     expect_equivalent_tbl(
       dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3, .join = full_join),
       tbl_1() %>%
@@ -393,7 +397,7 @@ test_that("tests with 'bad_dm' work (3)", {
   bad_filtered_dm <- dm_filter(bad_dm(), tbl_1 = (a != 4))
 
   # flatten bad_dm() (no referential integrity)
-  if (is_db(my_test_src()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+  if (is_db(test_src_sqlite()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
     expect_equivalent_tbl(
       dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_2, tbl_3, .join = right_join),
       tbl_1() %>%
@@ -404,7 +408,7 @@ test_that("tests with 'bad_dm' work (3)", {
 
 
   # flatten bad_dm() (no referential integrity); different order
-  if (is_db(my_test_src()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
+  if (is_db(test_src_sqlite()) || utils::packageVersion("dplyr") >= "1.1.0.9000") {
     expect_equivalent_tbl(
       dm_flatten_to_tbl(bad_dm(), tbl_1, tbl_3, tbl_2, .join = right_join),
       tbl_1() %>%

--- a/tests/testthat/test-json_nest-df.R
+++ b/tests/testthat/test-json_nest-df.R
@@ -1,0 +1,51 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for data frames
+test_that("`json_nest()` and `json_unnest()` work", {
+  expect_snapshot({
+    df <- tibble::tibble(x = c(1, 1, 1, 2, 2, 3), y = 1:6, z = 6:1)
+    nested <- json_nest(df, data = c(y, z))
+    nested
+  })
+
+  df_roundtrip <- json_unnest(nested, data)
+  df_roundtrip
+  expect_equal(df, df_roundtrip)
+})
+
+test_that("`json_nest()` works remotely", {
+  skip_if_src_not("postgres", "mssql")
+  con <- test_src_df()$con
+
+  local <- tibble(grp = c(1, 1, 2, 2), a_i = letters[1:4], a_j = LETTERS[1:4])
+  remote <- test_db_src_frame(!!!local)
+
+  expect_snapshot(variant = "df", {
+    query <- remote %>%
+      json_nest(a = starts_with("a")) %>%
+      arrange(grp) %>%
+      dbplyr::sql_render()
+    # For stable POSTGRES tests
+    gsub("test_frame_[_0-9]+", "test_frame_...", query)
+    remote %>%
+      json_nest(a = starts_with("a")) %>%
+      arrange(grp) %>%
+      collect()
+    query <- remote %>%
+      json_nest(a = starts_with("a"), .names_sep = "_") %>%
+      arrange(grp) %>%
+      dbplyr::sql_render()
+    # For stable POSTGRES tests
+    gsub("test_frame_[_0-9]+", "test_frame_...", query)
+    remote %>%
+      json_nest(a = starts_with("a"), .names_sep = "_") %>%
+      arrange(grp) %>%
+      collect()
+  })
+
+  expect_equivalent_tbl(
+    local %>% json_nest(A = starts_with("a")) %>% unjson_nested(),
+    remote %>% json_nest(A = starts_with("a")) %>% collect() %>% unjson_nested()
+  )
+})

--- a/tests/testthat/test-json_nest-duckdb.R
+++ b/tests/testthat/test-json_nest-duckdb.R
@@ -1,0 +1,51 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for DuckDB
+test_that("`json_nest()` and `json_unnest()` work", {
+  expect_snapshot({
+    df <- tibble::tibble(x = c(1, 1, 1, 2, 2, 3), y = 1:6, z = 6:1)
+    nested <- json_nest(df, data = c(y, z))
+    nested
+  })
+
+  df_roundtrip <- json_unnest(nested, data)
+  df_roundtrip
+  expect_equal(df, df_roundtrip)
+})
+
+test_that("`json_nest()` works remotely", {
+  skip_if_src_not("postgres", "mssql")
+  con <- test_src_duckdb()$con
+
+  local <- tibble(grp = c(1, 1, 2, 2), a_i = letters[1:4], a_j = LETTERS[1:4])
+  remote <- test_db_src_frame(!!!local)
+
+  expect_snapshot(variant = "duckdb", {
+    query <- remote %>%
+      json_nest(a = starts_with("a")) %>%
+      arrange(grp) %>%
+      dbplyr::sql_render()
+    # For stable POSTGRES tests
+    gsub("test_frame_[_0-9]+", "test_frame_...", query)
+    remote %>%
+      json_nest(a = starts_with("a")) %>%
+      arrange(grp) %>%
+      collect()
+    query <- remote %>%
+      json_nest(a = starts_with("a"), .names_sep = "_") %>%
+      arrange(grp) %>%
+      dbplyr::sql_render()
+    # For stable POSTGRES tests
+    gsub("test_frame_[_0-9]+", "test_frame_...", query)
+    remote %>%
+      json_nest(a = starts_with("a"), .names_sep = "_") %>%
+      arrange(grp) %>%
+      collect()
+  })
+
+  expect_equivalent_tbl(
+    local %>% json_nest(A = starts_with("a")) %>% unjson_nested(),
+    remote %>% json_nest(A = starts_with("a")) %>% collect() %>% unjson_nested()
+  )
+})

--- a/tests/testthat/test-json_nest-maria.R
+++ b/tests/testthat/test-json_nest-maria.R
@@ -1,0 +1,51 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for MariaDB
+test_that("`json_nest()` and `json_unnest()` work", {
+  expect_snapshot({
+    df <- tibble::tibble(x = c(1, 1, 1, 2, 2, 3), y = 1:6, z = 6:1)
+    nested <- json_nest(df, data = c(y, z))
+    nested
+  })
+
+  df_roundtrip <- json_unnest(nested, data)
+  df_roundtrip
+  expect_equal(df, df_roundtrip)
+})
+
+test_that("`json_nest()` works remotely", {
+  skip_if_src_not("postgres", "mssql")
+  con <- test_src_maria()$con
+
+  local <- tibble(grp = c(1, 1, 2, 2), a_i = letters[1:4], a_j = LETTERS[1:4])
+  remote <- test_db_src_frame(!!!local)
+
+  expect_snapshot(variant = "maria", {
+    query <- remote %>%
+      json_nest(a = starts_with("a")) %>%
+      arrange(grp) %>%
+      dbplyr::sql_render()
+    # For stable POSTGRES tests
+    gsub("test_frame_[_0-9]+", "test_frame_...", query)
+    remote %>%
+      json_nest(a = starts_with("a")) %>%
+      arrange(grp) %>%
+      collect()
+    query <- remote %>%
+      json_nest(a = starts_with("a"), .names_sep = "_") %>%
+      arrange(grp) %>%
+      dbplyr::sql_render()
+    # For stable POSTGRES tests
+    gsub("test_frame_[_0-9]+", "test_frame_...", query)
+    remote %>%
+      json_nest(a = starts_with("a"), .names_sep = "_") %>%
+      arrange(grp) %>%
+      collect()
+  })
+
+  expect_equivalent_tbl(
+    local %>% json_nest(A = starts_with("a")) %>% unjson_nested(),
+    remote %>% json_nest(A = starts_with("a")) %>% collect() %>% unjson_nested()
+  )
+})

--- a/tests/testthat/test-json_nest-mssql.R
+++ b/tests/testthat/test-json_nest-mssql.R
@@ -1,3 +1,7 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for SQL Server
 test_that("`json_nest()` and `json_unnest()` work", {
   expect_snapshot({
     df <- tibble::tibble(x = c(1, 1, 1, 2, 2, 3), y = 1:6, z = 6:1)
@@ -12,12 +16,12 @@ test_that("`json_nest()` and `json_unnest()` work", {
 
 test_that("`json_nest()` works remotely", {
   skip_if_src_not("postgres", "mssql")
-  con <- my_test_src()$con
+  con <- test_src_mssql()$con
 
   local <- tibble(grp = c(1, 1, 2, 2), a_i = letters[1:4], a_j = LETTERS[1:4])
   remote <- test_db_src_frame(!!!local)
 
-  expect_snapshot(variant = my_test_src_name, {
+  expect_snapshot(variant = "mssql", {
     query <- remote %>%
       json_nest(a = starts_with("a")) %>%
       arrange(grp) %>%

--- a/tests/testthat/test-json_nest-postgres.R
+++ b/tests/testthat/test-json_nest-postgres.R
@@ -1,0 +1,51 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for PostgreSQL
+test_that("`json_nest()` and `json_unnest()` work", {
+  expect_snapshot({
+    df <- tibble::tibble(x = c(1, 1, 1, 2, 2, 3), y = 1:6, z = 6:1)
+    nested <- json_nest(df, data = c(y, z))
+    nested
+  })
+
+  df_roundtrip <- json_unnest(nested, data)
+  df_roundtrip
+  expect_equal(df, df_roundtrip)
+})
+
+test_that("`json_nest()` works remotely", {
+  skip_if_src_not("postgres", "mssql")
+  con <- test_src_postgres()$con
+
+  local <- tibble(grp = c(1, 1, 2, 2), a_i = letters[1:4], a_j = LETTERS[1:4])
+  remote <- test_db_src_frame(!!!local)
+
+  expect_snapshot(variant = "postgres", {
+    query <- remote %>%
+      json_nest(a = starts_with("a")) %>%
+      arrange(grp) %>%
+      dbplyr::sql_render()
+    # For stable POSTGRES tests
+    gsub("test_frame_[_0-9]+", "test_frame_...", query)
+    remote %>%
+      json_nest(a = starts_with("a")) %>%
+      arrange(grp) %>%
+      collect()
+    query <- remote %>%
+      json_nest(a = starts_with("a"), .names_sep = "_") %>%
+      arrange(grp) %>%
+      dbplyr::sql_render()
+    # For stable POSTGRES tests
+    gsub("test_frame_[_0-9]+", "test_frame_...", query)
+    remote %>%
+      json_nest(a = starts_with("a"), .names_sep = "_") %>%
+      arrange(grp) %>%
+      collect()
+  })
+
+  expect_equivalent_tbl(
+    local %>% json_nest(A = starts_with("a")) %>% unjson_nested(),
+    remote %>% json_nest(A = starts_with("a")) %>% collect() %>% unjson_nested()
+  )
+})

--- a/tests/testthat/test-json_pack-df.R
+++ b/tests/testthat/test-json_pack-df.R
@@ -1,0 +1,38 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for data frames
+test_that("`json_pack()` works", {
+  expect_snapshot({
+    df <- tibble::tibble(x1 = 1:3, x2 = 4:6, x3 = 7:9, y = 1:3)
+    packed <- json_pack(df, x = c(x1, x2, x3), y = y)
+    packed
+  })
+
+  df_roundtrip <- json_unpack(packed, c(x, y))
+  expect_equal(df, df_roundtrip)
+})
+
+test_that("`json_pack()` works remotely", {
+  skip_if_src_not("postgres", "mssql")
+  con <- test_src_df()$con
+
+  local <- tibble(grp = c(1, 1, 2, 2), a_i = letters[1:4], a_j = LETTERS[1:4])
+  remote <- test_db_src_frame(!!!local)
+
+  expect_snapshot(variant = "df", {
+    query <- json_pack(remote, a = starts_with("a")) %>% dbplyr::sql_render()
+    # For stable POSTGRES tests
+    gsub("test_frame_[_0-9]+", "test_frame_...", query)
+    json_pack(remote, a = starts_with("a"))
+    query <- json_pack(remote, a = starts_with("a"), .names_sep = "_") %>% dbplyr::sql_render()
+    # For stable POSTGRES tests
+    gsub("test_frame_[_0-9]+", "test_frame_...", query)
+    json_pack(remote, a = starts_with("a"), .names_sep = "_")
+  })
+
+  expect_identical(
+    local %>% json_pack(a = starts_with("a")) %>% unjson_nested(),
+    remote %>% json_pack(a = starts_with("a")) %>% collect() %>% unjson_nested()
+  )
+})

--- a/tests/testthat/test-json_pack-duckdb.R
+++ b/tests/testthat/test-json_pack-duckdb.R
@@ -1,0 +1,38 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for DuckDB
+test_that("`json_pack()` works", {
+  expect_snapshot({
+    df <- tibble::tibble(x1 = 1:3, x2 = 4:6, x3 = 7:9, y = 1:3)
+    packed <- json_pack(df, x = c(x1, x2, x3), y = y)
+    packed
+  })
+
+  df_roundtrip <- json_unpack(packed, c(x, y))
+  expect_equal(df, df_roundtrip)
+})
+
+test_that("`json_pack()` works remotely", {
+  skip_if_src_not("postgres", "mssql")
+  con <- test_src_duckdb()$con
+
+  local <- tibble(grp = c(1, 1, 2, 2), a_i = letters[1:4], a_j = LETTERS[1:4])
+  remote <- test_db_src_frame(!!!local)
+
+  expect_snapshot(variant = "duckdb", {
+    query <- json_pack(remote, a = starts_with("a")) %>% dbplyr::sql_render()
+    # For stable POSTGRES tests
+    gsub("test_frame_[_0-9]+", "test_frame_...", query)
+    json_pack(remote, a = starts_with("a"))
+    query <- json_pack(remote, a = starts_with("a"), .names_sep = "_") %>% dbplyr::sql_render()
+    # For stable POSTGRES tests
+    gsub("test_frame_[_0-9]+", "test_frame_...", query)
+    json_pack(remote, a = starts_with("a"), .names_sep = "_")
+  })
+
+  expect_identical(
+    local %>% json_pack(a = starts_with("a")) %>% unjson_nested(),
+    remote %>% json_pack(a = starts_with("a")) %>% collect() %>% unjson_nested()
+  )
+})

--- a/tests/testthat/test-json_pack-maria.R
+++ b/tests/testthat/test-json_pack-maria.R
@@ -1,0 +1,38 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for MariaDB
+test_that("`json_pack()` works", {
+  expect_snapshot({
+    df <- tibble::tibble(x1 = 1:3, x2 = 4:6, x3 = 7:9, y = 1:3)
+    packed <- json_pack(df, x = c(x1, x2, x3), y = y)
+    packed
+  })
+
+  df_roundtrip <- json_unpack(packed, c(x, y))
+  expect_equal(df, df_roundtrip)
+})
+
+test_that("`json_pack()` works remotely", {
+  skip_if_src_not("postgres", "mssql")
+  con <- test_src_maria()$con
+
+  local <- tibble(grp = c(1, 1, 2, 2), a_i = letters[1:4], a_j = LETTERS[1:4])
+  remote <- test_db_src_frame(!!!local)
+
+  expect_snapshot(variant = "maria", {
+    query <- json_pack(remote, a = starts_with("a")) %>% dbplyr::sql_render()
+    # For stable POSTGRES tests
+    gsub("test_frame_[_0-9]+", "test_frame_...", query)
+    json_pack(remote, a = starts_with("a"))
+    query <- json_pack(remote, a = starts_with("a"), .names_sep = "_") %>% dbplyr::sql_render()
+    # For stable POSTGRES tests
+    gsub("test_frame_[_0-9]+", "test_frame_...", query)
+    json_pack(remote, a = starts_with("a"), .names_sep = "_")
+  })
+
+  expect_identical(
+    local %>% json_pack(a = starts_with("a")) %>% unjson_nested(),
+    remote %>% json_pack(a = starts_with("a")) %>% collect() %>% unjson_nested()
+  )
+})

--- a/tests/testthat/test-json_pack-mssql.R
+++ b/tests/testthat/test-json_pack-mssql.R
@@ -1,3 +1,7 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for SQL Server
 test_that("`json_pack()` works", {
   expect_snapshot({
     df <- tibble::tibble(x1 = 1:3, x2 = 4:6, x3 = 7:9, y = 1:3)
@@ -11,12 +15,12 @@ test_that("`json_pack()` works", {
 
 test_that("`json_pack()` works remotely", {
   skip_if_src_not("postgres", "mssql")
-  con <- my_test_src()$con
+  con <- test_src_mssql()$con
 
   local <- tibble(grp = c(1, 1, 2, 2), a_i = letters[1:4], a_j = LETTERS[1:4])
   remote <- test_db_src_frame(!!!local)
 
-  expect_snapshot(variant = my_test_src_name, {
+  expect_snapshot(variant = "mssql", {
     query <- json_pack(remote, a = starts_with("a")) %>% dbplyr::sql_render()
     # For stable POSTGRES tests
     gsub("test_frame_[_0-9]+", "test_frame_...", query)

--- a/tests/testthat/test-json_pack-postgres.R
+++ b/tests/testthat/test-json_pack-postgres.R
@@ -1,0 +1,38 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for PostgreSQL
+test_that("`json_pack()` works", {
+  expect_snapshot({
+    df <- tibble::tibble(x1 = 1:3, x2 = 4:6, x3 = 7:9, y = 1:3)
+    packed <- json_pack(df, x = c(x1, x2, x3), y = y)
+    packed
+  })
+
+  df_roundtrip <- json_unpack(packed, c(x, y))
+  expect_equal(df, df_roundtrip)
+})
+
+test_that("`json_pack()` works remotely", {
+  skip_if_src_not("postgres", "mssql")
+  con <- test_src_postgres()$con
+
+  local <- tibble(grp = c(1, 1, 2, 2), a_i = letters[1:4], a_j = LETTERS[1:4])
+  remote <- test_db_src_frame(!!!local)
+
+  expect_snapshot(variant = "postgres", {
+    query <- json_pack(remote, a = starts_with("a")) %>% dbplyr::sql_render()
+    # For stable POSTGRES tests
+    gsub("test_frame_[_0-9]+", "test_frame_...", query)
+    json_pack(remote, a = starts_with("a"))
+    query <- json_pack(remote, a = starts_with("a"), .names_sep = "_") %>% dbplyr::sql_render()
+    # For stable POSTGRES tests
+    gsub("test_frame_[_0-9]+", "test_frame_...", query)
+    json_pack(remote, a = starts_with("a"), .names_sep = "_")
+  })
+
+  expect_identical(
+    local %>% json_pack(a = starts_with("a")) %>% unjson_nested(),
+    remote %>% json_pack(a = starts_with("a")) %>% collect() %>% unjson_nested()
+  )
+})

--- a/tests/testthat/test-json_pack-sqlite.R
+++ b/tests/testthat/test-json_pack-sqlite.R
@@ -1,0 +1,38 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for SQLite
+test_that("`json_pack()` works", {
+  expect_snapshot({
+    df <- tibble::tibble(x1 = 1:3, x2 = 4:6, x3 = 7:9, y = 1:3)
+    packed <- json_pack(df, x = c(x1, x2, x3), y = y)
+    packed
+  })
+
+  df_roundtrip <- json_unpack(packed, c(x, y))
+  expect_equal(df, df_roundtrip)
+})
+
+test_that("`json_pack()` works remotely", {
+  skip_if_src_not("postgres", "mssql")
+  con <- test_src_sqlite()$con
+
+  local <- tibble(grp = c(1, 1, 2, 2), a_i = letters[1:4], a_j = LETTERS[1:4])
+  remote <- test_db_src_frame(!!!local)
+
+  expect_snapshot(variant = "sqlite", {
+    query <- json_pack(remote, a = starts_with("a")) %>% dbplyr::sql_render()
+    # For stable POSTGRES tests
+    gsub("test_frame_[_0-9]+", "test_frame_...", query)
+    json_pack(remote, a = starts_with("a"))
+    query <- json_pack(remote, a = starts_with("a"), .names_sep = "_") %>% dbplyr::sql_render()
+    # For stable POSTGRES tests
+    gsub("test_frame_[_0-9]+", "test_frame_...", query)
+    json_pack(remote, a = starts_with("a"), .names_sep = "_")
+  })
+
+  expect_identical(
+    local %>% json_pack(a = starts_with("a")) %>% unjson_nested(),
+    remote %>% json_pack(a = starts_with("a")) %>% collect() %>% unjson_nested()
+  )
+})

--- a/tests/testthat/test-meta-df.R
+++ b/tests/testthat/test-meta-df.R
@@ -1,0 +1,42 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for data frames
+test_that("dummy", {
+  # To avoid deletion of file
+  expect_snapshot({
+    TRUE
+  })
+})
+
+test_that("dm_meta() data model", {
+  skip_if_schema_not_supported()
+
+  expect_snapshot({
+    dm_meta(test_src_df()) %>%
+      dm_paste(options = c("select", "keys", "color"))
+  })
+})
+
+test_that("dm_meta(simple = TRUE) columns", {
+  # Still stored as snapshot in columns.csv, never cleared
+  skip("Dependent on database version, find better way to record this info")
+
+  columns <- tryCatch(
+    test_src_duckdb() %>%
+      dm_meta(simple = TRUE) %>%
+      .$columns %>%
+      filter(tolower(table_schema) == "information_schema") %>%
+      arrange(table_name, ordinal_position) %>%
+      select(-table_catalog) %>%
+      collect(),
+    error = function(e) {
+      data.frame(error = conditionMessage(e))
+    }
+  )
+
+  path <- withr::local_tempfile(fileext = ".csv")
+  write.csv(columns, path, na = "")
+
+  expect_snapshot_file(path, name = "columns.csv", variant = "df")
+})

--- a/tests/testthat/test-meta-duckdb.R
+++ b/tests/testthat/test-meta-duckdb.R
@@ -1,0 +1,42 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for DuckDB
+test_that("dummy", {
+  # To avoid deletion of file
+  expect_snapshot({
+    TRUE
+  })
+})
+
+test_that("dm_meta() data model", {
+  skip_if_schema_not_supported()
+
+  expect_snapshot({
+    dm_meta(test_src_duckdb()) %>%
+      dm_paste(options = c("select", "keys", "color"))
+  })
+})
+
+test_that("dm_meta(simple = TRUE) columns", {
+  # Still stored as snapshot in columns.csv, never cleared
+  skip("Dependent on database version, find better way to record this info")
+
+  columns <- tryCatch(
+    test_src_duckdb() %>%
+      dm_meta(simple = TRUE) %>%
+      .$columns %>%
+      filter(tolower(table_schema) == "information_schema") %>%
+      arrange(table_name, ordinal_position) %>%
+      select(-table_catalog) %>%
+      collect(),
+    error = function(e) {
+      data.frame(error = conditionMessage(e))
+    }
+  )
+
+  path <- withr::local_tempfile(fileext = ".csv")
+  write.csv(columns, path, na = "")
+
+  expect_snapshot_file(path, name = "columns.csv", variant = "duckdb")
+})

--- a/tests/testthat/test-meta-maria.R
+++ b/tests/testthat/test-meta-maria.R
@@ -1,0 +1,42 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for MariaDB
+test_that("dummy", {
+  # To avoid deletion of file
+  expect_snapshot({
+    TRUE
+  })
+})
+
+test_that("dm_meta() data model", {
+  skip_if_schema_not_supported()
+
+  expect_snapshot({
+    dm_meta(test_src_maria()) %>%
+      dm_paste(options = c("select", "keys", "color"))
+  })
+})
+
+test_that("dm_meta(simple = TRUE) columns", {
+  # Still stored as snapshot in columns.csv, never cleared
+  skip("Dependent on database version, find better way to record this info")
+
+  columns <- tryCatch(
+    test_src_maria() %>%
+      dm_meta(simple = TRUE) %>%
+      .$columns %>%
+      filter(tolower(table_schema) == "information_schema") %>%
+      arrange(table_name, ordinal_position) %>%
+      select(-table_catalog) %>%
+      collect(),
+    error = function(e) {
+      data.frame(error = conditionMessage(e))
+    }
+  )
+
+  path <- withr::local_tempfile(fileext = ".csv")
+  write.csv(columns, path, na = "")
+
+  expect_snapshot_file(path, name = "columns.csv", variant = "maria")
+})

--- a/tests/testthat/test-meta-mssql.R
+++ b/tests/testthat/test-meta-mssql.R
@@ -1,0 +1,42 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for SQL Server
+test_that("dummy", {
+  # To avoid deletion of file
+  expect_snapshot({
+    TRUE
+  })
+})
+
+test_that("dm_meta() data model", {
+  skip_if_schema_not_supported()
+
+  expect_snapshot({
+    dm_meta(test_src_mssql()) %>%
+      dm_paste(options = c("select", "keys", "color"))
+  })
+})
+
+test_that("dm_meta(simple = TRUE) columns", {
+  # Still stored as snapshot in columns.csv, never cleared
+  skip("Dependent on database version, find better way to record this info")
+
+  columns <- tryCatch(
+    test_src_mssql() %>%
+      dm_meta(simple = TRUE) %>%
+      .$columns %>%
+      filter(tolower(table_schema) == "information_schema") %>%
+      arrange(table_name, ordinal_position) %>%
+      select(-table_catalog) %>%
+      collect(),
+    error = function(e) {
+      data.frame(error = conditionMessage(e))
+    }
+  )
+
+  path <- withr::local_tempfile(fileext = ".csv")
+  write.csv(columns, path, na = "")
+
+  expect_snapshot_file(path, name = "columns.csv", variant = "mssql")
+})

--- a/tests/testthat/test-meta-postgres.R
+++ b/tests/testthat/test-meta-postgres.R
@@ -1,3 +1,7 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for PostgreSQL
 test_that("dummy", {
   # To avoid deletion of file
   expect_snapshot({
@@ -9,7 +13,7 @@ test_that("dm_meta() data model", {
   skip_if_schema_not_supported()
 
   expect_snapshot({
-    dm_meta(my_test_src()) %>%
+    dm_meta(test_src_postgres()) %>%
       dm_paste(options = c("select", "keys", "color"))
   })
 })
@@ -19,7 +23,7 @@ test_that("dm_meta(simple = TRUE) columns", {
   skip("Dependent on database version, find better way to record this info")
 
   columns <- tryCatch(
-    my_db_test_src() %>%
+    test_src_postgres() %>%
       dm_meta(simple = TRUE) %>%
       .$columns %>%
       filter(tolower(table_schema) == "information_schema") %>%
@@ -34,5 +38,5 @@ test_that("dm_meta(simple = TRUE) columns", {
   path <- withr::local_tempfile(fileext = ".csv")
   write.csv(columns, path, na = "")
 
-  expect_snapshot_file(path, name = "columns.csv", variant = my_test_src_name)
+  expect_snapshot_file(path, name = "columns.csv", variant = "postgres")
 })

--- a/tests/testthat/test-meta-sqlite.R
+++ b/tests/testthat/test-meta-sqlite.R
@@ -1,0 +1,42 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for SQLite
+test_that("dummy", {
+  # To avoid deletion of file
+  expect_snapshot({
+    TRUE
+  })
+})
+
+test_that("dm_meta() data model", {
+  skip_if_schema_not_supported()
+
+  expect_snapshot({
+    dm_meta(test_src_sqlite()) %>%
+      dm_paste(options = c("select", "keys", "color"))
+  })
+})
+
+test_that("dm_meta(simple = TRUE) columns", {
+  # Still stored as snapshot in columns.csv, never cleared
+  skip("Dependent on database version, find better way to record this info")
+
+  columns <- tryCatch(
+    test_src_sqlite() %>%
+      dm_meta(simple = TRUE) %>%
+      .$columns %>%
+      filter(tolower(table_schema) == "information_schema") %>%
+      arrange(table_name, ordinal_position) %>%
+      select(-table_catalog) %>%
+      collect(),
+    error = function(e) {
+      data.frame(error = conditionMessage(e))
+    }
+  )
+
+  path <- withr::local_tempfile(fileext = ".csv")
+  write.csv(columns, path, na = "")
+
+  expect_snapshot_file(path, name = "columns.csv", variant = "sqlite")
+})

--- a/tests/testthat/test-rows-dm-df.R
+++ b/tests/testthat/test-rows-dm-df.R
@@ -1,0 +1,411 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for data frames
+test_that("dumma", {
+  expect_snapshot({
+    "dummy"
+  })
+})
+
+test_that("dm_rows_insert()", {
+  skip_if_not_installed("RSQLite")
+  local_options(lifecycle_verbosity = "quiet")
+
+  # Entire dataset with all dimension tables populated
+  # with flights and weather data truncated:
+  flights_init <-
+    dm_nycflights13() %>%
+    dm_zoom_to(flights) %>%
+    filter(FALSE) %>%
+    dm_update_zoomed() %>%
+    dm_zoom_to(weather) %>%
+    filter(FALSE) %>%
+    dm_update_zoomed()
+
+  # Must use SQLite because other databases have strict foreign key constraints
+  sqlite <- DBI::dbConnect(RSQLite::SQLite())
+
+  # Target database:
+  flights_sqlite <- copy_dm_to(sqlite, flights_init, temporary = FALSE)
+
+  expect_snapshot({
+    print(dm_nrow(flights_sqlite))
+
+    # First update:
+    flights_hour10 <-
+      dm_nycflights13() %>%
+      dm_select_tbl(flights, weather) %>%
+      dm_zoom_to(flights) %>%
+      filter(month == 1, day == 10, hour == 10) %>%
+      dm_update_zoomed() %>%
+      dm_zoom_to(weather) %>%
+      filter(month == 1, day == 10, hour == 10) %>%
+      dm_update_zoomed()
+    print(dm_nrow(flights_hour10))
+
+    # Copy to temporary tables on the target database:
+    flights_hour10_sqlite <- copy_dm_to(sqlite, flights_hour10)
+
+    # Dry run by default:
+    out <- dm_rows_append(flights_sqlite, flights_hour10_sqlite)
+    print(dm_nrow(flights_sqlite))
+
+    # Explicitly request persistence:
+    dm_rows_append(flights_sqlite, flights_hour10_sqlite, in_place = TRUE)
+    print(dm_nrow(flights_sqlite))
+
+    # Second update:
+    flights_hour11 <-
+      dm_nycflights13() %>%
+      dm_select_tbl(flights, weather) %>%
+      dm_zoom_to(flights) %>%
+      filter(month == 1, day == 10, hour == 11) %>%
+      dm_update_zoomed() %>%
+      dm_zoom_to(weather) %>%
+      filter(month == 1, day == 10, hour == 11) %>%
+      dm_update_zoomed()
+
+    # Copy to temporary tables on the target database:
+    flights_hour11_sqlite <- copy_dm_to(sqlite, flights_hour11)
+
+    # Explicit dry run:
+    flights_new <- dm_rows_append(
+      flights_sqlite,
+      flights_hour11_sqlite,
+      in_place = FALSE
+    )
+    print(dm_nrow(flights_new))
+    print(dm_nrow(flights_sqlite))
+
+    # Check for consistency before applying:
+    flights_new %>%
+      dm_examine_constraints()
+
+    # Apply:
+    dm_rows_append(flights_sqlite, flights_hour11_sqlite, in_place = TRUE)
+    print(dm_nrow(flights_sqlite))
+
+    # Disconnect
+    DBI::dbDisconnect(sqlite)
+  })
+})
+
+test_that("dm_rows_update()", {
+  # Test bad column order
+  dm_filter_rearranged <-
+    dm_for_filter() %>%
+    dm_select(tf_2, d, everything()) %>%
+    dm_select(tf_4, i, everything()) %>%
+    dm_select(tf_5, l, m, everything())
+
+  dm_copy <- suppressMessages(copy_dm_to(test_src_duckdb(), dm_filter_rearranged))
+
+  dm_update_local <- dm(
+    tf_1 = tibble(
+      a = 2L,
+      b = "q"
+    ),
+    tf_4 = tibble(
+      h = "e",
+      i = "sieben",
+    ),
+    tf_5 = tibble(
+      k = 3L,
+      ww = 3,
+    ),
+  )
+
+  dm_update_copy <- suppressMessages(copy_dm_to(test_src_duckdb(), dm_update_local))
+
+  expect_snapshot({
+    dm_copy %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_rows_update(dm_update_copy) %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_rows_update(dm_update_copy, in_place = FALSE) %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_get_tables() %>%
+      map(arrange_all)
+
+    dm_copy %>%
+      dm_rows_update(dm_update_copy, in_place = TRUE)
+
+    dm_copy %>%
+      dm_get_tables() %>%
+      map(arrange_all)
+  })
+})
+
+test_that("dm_rows_truncate()", {
+  local_options(lifecycle_verbosity = "warning")
+
+  suppressMessages(dm_copy <- copy_dm_to(test_src_duckdb(), dm_for_filter()))
+
+  dm_truncate_local <- dm(
+    tf_2 = tibble(
+      c = c("worm"),
+      d = 10L,
+    ),
+    tf_5 = tibble(
+      k = 3L,
+      m = "tree",
+    ),
+  )
+
+  dm_truncate_copy <- suppressMessages(copy_dm_to(test_src_duckdb(), dm_truncate_local))
+
+  expect_snapshot({
+    dm_copy %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_rows_truncate(dm_truncate_copy) %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_rows_truncate(dm_truncate_copy, in_place = FALSE) %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_get_tables() %>%
+      map(arrange_all)
+
+    dm_copy %>%
+      dm_rows_truncate(dm_truncate_copy, in_place = TRUE)
+
+    dm_copy %>%
+      dm_get_tables() %>%
+      map(arrange_all)
+  })
+})
+
+
+# tests for compound keys -------------------------------------------------
+
+test_that("output for compound keys", {
+  skip("COMPOUND")
+  local_options(lifecycle_verbosity = "warning")
+
+  expect_snapshot({
+    target_dm <- dm_filter(nyc_comp(), weather, pressure > 1010) %>% dm_apply_filters()
+    insert_dm <-
+      dm_filter(nyc_comp(), weather, pressure <= 1010) %>%
+      dm_apply_filters() %>%
+      dm_select_tbl(flights, weather)
+    dm_rows_insert(target_dm, insert_dm, in_place = FALSE)
+    dm_rows_truncate(nyc_comp(), insert_dm, in_place = FALSE)
+  })
+})
+
+
+# tests for autoincrement PKs ---------------------------------------------
+
+test_that("dm_rows_append() works with autoincrement PKs and FKS for selected DBs", {
+  skip_if_src_not(c("postgres", "mssql", "sqlite"))
+
+  con_db <- my_test_con()
+
+  # Setup
+  dm_ai_w_keys <-
+    dm_for_autoinc_1() %>%
+    dm_add_pk(t1, a, autoincrement = TRUE) %>%
+    dm_add_pk(t2, c, autoincrement = TRUE) %>%
+    dm_add_pk(t4, g, autoincrement = TRUE) %>%
+    dm_add_fk(t2, d, t1) %>%
+    dm_add_fk(t3, e, t1) %>%
+    dm_add_fk(t4, h, t2)
+
+  local_dm <-
+    dm_ai_w_keys %>%
+    collect()
+
+  withr::defer({
+    order_of_deletion <- c("t4", "t2", "t3", "t1")
+    walk(
+      order_of_deletion,
+      ~ try(DBI::dbExecute(con_db, paste0("DROP TABLE ", .x)))
+    )
+  })
+
+  dm_ai_empty_remote <-
+    local_dm %>%
+    dm_ptype() %>%
+    copy_dm_to(con_db, ., temporary = FALSE)
+
+  # Tests
+  dm_ai_insert <-
+    dm_for_autoinc_1() %>%
+    # Remove one PK column, only provided by database
+    dm_select(t4, -g) %>%
+    dm_zoom_to(t3) %>%
+    filter(0L == 1L) %>%
+    dm_update_zoomed()
+
+  expect_silent(
+    filled_dm <- dm_rows_append(
+      dm_ai_empty_remote,
+      dm_ai_insert,
+      in_place = FALSE,
+      progress = FALSE
+    ) %>%
+      collect()
+  )
+
+  expect_silent(
+    filled_dm_in_place <- dm_rows_append(
+      dm_ai_empty_remote,
+      dm_ai_insert,
+      in_place = TRUE,
+      progress = FALSE
+    ) %>%
+      collect()
+  )
+
+  expect_silent(
+    filled_dm_in_place_twice <- dm_rows_append(
+      dm_ai_empty_remote,
+      dm_ai_insert,
+      in_place = TRUE,
+      progress = FALSE
+    ) %>%
+      collect()
+  )
+
+  expect_snapshot(
+    variant = "df",
+    {
+      local_dm$t1
+      local_dm$t2
+      local_dm$t3
+      local_dm$t4
+      filled_dm$t1
+      filled_dm$t2
+      filled_dm$t3
+      filled_dm$t4
+      filled_dm_in_place$t1
+      filled_dm_in_place$t2
+      filled_dm_in_place$t3
+      filled_dm_in_place$t4
+      filled_dm_in_place_twice$t1
+      filled_dm_in_place_twice$t2
+      filled_dm_in_place_twice$t3
+      filled_dm_in_place_twice$t4
+    }
+  )
+})
+
+
+test_that("dm_rows_append() works with autoincrement PKs and FKS locally", {
+  skip_if_remote_src()
+
+  # Setup
+  local_dm <-
+    dm_for_autoinc_1() %>%
+    dm_add_pk(t1, a, autoincrement = TRUE) %>%
+    dm_add_pk(t2, c, autoincrement = TRUE) %>%
+    dm_add_pk(t4, g, autoincrement = TRUE) %>%
+    dm_add_fk(t2, d, t1) %>%
+    dm_add_fk(t3, e, t1) %>%
+    dm_add_fk(t4, h, t2)
+
+  dm_ai_empty <-
+    local_dm %>%
+    dm_ptype()
+
+  # Corner case: empty + empty = empty
+  expect_identical(
+    expect_silent(dm_rows_append(
+      dm_ai_empty,
+      dm_ai_empty,
+      in_place = FALSE,
+      progress = FALSE
+    )),
+    dm_ai_empty
+  )
+
+  # Tests
+  dm_ai_insert <-
+    dm_for_autoinc_1() %>%
+    # Remove one PK column, only provided by local logic
+    dm_select(t4, -g) %>%
+    dm_zoom_to(t3) %>%
+    filter(0L == 1L) %>%
+    dm_update_zoomed()
+
+  expect_silent(
+    filled_dm <- dm_rows_append(
+      dm_ai_empty,
+      dm_ai_insert,
+      in_place = FALSE,
+      progress = FALSE
+    )
+  )
+
+  # Corner case: data + empty = data
+  expect_identical(
+    expect_silent(dm_rows_append(
+      filled_dm,
+      dm_ai_empty,
+      in_place = FALSE,
+      progress = FALSE
+    )),
+    filled_dm
+  )
+
+  expect_error(
+    dm_rows_append(
+      dm_ai_empty,
+      dm_ai_insert,
+      in_place = TRUE,
+      progress = FALSE
+    )
+  )
+
+  expect_silent(
+    filled_twice_dm <- dm_rows_append(
+      filled_dm,
+      dm_ai_insert,
+      in_place = FALSE,
+      progress = FALSE
+    )
+  )
+
+  expect_snapshot(
+    variant = "df",
+    {
+      local_dm$t1
+      local_dm$t2
+      local_dm$t3
+      local_dm$t4
+      filled_dm$t1
+      filled_dm$t2
+      filled_dm$t3
+      filled_dm$t4
+      filled_twice_dm$t1
+      filled_twice_dm$t2
+      filled_twice_dm$t3
+      filled_twice_dm$t4
+    }
+  )
+})

--- a/tests/testthat/test-rows-dm-duckdb.R
+++ b/tests/testthat/test-rows-dm-duckdb.R
@@ -1,0 +1,411 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for DuckDB
+test_that("dumma", {
+  expect_snapshot({
+    "dummy"
+  })
+})
+
+test_that("dm_rows_insert()", {
+  skip_if_not_installed("RSQLite")
+  local_options(lifecycle_verbosity = "quiet")
+
+  # Entire dataset with all dimension tables populated
+  # with flights and weather data truncated:
+  flights_init <-
+    dm_nycflights13() %>%
+    dm_zoom_to(flights) %>%
+    filter(FALSE) %>%
+    dm_update_zoomed() %>%
+    dm_zoom_to(weather) %>%
+    filter(FALSE) %>%
+    dm_update_zoomed()
+
+  # Must use SQLite because other databases have strict foreign key constraints
+  sqlite <- DBI::dbConnect(RSQLite::SQLite())
+
+  # Target database:
+  flights_sqlite <- copy_dm_to(sqlite, flights_init, temporary = FALSE)
+
+  expect_snapshot({
+    print(dm_nrow(flights_sqlite))
+
+    # First update:
+    flights_hour10 <-
+      dm_nycflights13() %>%
+      dm_select_tbl(flights, weather) %>%
+      dm_zoom_to(flights) %>%
+      filter(month == 1, day == 10, hour == 10) %>%
+      dm_update_zoomed() %>%
+      dm_zoom_to(weather) %>%
+      filter(month == 1, day == 10, hour == 10) %>%
+      dm_update_zoomed()
+    print(dm_nrow(flights_hour10))
+
+    # Copy to temporary tables on the target database:
+    flights_hour10_sqlite <- copy_dm_to(sqlite, flights_hour10)
+
+    # Dry run by default:
+    out <- dm_rows_append(flights_sqlite, flights_hour10_sqlite)
+    print(dm_nrow(flights_sqlite))
+
+    # Explicitly request persistence:
+    dm_rows_append(flights_sqlite, flights_hour10_sqlite, in_place = TRUE)
+    print(dm_nrow(flights_sqlite))
+
+    # Second update:
+    flights_hour11 <-
+      dm_nycflights13() %>%
+      dm_select_tbl(flights, weather) %>%
+      dm_zoom_to(flights) %>%
+      filter(month == 1, day == 10, hour == 11) %>%
+      dm_update_zoomed() %>%
+      dm_zoom_to(weather) %>%
+      filter(month == 1, day == 10, hour == 11) %>%
+      dm_update_zoomed()
+
+    # Copy to temporary tables on the target database:
+    flights_hour11_sqlite <- copy_dm_to(sqlite, flights_hour11)
+
+    # Explicit dry run:
+    flights_new <- dm_rows_append(
+      flights_sqlite,
+      flights_hour11_sqlite,
+      in_place = FALSE
+    )
+    print(dm_nrow(flights_new))
+    print(dm_nrow(flights_sqlite))
+
+    # Check for consistency before applying:
+    flights_new %>%
+      dm_examine_constraints()
+
+    # Apply:
+    dm_rows_append(flights_sqlite, flights_hour11_sqlite, in_place = TRUE)
+    print(dm_nrow(flights_sqlite))
+
+    # Disconnect
+    DBI::dbDisconnect(sqlite)
+  })
+})
+
+test_that("dm_rows_update()", {
+  # Test bad column order
+  dm_filter_rearranged <-
+    dm_for_filter() %>%
+    dm_select(tf_2, d, everything()) %>%
+    dm_select(tf_4, i, everything()) %>%
+    dm_select(tf_5, l, m, everything())
+
+  dm_copy <- suppressMessages(copy_dm_to(test_src_duckdb(), dm_filter_rearranged))
+
+  dm_update_local <- dm(
+    tf_1 = tibble(
+      a = 2L,
+      b = "q"
+    ),
+    tf_4 = tibble(
+      h = "e",
+      i = "sieben",
+    ),
+    tf_5 = tibble(
+      k = 3L,
+      ww = 3,
+    ),
+  )
+
+  dm_update_copy <- suppressMessages(copy_dm_to(test_src_duckdb(), dm_update_local))
+
+  expect_snapshot({
+    dm_copy %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_rows_update(dm_update_copy) %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_rows_update(dm_update_copy, in_place = FALSE) %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_get_tables() %>%
+      map(arrange_all)
+
+    dm_copy %>%
+      dm_rows_update(dm_update_copy, in_place = TRUE)
+
+    dm_copy %>%
+      dm_get_tables() %>%
+      map(arrange_all)
+  })
+})
+
+test_that("dm_rows_truncate()", {
+  local_options(lifecycle_verbosity = "warning")
+
+  suppressMessages(dm_copy <- copy_dm_to(test_src_duckdb(), dm_for_filter()))
+
+  dm_truncate_local <- dm(
+    tf_2 = tibble(
+      c = c("worm"),
+      d = 10L,
+    ),
+    tf_5 = tibble(
+      k = 3L,
+      m = "tree",
+    ),
+  )
+
+  dm_truncate_copy <- suppressMessages(copy_dm_to(test_src_duckdb(), dm_truncate_local))
+
+  expect_snapshot({
+    dm_copy %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_rows_truncate(dm_truncate_copy) %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_rows_truncate(dm_truncate_copy, in_place = FALSE) %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_get_tables() %>%
+      map(arrange_all)
+
+    dm_copy %>%
+      dm_rows_truncate(dm_truncate_copy, in_place = TRUE)
+
+    dm_copy %>%
+      dm_get_tables() %>%
+      map(arrange_all)
+  })
+})
+
+
+# tests for compound keys -------------------------------------------------
+
+test_that("output for compound keys", {
+  skip("COMPOUND")
+  local_options(lifecycle_verbosity = "warning")
+
+  expect_snapshot({
+    target_dm <- dm_filter(nyc_comp(), weather, pressure > 1010) %>% dm_apply_filters()
+    insert_dm <-
+      dm_filter(nyc_comp(), weather, pressure <= 1010) %>%
+      dm_apply_filters() %>%
+      dm_select_tbl(flights, weather)
+    dm_rows_insert(target_dm, insert_dm, in_place = FALSE)
+    dm_rows_truncate(nyc_comp(), insert_dm, in_place = FALSE)
+  })
+})
+
+
+# tests for autoincrement PKs ---------------------------------------------
+
+test_that("dm_rows_append() works with autoincrement PKs and FKS for selected DBs", {
+  skip_if_src_not(c("postgres", "mssql", "sqlite"))
+
+  con_db <- my_test_con()
+
+  # Setup
+  dm_ai_w_keys <-
+    dm_for_autoinc_1() %>%
+    dm_add_pk(t1, a, autoincrement = TRUE) %>%
+    dm_add_pk(t2, c, autoincrement = TRUE) %>%
+    dm_add_pk(t4, g, autoincrement = TRUE) %>%
+    dm_add_fk(t2, d, t1) %>%
+    dm_add_fk(t3, e, t1) %>%
+    dm_add_fk(t4, h, t2)
+
+  local_dm <-
+    dm_ai_w_keys %>%
+    collect()
+
+  withr::defer({
+    order_of_deletion <- c("t4", "t2", "t3", "t1")
+    walk(
+      order_of_deletion,
+      ~ try(DBI::dbExecute(con_db, paste0("DROP TABLE ", .x)))
+    )
+  })
+
+  dm_ai_empty_remote <-
+    local_dm %>%
+    dm_ptype() %>%
+    copy_dm_to(con_db, ., temporary = FALSE)
+
+  # Tests
+  dm_ai_insert <-
+    dm_for_autoinc_1() %>%
+    # Remove one PK column, only provided by database
+    dm_select(t4, -g) %>%
+    dm_zoom_to(t3) %>%
+    filter(0L == 1L) %>%
+    dm_update_zoomed()
+
+  expect_silent(
+    filled_dm <- dm_rows_append(
+      dm_ai_empty_remote,
+      dm_ai_insert,
+      in_place = FALSE,
+      progress = FALSE
+    ) %>%
+      collect()
+  )
+
+  expect_silent(
+    filled_dm_in_place <- dm_rows_append(
+      dm_ai_empty_remote,
+      dm_ai_insert,
+      in_place = TRUE,
+      progress = FALSE
+    ) %>%
+      collect()
+  )
+
+  expect_silent(
+    filled_dm_in_place_twice <- dm_rows_append(
+      dm_ai_empty_remote,
+      dm_ai_insert,
+      in_place = TRUE,
+      progress = FALSE
+    ) %>%
+      collect()
+  )
+
+  expect_snapshot(
+    variant = "duckdb",
+    {
+      local_dm$t1
+      local_dm$t2
+      local_dm$t3
+      local_dm$t4
+      filled_dm$t1
+      filled_dm$t2
+      filled_dm$t3
+      filled_dm$t4
+      filled_dm_in_place$t1
+      filled_dm_in_place$t2
+      filled_dm_in_place$t3
+      filled_dm_in_place$t4
+      filled_dm_in_place_twice$t1
+      filled_dm_in_place_twice$t2
+      filled_dm_in_place_twice$t3
+      filled_dm_in_place_twice$t4
+    }
+  )
+})
+
+
+test_that("dm_rows_append() works with autoincrement PKs and FKS locally", {
+  skip_if_remote_src()
+
+  # Setup
+  local_dm <-
+    dm_for_autoinc_1() %>%
+    dm_add_pk(t1, a, autoincrement = TRUE) %>%
+    dm_add_pk(t2, c, autoincrement = TRUE) %>%
+    dm_add_pk(t4, g, autoincrement = TRUE) %>%
+    dm_add_fk(t2, d, t1) %>%
+    dm_add_fk(t3, e, t1) %>%
+    dm_add_fk(t4, h, t2)
+
+  dm_ai_empty <-
+    local_dm %>%
+    dm_ptype()
+
+  # Corner case: empty + empty = empty
+  expect_identical(
+    expect_silent(dm_rows_append(
+      dm_ai_empty,
+      dm_ai_empty,
+      in_place = FALSE,
+      progress = FALSE
+    )),
+    dm_ai_empty
+  )
+
+  # Tests
+  dm_ai_insert <-
+    dm_for_autoinc_1() %>%
+    # Remove one PK column, only provided by local logic
+    dm_select(t4, -g) %>%
+    dm_zoom_to(t3) %>%
+    filter(0L == 1L) %>%
+    dm_update_zoomed()
+
+  expect_silent(
+    filled_dm <- dm_rows_append(
+      dm_ai_empty,
+      dm_ai_insert,
+      in_place = FALSE,
+      progress = FALSE
+    )
+  )
+
+  # Corner case: data + empty = data
+  expect_identical(
+    expect_silent(dm_rows_append(
+      filled_dm,
+      dm_ai_empty,
+      in_place = FALSE,
+      progress = FALSE
+    )),
+    filled_dm
+  )
+
+  expect_error(
+    dm_rows_append(
+      dm_ai_empty,
+      dm_ai_insert,
+      in_place = TRUE,
+      progress = FALSE
+    )
+  )
+
+  expect_silent(
+    filled_twice_dm <- dm_rows_append(
+      filled_dm,
+      dm_ai_insert,
+      in_place = FALSE,
+      progress = FALSE
+    )
+  )
+
+  expect_snapshot(
+    variant = "duckdb",
+    {
+      local_dm$t1
+      local_dm$t2
+      local_dm$t3
+      local_dm$t4
+      filled_dm$t1
+      filled_dm$t2
+      filled_dm$t3
+      filled_dm$t4
+      filled_twice_dm$t1
+      filled_twice_dm$t2
+      filled_twice_dm$t3
+      filled_twice_dm$t4
+    }
+  )
+})

--- a/tests/testthat/test-rows-dm-maria.R
+++ b/tests/testthat/test-rows-dm-maria.R
@@ -1,0 +1,411 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for MariaDB
+test_that("dumma", {
+  expect_snapshot({
+    "dummy"
+  })
+})
+
+test_that("dm_rows_insert()", {
+  skip_if_not_installed("RSQLite")
+  local_options(lifecycle_verbosity = "quiet")
+
+  # Entire dataset with all dimension tables populated
+  # with flights and weather data truncated:
+  flights_init <-
+    dm_nycflights13() %>%
+    dm_zoom_to(flights) %>%
+    filter(FALSE) %>%
+    dm_update_zoomed() %>%
+    dm_zoom_to(weather) %>%
+    filter(FALSE) %>%
+    dm_update_zoomed()
+
+  # Must use SQLite because other databases have strict foreign key constraints
+  sqlite <- DBI::dbConnect(RSQLite::SQLite())
+
+  # Target database:
+  flights_sqlite <- copy_dm_to(sqlite, flights_init, temporary = FALSE)
+
+  expect_snapshot({
+    print(dm_nrow(flights_sqlite))
+
+    # First update:
+    flights_hour10 <-
+      dm_nycflights13() %>%
+      dm_select_tbl(flights, weather) %>%
+      dm_zoom_to(flights) %>%
+      filter(month == 1, day == 10, hour == 10) %>%
+      dm_update_zoomed() %>%
+      dm_zoom_to(weather) %>%
+      filter(month == 1, day == 10, hour == 10) %>%
+      dm_update_zoomed()
+    print(dm_nrow(flights_hour10))
+
+    # Copy to temporary tables on the target database:
+    flights_hour10_sqlite <- copy_dm_to(sqlite, flights_hour10)
+
+    # Dry run by default:
+    out <- dm_rows_append(flights_sqlite, flights_hour10_sqlite)
+    print(dm_nrow(flights_sqlite))
+
+    # Explicitly request persistence:
+    dm_rows_append(flights_sqlite, flights_hour10_sqlite, in_place = TRUE)
+    print(dm_nrow(flights_sqlite))
+
+    # Second update:
+    flights_hour11 <-
+      dm_nycflights13() %>%
+      dm_select_tbl(flights, weather) %>%
+      dm_zoom_to(flights) %>%
+      filter(month == 1, day == 10, hour == 11) %>%
+      dm_update_zoomed() %>%
+      dm_zoom_to(weather) %>%
+      filter(month == 1, day == 10, hour == 11) %>%
+      dm_update_zoomed()
+
+    # Copy to temporary tables on the target database:
+    flights_hour11_sqlite <- copy_dm_to(sqlite, flights_hour11)
+
+    # Explicit dry run:
+    flights_new <- dm_rows_append(
+      flights_sqlite,
+      flights_hour11_sqlite,
+      in_place = FALSE
+    )
+    print(dm_nrow(flights_new))
+    print(dm_nrow(flights_sqlite))
+
+    # Check for consistency before applying:
+    flights_new %>%
+      dm_examine_constraints()
+
+    # Apply:
+    dm_rows_append(flights_sqlite, flights_hour11_sqlite, in_place = TRUE)
+    print(dm_nrow(flights_sqlite))
+
+    # Disconnect
+    DBI::dbDisconnect(sqlite)
+  })
+})
+
+test_that("dm_rows_update()", {
+  # Test bad column order
+  dm_filter_rearranged <-
+    dm_for_filter() %>%
+    dm_select(tf_2, d, everything()) %>%
+    dm_select(tf_4, i, everything()) %>%
+    dm_select(tf_5, l, m, everything())
+
+  dm_copy <- suppressMessages(copy_dm_to(test_src_maria(), dm_filter_rearranged))
+
+  dm_update_local <- dm(
+    tf_1 = tibble(
+      a = 2L,
+      b = "q"
+    ),
+    tf_4 = tibble(
+      h = "e",
+      i = "sieben",
+    ),
+    tf_5 = tibble(
+      k = 3L,
+      ww = 3,
+    ),
+  )
+
+  dm_update_copy <- suppressMessages(copy_dm_to(test_src_maria(), dm_update_local))
+
+  expect_snapshot({
+    dm_copy %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_rows_update(dm_update_copy) %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_rows_update(dm_update_copy, in_place = FALSE) %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_get_tables() %>%
+      map(arrange_all)
+
+    dm_copy %>%
+      dm_rows_update(dm_update_copy, in_place = TRUE)
+
+    dm_copy %>%
+      dm_get_tables() %>%
+      map(arrange_all)
+  })
+})
+
+test_that("dm_rows_truncate()", {
+  local_options(lifecycle_verbosity = "warning")
+
+  suppressMessages(dm_copy <- copy_dm_to(test_src_maria(), dm_for_filter()))
+
+  dm_truncate_local <- dm(
+    tf_2 = tibble(
+      c = c("worm"),
+      d = 10L,
+    ),
+    tf_5 = tibble(
+      k = 3L,
+      m = "tree",
+    ),
+  )
+
+  dm_truncate_copy <- suppressMessages(copy_dm_to(test_src_maria(), dm_truncate_local))
+
+  expect_snapshot({
+    dm_copy %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_rows_truncate(dm_truncate_copy) %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_rows_truncate(dm_truncate_copy, in_place = FALSE) %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_get_tables() %>%
+      map(arrange_all)
+
+    dm_copy %>%
+      dm_rows_truncate(dm_truncate_copy, in_place = TRUE)
+
+    dm_copy %>%
+      dm_get_tables() %>%
+      map(arrange_all)
+  })
+})
+
+
+# tests for compound keys -------------------------------------------------
+
+test_that("output for compound keys", {
+  skip("COMPOUND")
+  local_options(lifecycle_verbosity = "warning")
+
+  expect_snapshot({
+    target_dm <- dm_filter(nyc_comp(), weather, pressure > 1010) %>% dm_apply_filters()
+    insert_dm <-
+      dm_filter(nyc_comp(), weather, pressure <= 1010) %>%
+      dm_apply_filters() %>%
+      dm_select_tbl(flights, weather)
+    dm_rows_insert(target_dm, insert_dm, in_place = FALSE)
+    dm_rows_truncate(nyc_comp(), insert_dm, in_place = FALSE)
+  })
+})
+
+
+# tests for autoincrement PKs ---------------------------------------------
+
+test_that("dm_rows_append() works with autoincrement PKs and FKS for selected DBs", {
+  skip_if_src_not(c("postgres", "mssql", "sqlite"))
+
+  con_db <- my_test_con()
+
+  # Setup
+  dm_ai_w_keys <-
+    dm_for_autoinc_1() %>%
+    dm_add_pk(t1, a, autoincrement = TRUE) %>%
+    dm_add_pk(t2, c, autoincrement = TRUE) %>%
+    dm_add_pk(t4, g, autoincrement = TRUE) %>%
+    dm_add_fk(t2, d, t1) %>%
+    dm_add_fk(t3, e, t1) %>%
+    dm_add_fk(t4, h, t2)
+
+  local_dm <-
+    dm_ai_w_keys %>%
+    collect()
+
+  withr::defer({
+    order_of_deletion <- c("t4", "t2", "t3", "t1")
+    walk(
+      order_of_deletion,
+      ~ try(DBI::dbExecute(con_db, paste0("DROP TABLE ", .x)))
+    )
+  })
+
+  dm_ai_empty_remote <-
+    local_dm %>%
+    dm_ptype() %>%
+    copy_dm_to(con_db, ., temporary = FALSE)
+
+  # Tests
+  dm_ai_insert <-
+    dm_for_autoinc_1() %>%
+    # Remove one PK column, only provided by database
+    dm_select(t4, -g) %>%
+    dm_zoom_to(t3) %>%
+    filter(0L == 1L) %>%
+    dm_update_zoomed()
+
+  expect_silent(
+    filled_dm <- dm_rows_append(
+      dm_ai_empty_remote,
+      dm_ai_insert,
+      in_place = FALSE,
+      progress = FALSE
+    ) %>%
+      collect()
+  )
+
+  expect_silent(
+    filled_dm_in_place <- dm_rows_append(
+      dm_ai_empty_remote,
+      dm_ai_insert,
+      in_place = TRUE,
+      progress = FALSE
+    ) %>%
+      collect()
+  )
+
+  expect_silent(
+    filled_dm_in_place_twice <- dm_rows_append(
+      dm_ai_empty_remote,
+      dm_ai_insert,
+      in_place = TRUE,
+      progress = FALSE
+    ) %>%
+      collect()
+  )
+
+  expect_snapshot(
+    variant = "maria",
+    {
+      local_dm$t1
+      local_dm$t2
+      local_dm$t3
+      local_dm$t4
+      filled_dm$t1
+      filled_dm$t2
+      filled_dm$t3
+      filled_dm$t4
+      filled_dm_in_place$t1
+      filled_dm_in_place$t2
+      filled_dm_in_place$t3
+      filled_dm_in_place$t4
+      filled_dm_in_place_twice$t1
+      filled_dm_in_place_twice$t2
+      filled_dm_in_place_twice$t3
+      filled_dm_in_place_twice$t4
+    }
+  )
+})
+
+
+test_that("dm_rows_append() works with autoincrement PKs and FKS locally", {
+  skip_if_remote_src()
+
+  # Setup
+  local_dm <-
+    dm_for_autoinc_1() %>%
+    dm_add_pk(t1, a, autoincrement = TRUE) %>%
+    dm_add_pk(t2, c, autoincrement = TRUE) %>%
+    dm_add_pk(t4, g, autoincrement = TRUE) %>%
+    dm_add_fk(t2, d, t1) %>%
+    dm_add_fk(t3, e, t1) %>%
+    dm_add_fk(t4, h, t2)
+
+  dm_ai_empty <-
+    local_dm %>%
+    dm_ptype()
+
+  # Corner case: empty + empty = empty
+  expect_identical(
+    expect_silent(dm_rows_append(
+      dm_ai_empty,
+      dm_ai_empty,
+      in_place = FALSE,
+      progress = FALSE
+    )),
+    dm_ai_empty
+  )
+
+  # Tests
+  dm_ai_insert <-
+    dm_for_autoinc_1() %>%
+    # Remove one PK column, only provided by local logic
+    dm_select(t4, -g) %>%
+    dm_zoom_to(t3) %>%
+    filter(0L == 1L) %>%
+    dm_update_zoomed()
+
+  expect_silent(
+    filled_dm <- dm_rows_append(
+      dm_ai_empty,
+      dm_ai_insert,
+      in_place = FALSE,
+      progress = FALSE
+    )
+  )
+
+  # Corner case: data + empty = data
+  expect_identical(
+    expect_silent(dm_rows_append(
+      filled_dm,
+      dm_ai_empty,
+      in_place = FALSE,
+      progress = FALSE
+    )),
+    filled_dm
+  )
+
+  expect_error(
+    dm_rows_append(
+      dm_ai_empty,
+      dm_ai_insert,
+      in_place = TRUE,
+      progress = FALSE
+    )
+  )
+
+  expect_silent(
+    filled_twice_dm <- dm_rows_append(
+      filled_dm,
+      dm_ai_insert,
+      in_place = FALSE,
+      progress = FALSE
+    )
+  )
+
+  expect_snapshot(
+    variant = "maria",
+    {
+      local_dm$t1
+      local_dm$t2
+      local_dm$t3
+      local_dm$t4
+      filled_dm$t1
+      filled_dm$t2
+      filled_dm$t3
+      filled_dm$t4
+      filled_twice_dm$t1
+      filled_twice_dm$t2
+      filled_twice_dm$t3
+      filled_twice_dm$t4
+    }
+  )
+})

--- a/tests/testthat/test-rows-dm-mssql.R
+++ b/tests/testthat/test-rows-dm-mssql.R
@@ -1,0 +1,411 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for SQL Server
+test_that("dumma", {
+  expect_snapshot({
+    "dummy"
+  })
+})
+
+test_that("dm_rows_insert()", {
+  skip_if_not_installed("RSQLite")
+  local_options(lifecycle_verbosity = "quiet")
+
+  # Entire dataset with all dimension tables populated
+  # with flights and weather data truncated:
+  flights_init <-
+    dm_nycflights13() %>%
+    dm_zoom_to(flights) %>%
+    filter(FALSE) %>%
+    dm_update_zoomed() %>%
+    dm_zoom_to(weather) %>%
+    filter(FALSE) %>%
+    dm_update_zoomed()
+
+  # Must use SQLite because other databases have strict foreign key constraints
+  sqlite <- DBI::dbConnect(RSQLite::SQLite())
+
+  # Target database:
+  flights_sqlite <- copy_dm_to(sqlite, flights_init, temporary = FALSE)
+
+  expect_snapshot({
+    print(dm_nrow(flights_sqlite))
+
+    # First update:
+    flights_hour10 <-
+      dm_nycflights13() %>%
+      dm_select_tbl(flights, weather) %>%
+      dm_zoom_to(flights) %>%
+      filter(month == 1, day == 10, hour == 10) %>%
+      dm_update_zoomed() %>%
+      dm_zoom_to(weather) %>%
+      filter(month == 1, day == 10, hour == 10) %>%
+      dm_update_zoomed()
+    print(dm_nrow(flights_hour10))
+
+    # Copy to temporary tables on the target database:
+    flights_hour10_sqlite <- copy_dm_to(sqlite, flights_hour10)
+
+    # Dry run by default:
+    out <- dm_rows_append(flights_sqlite, flights_hour10_sqlite)
+    print(dm_nrow(flights_sqlite))
+
+    # Explicitly request persistence:
+    dm_rows_append(flights_sqlite, flights_hour10_sqlite, in_place = TRUE)
+    print(dm_nrow(flights_sqlite))
+
+    # Second update:
+    flights_hour11 <-
+      dm_nycflights13() %>%
+      dm_select_tbl(flights, weather) %>%
+      dm_zoom_to(flights) %>%
+      filter(month == 1, day == 10, hour == 11) %>%
+      dm_update_zoomed() %>%
+      dm_zoom_to(weather) %>%
+      filter(month == 1, day == 10, hour == 11) %>%
+      dm_update_zoomed()
+
+    # Copy to temporary tables on the target database:
+    flights_hour11_sqlite <- copy_dm_to(sqlite, flights_hour11)
+
+    # Explicit dry run:
+    flights_new <- dm_rows_append(
+      flights_sqlite,
+      flights_hour11_sqlite,
+      in_place = FALSE
+    )
+    print(dm_nrow(flights_new))
+    print(dm_nrow(flights_sqlite))
+
+    # Check for consistency before applying:
+    flights_new %>%
+      dm_examine_constraints()
+
+    # Apply:
+    dm_rows_append(flights_sqlite, flights_hour11_sqlite, in_place = TRUE)
+    print(dm_nrow(flights_sqlite))
+
+    # Disconnect
+    DBI::dbDisconnect(sqlite)
+  })
+})
+
+test_that("dm_rows_update()", {
+  # Test bad column order
+  dm_filter_rearranged <-
+    dm_for_filter() %>%
+    dm_select(tf_2, d, everything()) %>%
+    dm_select(tf_4, i, everything()) %>%
+    dm_select(tf_5, l, m, everything())
+
+  dm_copy <- suppressMessages(copy_dm_to(test_src_mssql(), dm_filter_rearranged))
+
+  dm_update_local <- dm(
+    tf_1 = tibble(
+      a = 2L,
+      b = "q"
+    ),
+    tf_4 = tibble(
+      h = "e",
+      i = "sieben",
+    ),
+    tf_5 = tibble(
+      k = 3L,
+      ww = 3,
+    ),
+  )
+
+  dm_update_copy <- suppressMessages(copy_dm_to(test_src_mssql(), dm_update_local))
+
+  expect_snapshot({
+    dm_copy %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_rows_update(dm_update_copy) %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_rows_update(dm_update_copy, in_place = FALSE) %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_get_tables() %>%
+      map(arrange_all)
+
+    dm_copy %>%
+      dm_rows_update(dm_update_copy, in_place = TRUE)
+
+    dm_copy %>%
+      dm_get_tables() %>%
+      map(arrange_all)
+  })
+})
+
+test_that("dm_rows_truncate()", {
+  local_options(lifecycle_verbosity = "warning")
+
+  suppressMessages(dm_copy <- copy_dm_to(test_src_mssql(), dm_for_filter()))
+
+  dm_truncate_local <- dm(
+    tf_2 = tibble(
+      c = c("worm"),
+      d = 10L,
+    ),
+    tf_5 = tibble(
+      k = 3L,
+      m = "tree",
+    ),
+  )
+
+  dm_truncate_copy <- suppressMessages(copy_dm_to(test_src_mssql(), dm_truncate_local))
+
+  expect_snapshot({
+    dm_copy %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_rows_truncate(dm_truncate_copy) %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_rows_truncate(dm_truncate_copy, in_place = FALSE) %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_get_tables() %>%
+      map(arrange_all)
+
+    dm_copy %>%
+      dm_rows_truncate(dm_truncate_copy, in_place = TRUE)
+
+    dm_copy %>%
+      dm_get_tables() %>%
+      map(arrange_all)
+  })
+})
+
+
+# tests for compound keys -------------------------------------------------
+
+test_that("output for compound keys", {
+  skip("COMPOUND")
+  local_options(lifecycle_verbosity = "warning")
+
+  expect_snapshot({
+    target_dm <- dm_filter(nyc_comp(), weather, pressure > 1010) %>% dm_apply_filters()
+    insert_dm <-
+      dm_filter(nyc_comp(), weather, pressure <= 1010) %>%
+      dm_apply_filters() %>%
+      dm_select_tbl(flights, weather)
+    dm_rows_insert(target_dm, insert_dm, in_place = FALSE)
+    dm_rows_truncate(nyc_comp(), insert_dm, in_place = FALSE)
+  })
+})
+
+
+# tests for autoincrement PKs ---------------------------------------------
+
+test_that("dm_rows_append() works with autoincrement PKs and FKS for selected DBs", {
+  skip_if_src_not(c("postgres", "mssql", "sqlite"))
+
+  con_db <- my_test_con()
+
+  # Setup
+  dm_ai_w_keys <-
+    dm_for_autoinc_1() %>%
+    dm_add_pk(t1, a, autoincrement = TRUE) %>%
+    dm_add_pk(t2, c, autoincrement = TRUE) %>%
+    dm_add_pk(t4, g, autoincrement = TRUE) %>%
+    dm_add_fk(t2, d, t1) %>%
+    dm_add_fk(t3, e, t1) %>%
+    dm_add_fk(t4, h, t2)
+
+  local_dm <-
+    dm_ai_w_keys %>%
+    collect()
+
+  withr::defer({
+    order_of_deletion <- c("t4", "t2", "t3", "t1")
+    walk(
+      order_of_deletion,
+      ~ try(DBI::dbExecute(con_db, paste0("DROP TABLE ", .x)))
+    )
+  })
+
+  dm_ai_empty_remote <-
+    local_dm %>%
+    dm_ptype() %>%
+    copy_dm_to(con_db, ., temporary = FALSE)
+
+  # Tests
+  dm_ai_insert <-
+    dm_for_autoinc_1() %>%
+    # Remove one PK column, only provided by database
+    dm_select(t4, -g) %>%
+    dm_zoom_to(t3) %>%
+    filter(0L == 1L) %>%
+    dm_update_zoomed()
+
+  expect_silent(
+    filled_dm <- dm_rows_append(
+      dm_ai_empty_remote,
+      dm_ai_insert,
+      in_place = FALSE,
+      progress = FALSE
+    ) %>%
+      collect()
+  )
+
+  expect_silent(
+    filled_dm_in_place <- dm_rows_append(
+      dm_ai_empty_remote,
+      dm_ai_insert,
+      in_place = TRUE,
+      progress = FALSE
+    ) %>%
+      collect()
+  )
+
+  expect_silent(
+    filled_dm_in_place_twice <- dm_rows_append(
+      dm_ai_empty_remote,
+      dm_ai_insert,
+      in_place = TRUE,
+      progress = FALSE
+    ) %>%
+      collect()
+  )
+
+  expect_snapshot(
+    variant = "mssql",
+    {
+      local_dm$t1
+      local_dm$t2
+      local_dm$t3
+      local_dm$t4
+      filled_dm$t1
+      filled_dm$t2
+      filled_dm$t3
+      filled_dm$t4
+      filled_dm_in_place$t1
+      filled_dm_in_place$t2
+      filled_dm_in_place$t3
+      filled_dm_in_place$t4
+      filled_dm_in_place_twice$t1
+      filled_dm_in_place_twice$t2
+      filled_dm_in_place_twice$t3
+      filled_dm_in_place_twice$t4
+    }
+  )
+})
+
+
+test_that("dm_rows_append() works with autoincrement PKs and FKS locally", {
+  skip_if_remote_src()
+
+  # Setup
+  local_dm <-
+    dm_for_autoinc_1() %>%
+    dm_add_pk(t1, a, autoincrement = TRUE) %>%
+    dm_add_pk(t2, c, autoincrement = TRUE) %>%
+    dm_add_pk(t4, g, autoincrement = TRUE) %>%
+    dm_add_fk(t2, d, t1) %>%
+    dm_add_fk(t3, e, t1) %>%
+    dm_add_fk(t4, h, t2)
+
+  dm_ai_empty <-
+    local_dm %>%
+    dm_ptype()
+
+  # Corner case: empty + empty = empty
+  expect_identical(
+    expect_silent(dm_rows_append(
+      dm_ai_empty,
+      dm_ai_empty,
+      in_place = FALSE,
+      progress = FALSE
+    )),
+    dm_ai_empty
+  )
+
+  # Tests
+  dm_ai_insert <-
+    dm_for_autoinc_1() %>%
+    # Remove one PK column, only provided by local logic
+    dm_select(t4, -g) %>%
+    dm_zoom_to(t3) %>%
+    filter(0L == 1L) %>%
+    dm_update_zoomed()
+
+  expect_silent(
+    filled_dm <- dm_rows_append(
+      dm_ai_empty,
+      dm_ai_insert,
+      in_place = FALSE,
+      progress = FALSE
+    )
+  )
+
+  # Corner case: data + empty = data
+  expect_identical(
+    expect_silent(dm_rows_append(
+      filled_dm,
+      dm_ai_empty,
+      in_place = FALSE,
+      progress = FALSE
+    )),
+    filled_dm
+  )
+
+  expect_error(
+    dm_rows_append(
+      dm_ai_empty,
+      dm_ai_insert,
+      in_place = TRUE,
+      progress = FALSE
+    )
+  )
+
+  expect_silent(
+    filled_twice_dm <- dm_rows_append(
+      filled_dm,
+      dm_ai_insert,
+      in_place = FALSE,
+      progress = FALSE
+    )
+  )
+
+  expect_snapshot(
+    variant = "mssql",
+    {
+      local_dm$t1
+      local_dm$t2
+      local_dm$t3
+      local_dm$t4
+      filled_dm$t1
+      filled_dm$t2
+      filled_dm$t3
+      filled_dm$t4
+      filled_twice_dm$t1
+      filled_twice_dm$t2
+      filled_twice_dm$t3
+      filled_twice_dm$t4
+    }
+  )
+})

--- a/tests/testthat/test-rows-dm-postgres.R
+++ b/tests/testthat/test-rows-dm-postgres.R
@@ -1,3 +1,7 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for PostgreSQL
 test_that("dumma", {
   expect_snapshot({
     "dummy"
@@ -95,7 +99,7 @@ test_that("dm_rows_update()", {
     dm_select(tf_4, i, everything()) %>%
     dm_select(tf_5, l, m, everything())
 
-  dm_copy <- suppressMessages(copy_dm_to(my_db_test_src(), dm_filter_rearranged))
+  dm_copy <- suppressMessages(copy_dm_to(test_src_postgres(), dm_filter_rearranged))
 
   dm_update_local <- dm(
     tf_1 = tibble(
@@ -112,7 +116,7 @@ test_that("dm_rows_update()", {
     ),
   )
 
-  dm_update_copy <- suppressMessages(copy_dm_to(my_db_test_src(), dm_update_local))
+  dm_update_copy <- suppressMessages(copy_dm_to(test_src_postgres(), dm_update_local))
 
   expect_snapshot({
     dm_copy %>%
@@ -149,7 +153,7 @@ test_that("dm_rows_update()", {
 test_that("dm_rows_truncate()", {
   local_options(lifecycle_verbosity = "warning")
 
-  suppressMessages(dm_copy <- copy_dm_to(my_db_test_src(), dm_for_filter()))
+  suppressMessages(dm_copy <- copy_dm_to(test_src_postgres(), dm_for_filter()))
 
   dm_truncate_local <- dm(
     tf_2 = tibble(
@@ -162,7 +166,7 @@ test_that("dm_rows_truncate()", {
     ),
   )
 
-  dm_truncate_copy <- suppressMessages(copy_dm_to(my_db_test_src(), dm_truncate_local))
+  dm_truncate_copy <- suppressMessages(copy_dm_to(test_src_postgres(), dm_truncate_local))
 
   expect_snapshot({
     dm_copy %>%
@@ -289,7 +293,7 @@ test_that("dm_rows_append() works with autoincrement PKs and FKS for selected DB
   )
 
   expect_snapshot(
-    variant = my_test_src_name,
+    variant = "postgres",
     {
       local_dm$t1
       local_dm$t2
@@ -388,7 +392,7 @@ test_that("dm_rows_append() works with autoincrement PKs and FKS locally", {
   )
 
   expect_snapshot(
-    variant = my_test_src_name,
+    variant = "postgres",
     {
       local_dm$t1
       local_dm$t2

--- a/tests/testthat/test-rows-dm-sqlite.R
+++ b/tests/testthat/test-rows-dm-sqlite.R
@@ -1,0 +1,411 @@
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for SQLite
+test_that("dumma", {
+  expect_snapshot({
+    "dummy"
+  })
+})
+
+test_that("dm_rows_insert()", {
+  skip_if_not_installed("RSQLite")
+  local_options(lifecycle_verbosity = "quiet")
+
+  # Entire dataset with all dimension tables populated
+  # with flights and weather data truncated:
+  flights_init <-
+    dm_nycflights13() %>%
+    dm_zoom_to(flights) %>%
+    filter(FALSE) %>%
+    dm_update_zoomed() %>%
+    dm_zoom_to(weather) %>%
+    filter(FALSE) %>%
+    dm_update_zoomed()
+
+  # Must use SQLite because other databases have strict foreign key constraints
+  sqlite <- DBI::dbConnect(RSQLite::SQLite())
+
+  # Target database:
+  flights_sqlite <- copy_dm_to(sqlite, flights_init, temporary = FALSE)
+
+  expect_snapshot({
+    print(dm_nrow(flights_sqlite))
+
+    # First update:
+    flights_hour10 <-
+      dm_nycflights13() %>%
+      dm_select_tbl(flights, weather) %>%
+      dm_zoom_to(flights) %>%
+      filter(month == 1, day == 10, hour == 10) %>%
+      dm_update_zoomed() %>%
+      dm_zoom_to(weather) %>%
+      filter(month == 1, day == 10, hour == 10) %>%
+      dm_update_zoomed()
+    print(dm_nrow(flights_hour10))
+
+    # Copy to temporary tables on the target database:
+    flights_hour10_sqlite <- copy_dm_to(sqlite, flights_hour10)
+
+    # Dry run by default:
+    out <- dm_rows_append(flights_sqlite, flights_hour10_sqlite)
+    print(dm_nrow(flights_sqlite))
+
+    # Explicitly request persistence:
+    dm_rows_append(flights_sqlite, flights_hour10_sqlite, in_place = TRUE)
+    print(dm_nrow(flights_sqlite))
+
+    # Second update:
+    flights_hour11 <-
+      dm_nycflights13() %>%
+      dm_select_tbl(flights, weather) %>%
+      dm_zoom_to(flights) %>%
+      filter(month == 1, day == 10, hour == 11) %>%
+      dm_update_zoomed() %>%
+      dm_zoom_to(weather) %>%
+      filter(month == 1, day == 10, hour == 11) %>%
+      dm_update_zoomed()
+
+    # Copy to temporary tables on the target database:
+    flights_hour11_sqlite <- copy_dm_to(sqlite, flights_hour11)
+
+    # Explicit dry run:
+    flights_new <- dm_rows_append(
+      flights_sqlite,
+      flights_hour11_sqlite,
+      in_place = FALSE
+    )
+    print(dm_nrow(flights_new))
+    print(dm_nrow(flights_sqlite))
+
+    # Check for consistency before applying:
+    flights_new %>%
+      dm_examine_constraints()
+
+    # Apply:
+    dm_rows_append(flights_sqlite, flights_hour11_sqlite, in_place = TRUE)
+    print(dm_nrow(flights_sqlite))
+
+    # Disconnect
+    DBI::dbDisconnect(sqlite)
+  })
+})
+
+test_that("dm_rows_update()", {
+  # Test bad column order
+  dm_filter_rearranged <-
+    dm_for_filter() %>%
+    dm_select(tf_2, d, everything()) %>%
+    dm_select(tf_4, i, everything()) %>%
+    dm_select(tf_5, l, m, everything())
+
+  dm_copy <- suppressMessages(copy_dm_to(test_src_sqlite(), dm_filter_rearranged))
+
+  dm_update_local <- dm(
+    tf_1 = tibble(
+      a = 2L,
+      b = "q"
+    ),
+    tf_4 = tibble(
+      h = "e",
+      i = "sieben",
+    ),
+    tf_5 = tibble(
+      k = 3L,
+      ww = 3,
+    ),
+  )
+
+  dm_update_copy <- suppressMessages(copy_dm_to(test_src_sqlite(), dm_update_local))
+
+  expect_snapshot({
+    dm_copy %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_rows_update(dm_update_copy) %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_rows_update(dm_update_copy, in_place = FALSE) %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_get_tables() %>%
+      map(arrange_all)
+
+    dm_copy %>%
+      dm_rows_update(dm_update_copy, in_place = TRUE)
+
+    dm_copy %>%
+      dm_get_tables() %>%
+      map(arrange_all)
+  })
+})
+
+test_that("dm_rows_truncate()", {
+  local_options(lifecycle_verbosity = "warning")
+
+  suppressMessages(dm_copy <- copy_dm_to(test_src_sqlite(), dm_for_filter()))
+
+  dm_truncate_local <- dm(
+    tf_2 = tibble(
+      c = c("worm"),
+      d = 10L,
+    ),
+    tf_5 = tibble(
+      k = 3L,
+      m = "tree",
+    ),
+  )
+
+  dm_truncate_copy <- suppressMessages(copy_dm_to(test_src_sqlite(), dm_truncate_local))
+
+  expect_snapshot({
+    dm_copy %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_rows_truncate(dm_truncate_copy) %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_rows_truncate(dm_truncate_copy, in_place = FALSE) %>%
+      pull_tbl(tf_2) %>%
+      arrange_all()
+
+    dm_copy %>%
+      dm_get_tables() %>%
+      map(arrange_all)
+
+    dm_copy %>%
+      dm_rows_truncate(dm_truncate_copy, in_place = TRUE)
+
+    dm_copy %>%
+      dm_get_tables() %>%
+      map(arrange_all)
+  })
+})
+
+
+# tests for compound keys -------------------------------------------------
+
+test_that("output for compound keys", {
+  skip("COMPOUND")
+  local_options(lifecycle_verbosity = "warning")
+
+  expect_snapshot({
+    target_dm <- dm_filter(nyc_comp(), weather, pressure > 1010) %>% dm_apply_filters()
+    insert_dm <-
+      dm_filter(nyc_comp(), weather, pressure <= 1010) %>%
+      dm_apply_filters() %>%
+      dm_select_tbl(flights, weather)
+    dm_rows_insert(target_dm, insert_dm, in_place = FALSE)
+    dm_rows_truncate(nyc_comp(), insert_dm, in_place = FALSE)
+  })
+})
+
+
+# tests for autoincrement PKs ---------------------------------------------
+
+test_that("dm_rows_append() works with autoincrement PKs and FKS for selected DBs", {
+  skip_if_src_not(c("postgres", "mssql", "sqlite"))
+
+  con_db <- my_test_con()
+
+  # Setup
+  dm_ai_w_keys <-
+    dm_for_autoinc_1() %>%
+    dm_add_pk(t1, a, autoincrement = TRUE) %>%
+    dm_add_pk(t2, c, autoincrement = TRUE) %>%
+    dm_add_pk(t4, g, autoincrement = TRUE) %>%
+    dm_add_fk(t2, d, t1) %>%
+    dm_add_fk(t3, e, t1) %>%
+    dm_add_fk(t4, h, t2)
+
+  local_dm <-
+    dm_ai_w_keys %>%
+    collect()
+
+  withr::defer({
+    order_of_deletion <- c("t4", "t2", "t3", "t1")
+    walk(
+      order_of_deletion,
+      ~ try(DBI::dbExecute(con_db, paste0("DROP TABLE ", .x)))
+    )
+  })
+
+  dm_ai_empty_remote <-
+    local_dm %>%
+    dm_ptype() %>%
+    copy_dm_to(con_db, ., temporary = FALSE)
+
+  # Tests
+  dm_ai_insert <-
+    dm_for_autoinc_1() %>%
+    # Remove one PK column, only provided by database
+    dm_select(t4, -g) %>%
+    dm_zoom_to(t3) %>%
+    filter(0L == 1L) %>%
+    dm_update_zoomed()
+
+  expect_silent(
+    filled_dm <- dm_rows_append(
+      dm_ai_empty_remote,
+      dm_ai_insert,
+      in_place = FALSE,
+      progress = FALSE
+    ) %>%
+      collect()
+  )
+
+  expect_silent(
+    filled_dm_in_place <- dm_rows_append(
+      dm_ai_empty_remote,
+      dm_ai_insert,
+      in_place = TRUE,
+      progress = FALSE
+    ) %>%
+      collect()
+  )
+
+  expect_silent(
+    filled_dm_in_place_twice <- dm_rows_append(
+      dm_ai_empty_remote,
+      dm_ai_insert,
+      in_place = TRUE,
+      progress = FALSE
+    ) %>%
+      collect()
+  )
+
+  expect_snapshot(
+    variant = "sqlite",
+    {
+      local_dm$t1
+      local_dm$t2
+      local_dm$t3
+      local_dm$t4
+      filled_dm$t1
+      filled_dm$t2
+      filled_dm$t3
+      filled_dm$t4
+      filled_dm_in_place$t1
+      filled_dm_in_place$t2
+      filled_dm_in_place$t3
+      filled_dm_in_place$t4
+      filled_dm_in_place_twice$t1
+      filled_dm_in_place_twice$t2
+      filled_dm_in_place_twice$t3
+      filled_dm_in_place_twice$t4
+    }
+  )
+})
+
+
+test_that("dm_rows_append() works with autoincrement PKs and FKS locally", {
+  skip_if_remote_src()
+
+  # Setup
+  local_dm <-
+    dm_for_autoinc_1() %>%
+    dm_add_pk(t1, a, autoincrement = TRUE) %>%
+    dm_add_pk(t2, c, autoincrement = TRUE) %>%
+    dm_add_pk(t4, g, autoincrement = TRUE) %>%
+    dm_add_fk(t2, d, t1) %>%
+    dm_add_fk(t3, e, t1) %>%
+    dm_add_fk(t4, h, t2)
+
+  dm_ai_empty <-
+    local_dm %>%
+    dm_ptype()
+
+  # Corner case: empty + empty = empty
+  expect_identical(
+    expect_silent(dm_rows_append(
+      dm_ai_empty,
+      dm_ai_empty,
+      in_place = FALSE,
+      progress = FALSE
+    )),
+    dm_ai_empty
+  )
+
+  # Tests
+  dm_ai_insert <-
+    dm_for_autoinc_1() %>%
+    # Remove one PK column, only provided by local logic
+    dm_select(t4, -g) %>%
+    dm_zoom_to(t3) %>%
+    filter(0L == 1L) %>%
+    dm_update_zoomed()
+
+  expect_silent(
+    filled_dm <- dm_rows_append(
+      dm_ai_empty,
+      dm_ai_insert,
+      in_place = FALSE,
+      progress = FALSE
+    )
+  )
+
+  # Corner case: data + empty = data
+  expect_identical(
+    expect_silent(dm_rows_append(
+      filled_dm,
+      dm_ai_empty,
+      in_place = FALSE,
+      progress = FALSE
+    )),
+    filled_dm
+  )
+
+  expect_error(
+    dm_rows_append(
+      dm_ai_empty,
+      dm_ai_insert,
+      in_place = TRUE,
+      progress = FALSE
+    )
+  )
+
+  expect_silent(
+    filled_twice_dm <- dm_rows_append(
+      filled_dm,
+      dm_ai_insert,
+      in_place = FALSE,
+      progress = FALSE
+    )
+  )
+
+  expect_snapshot(
+    variant = "sqlite",
+    {
+      local_dm$t1
+      local_dm$t2
+      local_dm$t3
+      local_dm$t4
+      filled_dm$t1
+      filled_dm$t2
+      filled_dm$t3
+      filled_dm$t4
+      filled_twice_dm$t1
+      filled_twice_dm$t2
+      filled_twice_dm$t3
+      filled_twice_dm$t4
+    }
+  )
+})

--- a/tools/generate-backend-tests.R
+++ b/tools/generate-backend-tests.R
@@ -1,0 +1,153 @@
+#!/usr/bin/env Rscript
+
+# Tool to generate backend-specific test files from templates
+# This replaces the DM_TEST_SRC environment variable approach
+
+library(fs)
+library(purrr)
+library(readr)
+library(stringr)
+
+# Define backend configurations
+backends <- list(
+  df = list(
+    name = "df",
+    test_src_name = "df",
+    full_name = "data frames"
+  ),
+  duckdb = list(
+    name = "duckdb", 
+    test_src_name = "duckdb",
+    full_name = "DuckDB"
+  ),
+  postgres = list(
+    name = "postgres",
+    test_src_name = "postgres", 
+    full_name = "PostgreSQL"
+  ),
+  maria = list(
+    name = "maria",
+    test_src_name = "maria",
+    full_name = "MariaDB"
+  ),
+  mssql = list(
+    name = "mssql",
+    test_src_name = "mssql",
+    full_name = "SQL Server"
+  ),
+  sqlite = list(
+    name = "sqlite",
+    test_src_name = "sqlite",
+    full_name = "SQLite"
+  )
+)
+
+# Template patterns to identify files that need backend-specific versions
+template_patterns <- c(
+  "build_copy_queries",
+  "flatten", 
+  "rows-dm",
+  "json_nest",
+  "json_pack",
+  "meta"
+)
+
+# Generate header for backend-specific test files
+generate_header <- function(backend_name, full_name) {
+  glue::glue('
+# This file is generated automatically by tools/generate-backend-tests.R
+# Do not edit manually - edit the template and regenerate
+
+# Backend-specific tests for {full_name}
+
+')
+}
+
+# Replace template variables in test content
+replace_template_vars <- function(content, backend) {
+  result <- content %>%
+    str_replace_all("my_test_src_name", paste0('"', backend$test_src_name, '"')) %>%
+    str_replace_all("my_test_src\\(\\)", paste0("test_src_", backend$name, "()")) %>%
+    str_replace_all("is_db_test_src\\(\\)", ifelse(backend$name == "df", "FALSE", "TRUE"))
+  
+  # For data frame backend, replace my_db_test_src() with test_src_duckdb() 
+  # since data frame tests that need a database should use DuckDB
+  if (backend$name == "df") {
+    result <- str_replace_all(result, "my_db_test_src\\(\\)", "test_src_duckdb()")
+  } else {
+    result <- str_replace_all(result, "my_db_test_src\\(\\)", paste0("test_src_", backend$name, "()"))
+  }
+  
+  result
+}
+
+# Generate backend-specific test file
+generate_backend_test <- function(template_file, backend) {
+  template_content <- read_file(template_file)
+  
+  # Check for backend-specific patterns
+  backend_patterns <- c("my_test_src", "my_db_test_src", "variant\\s*=\\s*my_test_src_name")
+  has_backend_code <- any(str_detect(template_content, backend_patterns))
+  
+  cli::cli_inform("Checking {path_file(template_file)} for backend patterns...")
+  cli::cli_inform("  Has backend code: {has_backend_code}")
+  
+  # Skip if not a template that uses backend-specific functions
+  if (!has_backend_code) {
+    return(NULL)
+  }
+  
+  header <- generate_header(backend$name, backend$full_name)
+  processed_content <- replace_template_vars(template_content, backend)
+  
+  # Create output file path
+  base_name <- path_ext_remove(path_file(template_file))
+  base_name <- str_remove(base_name, "^test-")
+  output_file <- path("tests", "testthat", paste0("test-", base_name, "-", backend$name, ".R"))
+  
+  # Write the file
+  full_content <- paste0(header, processed_content)
+  write_file(full_content, output_file)
+  
+  cli::cli_inform("Generated {output_file}")
+  output_file
+}
+
+# Main function to generate all backend-specific tests
+generate_all_backend_tests <- function() {
+  # Find all test files that match our template patterns
+  template_files <- character(0)
+  for (pattern in template_patterns) {
+    pattern_files <- dir_ls("tests/testthat", regexp = paste0("test-.*", pattern, ".*\\.R$"))
+    template_files <- c(template_files, pattern_files)
+  }
+  
+  # Remove duplicates
+  template_files <- unique(template_files)
+  
+  cli::cli_h1("Generating backend-specific test files")
+  cli::cli_inform("Found {length(template_files)} template files: {path_file(template_files)}")
+  
+  generated_files <- list()
+  
+  # Generate files for each backend and template
+  for (backend_name in names(backends)) {
+    backend <- backends[[backend_name]]
+    cli::cli_h2("Backend: {backend$full_name}")
+    
+    backend_files <- map(template_files, ~ generate_backend_test(.x, backend))
+    backend_files <- compact(backend_files)
+    generated_files[[backend_name]] <- backend_files
+  }
+  
+  # Write summary
+  total_generated <- sum(map_int(generated_files, length))
+  cli::cli_alert_success("Generated {total_generated} backend-specific test files")
+  
+  invisible(generated_files)
+}
+
+# Run if called as script
+if (!interactive()) {
+  generate_all_backend_tests()
+}


### PR DESCRIPTION
Removes `DM_TEST_SRC` environment variable and creates template-based infrastructure to keep duplicated tests in sync.

Closes #1981

Generated with [Claude Code](https://claude.ai/code)