### PR TITLE
fledge: CRAN release v1.1.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dm
 Title: Relational Data Models
-Version: 1.1.1.9006
+Version: 1.1.2
 Date: 2026-05-17
 Authors@R: 
     c(person(given = "Tobias",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# dm 1.1.1.9006
+# dm 1.1.2
+
+## fledge
+
+- CRAN release v1.1.1 (#2428).
 
 ## Bug fixes
 
@@ -11,6 +15,16 @@
 - Auto-update from GitHub Actions (#2460).
 
 - Add ccache to `.gitignore` and `.Rbuildignore`.
+
+- Ensure exported dm functions call `check_dm()` first (#2441, #2442).
+
+- Auto-update from GitHub Actions (#2439).
+
+- Auto-update from GitHub Actions (#2434).
+
+- Auto-update from GitHub Actions (#2432).
+
+- Auto-update from GitHub Actions (#2430).
 
 ## Continuous integration
 
@@ -41,48 +55,6 @@
 ## Testing
 
 - Snapshot updates for rcc-smoke (null) (#2459).
-
-
-# dm 1.1.1.9005
-
-## Chore
-
-- Ensure exported dm functions call `check_dm()` first (#2441, #2442).
-
-
-# dm 1.1.1.9004
-
-## Chore
-
-- Auto-update from GitHub Actions (#2439).
-
-
-# dm 1.1.1.9003
-
-## Chore
-
-- Auto-update from GitHub Actions (#2434).
-
-
-# dm 1.1.1.9002
-
-## Chore
-
-- Auto-update from GitHub Actions (#2432).
-
-
-# dm 1.1.1.9001
-
-## Chore
-
-- Auto-update from GitHub Actions (#2430).
-
-
-# dm 1.1.1.9000
-
-## fledge
-
-- CRAN release v1.1.1 (#2428).
 
 
 # dm 1.1.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,59 +2,9 @@
 
 # dm 1.1.2
 
-## fledge
-
-- CRAN release v1.1.1 (#2428).
-
 ## Bug fixes
 
 - Fix for upcoming dbplyr 2.6.0 release (@hadley, #2454).
-
-## Chore
-
-- Auto-update from GitHub Actions (#2460).
-
-- Add ccache to `.gitignore` and `.Rbuildignore`.
-
-- Ensure exported dm functions call `check_dm()` first (#2441, #2442).
-
-- Auto-update from GitHub Actions (#2439).
-
-- Auto-update from GitHub Actions (#2434).
-
-- Auto-update from GitHub Actions (#2432).
-
-- Auto-update from GitHub Actions (#2430).
-
-## Continuous integration
-
-- Bump action version.
-
-- Create snapshot update PR against correct branch.
-
-- Add reference to `/apply-patch` workflow in commit message.
-
-- Clarify rationale for not deploying on schedule.
-
-- Only run fledge on pushes to main.
-
-- Tweak fledge workflow and ccache action.
-
-- Align.
-
-- Cosmetics.
-
-- Bump action versions.
-
-- Install clang-format-21.
-
-- Align fledge workflow.
-
-- Harmonize.
-
-## Testing
-
-- Snapshot updates for rcc-smoke (null) (#2459).
 
 
 # dm 1.1.1

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -2,6 +2,6 @@ dm 1.1.2
 
 ## Cran Repository Policy
 
-- [ ] Reviewed CRP last edited 2026-04-21.
+- [x] Reviewed CRP last edited 2026-04-21.
 
 See changes at https://github.com/eddelbuettel/crp/compare/master@%7B2026-02-20%7D...master@%7B2026-04-21%7D

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,7 @@
-dm 1.1.1
+dm 1.1.2
 
 ## Cran Repository Policy
 
-- [x] Reviewed CRP last edited 2026-02-20.
+- [ ] Reviewed CRP last edited 2026-04-21.
+
+See changes at https://github.com/eddelbuettel/crp/compare/master@%7B2026-02-20%7D...master@%7B2026-04-21%7D


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2026-05-17, no problems found.

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`