### PR TITLE
Fix print() method for dm_zoomed to pass through n parameter

### DIFF
--- a/R/dm.R
+++ b/R/dm.R
@@ -354,7 +354,7 @@ print.dm <- function(x, ...) {
 
 #' @export
 print.dm_zoomed <- function(x, ..., n = NULL, width = NULL, n_extra = NULL) {
-  format(x, ..., n = NULL, width = NULL, n_extra = NULL)
+  format(x, ..., n = n, width = width, n_extra = n_extra)
 }
 
 show_dm <- function(x) {

--- a/tests/testthat/_snaps/zoom.md
+++ b/tests/testthat/_snaps/zoom.md
@@ -14,6 +14,19 @@
       Zoomed table     A tibble 
             "tf_2"      "6 x 4" 
 
+---
+
+    Code
+      dm_for_filter() %>% dm_zoom_to(tf_2) %>% print(n = 2)
+    Output
+      # Zoomed table: tf_2
+      # A tibble:     6 x 4
+        c            d e        e1
+        <chr>    <int> <chr> <int>
+      1 elephant     2 D         4
+      2 lion         3 E         5
+      # i 4 more rows
+
 # zoom output for compound keys
 
     Code

--- a/tests/testthat/test-zoom.R
+++ b/tests/testthat/test-zoom.R
@@ -34,6 +34,11 @@ test_that("print() and format() methods for subclass `dm_zoomed` work", {
   expect_snapshot(
     dm_for_filter() %>% dm_zoom_to(tf_2) %>% as_dm_zoomed_df() %>% tbl_sum()
   )
+
+  # `n` is passed on to `format()` (#2474)
+  expect_snapshot(
+    dm_for_filter() %>% dm_zoom_to(tf_2) %>% print(n = 2)
+  )
 })
 
 


### PR DESCRIPTION
## Summary
Fixed a bug in the `print.dm_zoomed()` method where the `n`, `width`, and `n_extra` parameters were not being passed through to the underlying `format()` function, causing them to be ignored.

## Changes
- **R/dm.R**: Updated `print.dm_zoomed()` to pass the `n`, `width`, and `n_extra` parameters to `format()` instead of hardcoding them to `NULL`
- **tests/testthat/test-zoom.R**: Added test case to verify that the `n` parameter is correctly passed through when printing a zoomed table
- **tests/testthat/_snaps/zoom.md**: Added snapshot output demonstrating the corrected behavior with `print(n = 2)`

## Details
The bug was in line 357 of R/dm.R where `format(x, ..., n = NULL, width = NULL, n_extra = NULL)` was hardcoding all three parameters to `NULL` instead of using the values passed to `print()`. This prevented users from controlling the number of rows displayed when printing zoomed tables. The fix simply uses the parameter values directly: `format(x, ..., n = n, width = width, n_extra = n_extra)`.

Fixes #2474

https://claude.ai/code/session_01FbTe77QU4QemNYB6HzQXui