### PR TITLE
ci: Move validate logic into custom hooks driven by a matrix entry

### DIFF
--- a/.github/versions-matrix.R
+++ b/.github/versions-matrix.R
@@ -1,21 +1,34 @@
-data.frame(
-  os = "ubuntu-22.04",
-  r = "release",
-  test_src = c(
-    "test-mssql",
-    "test-postgres",
-    "test-maria",
-    "test-mysql-maria",
-    "test-duckdb",
-    "test-sqlite"
+list(
+  data.frame(
+    os = "ubuntu-22.04",
+    r = "release",
+    test_src = c(
+      "test-mssql",
+      "test-postgres",
+      "test-maria",
+      "test-mysql-maria",
+      "test-duckdb",
+      "test-sqlite"
+    ),
+    covr = "true",
+    desc = c(
+      "SQL Server with covr",
+      "Postgres with covr",
+      "MariaDB with covr",
+      "MySQL with covr",
+      "DuckDB with covr",
+      "SQLite with covr"
+    )
   ),
-  covr = "true",
-  desc = c(
-    "SQL Server with covr",
-    "Postgres with covr",
-    "MariaDB with covr",
-    "MySQL with covr",
-    "DuckDB with covr",
-    "SQLite with covr"
+  # Instrumented validation run. The DM_VALIDATE flag travels through the
+  # generic "env" matrix field to the custom before/after-install actions,
+  # which uncomment code marked "# INSTRUMENT: validate" and opt out of the
+  # snapshot updater. covr then builds and tests the instrumented sources.
+  data.frame(
+    os = "ubuntu-22.04",
+    r = "release",
+    env = "DM_VALIDATE=true",
+    covr = "true",
+    desc = "instrumented validation"
   )
 )

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -119,7 +119,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           cache-version: rcc-smoke-2
-          needs: build, check, website
+          needs: build, check, website, roxygen2
           # Beware of using dev pkgdown here, has brought in dev dependencies in the past
           extra-packages: any::rcmdcheck r-lib/roxygen2 any::decor r-lib/pkgdown deps::.
 
@@ -312,6 +312,10 @@ jobs:
 
       - uses: ./.github/workflows/custom/before-install
         if: hashFiles('.github/workflows/custom/before-install/action.yml') != ''
+        with:
+          # Generic: forward any per-entry environment variables defined in the
+          # test matrix (see .github/versions-matrix.R) to the custom action.
+          env: ${{ matrix.env }}
 
       - uses: ./.github/workflows/install
         with:
@@ -336,7 +340,11 @@ jobs:
         shell: Rscript {0}
 
       - uses: ./.github/workflows/update-snapshots
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        # Generic escape hatch: a custom action may set SKIP_UPDATE_SNAPSHOTS
+        # to opt out of running the snapshot updater,
+        # which runs tests directly via testthat::test_local()
+        # and is difficult to disable otherwise.
+        if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && env.SKIP_UPDATE_SNAPSHOTS != 'true'
         with:
           base: ${{ github.head_ref }}
 
@@ -421,72 +429,3 @@ jobs:
           results: ${{ matrix.package }}
 
 # The status update is taken care of by R-CMD-check-status.yaml
-
-  # FIXME: integrate with dynamic matrix creation
-  validate:
-    needs:
-      - rcc-smoke
-
-    runs-on: ${{ matrix.config.os }}${{ matrix.config.os-version }}
-
-    name: ${{ matrix.config.os }}${{ matrix.config.os-version }} (${{ matrix.config.r }}) ${{ matrix.config.desc }}
-
-    # Begin custom: services
-    # End custom: services
-
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - { os: ubuntu-, os-version: 22.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest" }
-
-    env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      # prevent rgl issues because no X11 display is available
-      RGL_USE_NULL: true
-      # Begin custom: env vars
-      # End custom: env vars
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: ./.github/workflows/custom/before-install
-        if: hashFiles('.github/workflows/custom/before-install/action.yml') != ''
-
-      - uses: ./.github/workflows/install
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          install-r: false
-          cache-version: rcc-smoke-1
-          needs: check
-          extra-packages: any::rcmdcheck any::roxygen2 r-lib/styler
-
-      - uses: ./.github/workflows/custom/after-install
-        if: hashFiles('.github/workflows/custom/after-install/action.yml') != ''
-
-      - name: Instrument R code for validation
-        run: |
-          if [ $(git status --porcelain | wc -l) -gt 0 ]; then
-            echo "Fatal: git working copy not clean"
-          fi
-          sed -i -r '/INSTRUMENT: validate/ s/^( +)# /\1/g' R/*
-          if [ $(git status --porcelain | wc -l) -eq 0 ]; then
-            echo "Fatal: substitution did not change anything"
-          fi
-
-      - name: Run tests
-        run: |
-          testthat::test_local(reporter = testthat::ProgressReporter$new(max_failures = Inf, update_interval = Inf))
-        shell: Rscript {0}
-
-      - name: Show test output
-        if: always()
-        run: |
-          find check -name '*.Rout*' -exec head -n 1000000 '{}' \; || true
-        shell: bash
-
-      - name: Test coverage
-        run: covr::codecov()
-        shell: Rscript {0}

--- a/.github/workflows/custom/after-install/action.yml
+++ b/.github/workflows/custom/after-install/action.yml
@@ -53,3 +53,19 @@ runs:
         # FIXME: Slow examples in dm?
         echo "_R_CHECK_EXAMPLE_TIMING_THRESHOLD_=15" | tee -a $GITHUB_ENV
       shell: bash
+
+    # Instrumented-validation matrix entry (DM_VALIDATE=true): uncomment the
+    # code guarded by "# INSTRUMENT: validate" so the assertions are compiled
+    # in. The matrix entry runs with covr: true, so the standard covr step then
+    # builds and tests these instrumented sources.
+    - name: Instrument R code for validation
+      if: env.DM_VALIDATE != ''
+      run: |
+        if [ $(git status --porcelain | wc -l) -gt 0 ]; then
+          echo "Fatal: git working copy not clean"
+        fi
+        sed -i -r '/INSTRUMENT: validate/ s/^( +)# /\1/g' R/*
+        if [ $(git status --porcelain | wc -l) -eq 0 ]; then
+          echo "Fatal: substitution did not change anything"
+        fi
+      shell: bash

--- a/.github/workflows/custom/before-install/action.yml
+++ b/.github/workflows/custom/before-install/action.yml
@@ -1,8 +1,35 @@
 name: 'Custom steps to run before R packages are installed'
 
+inputs:
+  env:
+    description: >
+      Additional environment variables (one KEY=VALUE per line) contributed by
+      the test matrix. Generic hook used by .github/versions-matrix.R to flag
+      special matrix entries (e.g. the instrumented-validation entry below).
+    required: false
+    default: ""
+
 runs:
   using: "composite"
   steps:
+    - name: Apply environment variables from the test matrix
+      if: inputs.env != ''
+      env:
+        MATRIX_ENV: ${{ inputs.env }}
+      run: |
+        printf '%s\n' "$MATRIX_ENV" | tee -a "$GITHUB_ENV"
+      shell: bash
+
+    # The instrumented-validation matrix entry sets DM_VALIDATE=true via the
+    # generic "env" field. Opt it out of the snapshot updater, which bypasses
+    # tests/testthat.R via testthat::test_local() and would otherwise run the
+    # instrumented tests twice.
+    - name: Opt out of the snapshot updater (instrumented validation)
+      if: env.DM_VALIDATE != ''
+      run: |
+        echo 'SKIP_UPDATE_SNAPSHOTS=true' | tee -a "$GITHUB_ENV"
+      shell: bash
+
     - name: Define _R_CHECK_PKG_SIZES_THRESHOLD_
       run: |
         echo '_R_CHECK_PKG_SIZES_THRESHOLD_=10' | tee -a $GITHUB_ENV


### PR DESCRIPTION
## Why

The `validate` logic (instrument `# INSTRUMENT: validate` code, then run the test suite + coverage) was a hand-written job baked into the **shared** `R-CMD-check.yaml`. That file is meant to track the template verbatim, so the bespoke job was drift that would conflict on every template update.

This moves the validation entirely into dm's own extension points — a matrix entry plus the `custom/before-install` / `custom/after-install` hooks — using the template's generic escape-hatch mechanism (the same pattern duckdb/duckdb-r uses for its engine-poisoning entry). `R-CMD-check.yaml` returns to being template-identical.

## What changes

- **`R-CMD-check.yaml`**: drop the hand-written `validate` job and sync the file to the **updated** template (cynkra/cynkratemplate#87), which forwards per-entry `matrix.env` into `custom/before-install` and adds the `SKIP_UPDATE_SNAPSHOTS` escape hatch. The file is now byte-identical to that template.
- **`versions-matrix.R`**: add one matrix entry carrying `env = "DM_VALIDATE=true"` with `covr: true` (returns a `list()` of the existing DB data.frame + the new validation data.frame).
- **`custom/before-install/action.yml`**: accept the generic `env` input, apply it to `$GITHUB_ENV`, and — when `DM_VALIDATE` is set — opt the entry out of the snapshot updater (`SKIP_UPDATE_SNAPSHOTS=true`).
- **`custom/after-install/action.yml`**: when `DM_VALIDATE` is set, uncomment the `# INSTRUMENT: validate` code. The matrix entry runs with `covr: true`, so the standard `covr` step then builds and tests the instrumented sources (this subsumes the old job's explicit `testthat::test_local()` + `covr::codecov()`).

## How it flows

```
versions-matrix.R adds  { env: "DM_VALIDATE=true", covr: true }
        │
rcc-full (template) forwards  env: ${{ matrix.env }}  → custom/before-install
        │                         ├─ applies DM_VALIDATE=true to $GITHUB_ENV
        │                         └─ sets SKIP_UPDATE_SNAPSHOTS=true
   install → custom/after-install ─ uncomments "# INSTRUMENT: validate" lines
        │
   update-snapshots  (skipped via SKIP_UPDATE_SNAPSHOTS)
   check             (skipped, covr: true)
   covr              ─ builds & tests the instrumented sources
```

## Notes for reviewers

- **Depends on cynkra/cynkratemplate#87.** The `matrix.env` forwarding and `SKIP_UPDATE_SNAPSHOTS` hatch this relies on come from that PR. This PR syncs `R-CMD-check.yaml` to that updated template so it works immediately and stays drift-free once #87 merges and spreads.
- **Behavioral change**: validation now runs as part of the dynamic `rcc-full` matrix (when the version matrix is produced) rather than on every event on a pinned config; coverage of the instrumented run is uploaded via the standard `covr` step instead of a separate `covr::codecov()` call.
- Supersedes this PR's earlier approach (converting the bespoke job to a dynamic matrix); the branch now removes the bespoke job entirely.

All YAML parses cleanly; `versions-matrix.R` is a straightforward `list()` of two `data.frame`s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDjzn9A39XEA9yijABAFtz