### PR TITLE
ci: Create `~/.duckdb` and set `DUCKDB_R_HOME` for the duckdb tests

### DIFF
--- a/.github/workflows/custom/before-install/action.yml
+++ b/.github/workflows/custom/before-install/action.yml
@@ -55,3 +55,34 @@ runs:
       run: |
         brew install unixodbc
       shell: bash
+
+    # The duckdb test source connects with a bare `duckdb::duckdb()`,
+    # which leaves it to the package to pick where downloaded extensions
+    # and stored secrets live.
+    # Whenever the package picks by itself it announces the location:
+    # a missing `~/.duckdb` draws the long "temporary directory" notice,
+    # and a bare `~/.duckdb` still draws a shorter "storing under ~/.duckdb" one
+    # (see `?duckdb_storage`).
+    # Both are noise in CI, and both can leak into test output.
+    #
+    # So create the shared home -- the same directory the duckdb repo creates in
+    # its own CI -- and additionally point `DUCKDB_R_HOME` at it.
+    # The environment variable counts as an explicit choice,
+    # so duckdb resolves to that directory without announcing anything,
+    # while the directory itself keeps extensions in one place for the whole run.
+    # duckdb derives the home from `USERPROFILE` on Windows and `HOME` elsewhere,
+    # so match that here rather than relying on shell `~` expansion.
+    - name: Create the shared DuckDB home (~/.duckdb)
+      run: |
+        if [ "${RUNNER_OS}" = "Windows" ]; then
+          home="$(cygpath -u "${USERPROFILE}")"
+        else
+          home="${HOME}"
+        fi
+        mkdir -p "${home}/.duckdb"
+        duckdb_home="${home}/.duckdb"
+        if [ "${RUNNER_OS}" = "Windows" ]; then
+          duckdb_home="$(cygpath -w "${duckdb_home}")"
+        fi
+        echo "DUCKDB_R_HOME=${duckdb_home}" | tee -a "$GITHUB_ENV"
+      shell: bash


### PR DESCRIPTION
The duckdb test source connects with a bare `duckdb::duckdb()`,
so the package picks where downloaded extensions and stored secrets live
and announces that choice whenever it makes it (see `?duckdb_storage`).
This is noise in CI, and it can leak into test output.

Creating `~/.duckdb` alone — what the duckdb repo does in its own CI —
switches the notice rather than removing it.
Verified against duckdb 1.5.5:

| setup | output on `dbConnect(duckdb::duckdb())` |
| --- | --- |
| no `~/.duckdb` | 8 lines, "duckdb keeps downloaded extensions and secrets in a temporary directory" |
| `~/.duckdb` exists | 5 lines, "duckdb is storing downloaded extensions and secrets under `~/.duckdb`" |
| `DUCKDB_R_HOME` set | silent |

Non-interactively, the `~/.duckdb` case still announces
(`R/Driver.R`, the `announce` condition), so the environment variable
is what actually silences it: it resolves as an explicit choice
rather than a location the package picked by itself.

So the new step in the `before-install` custom action does both:
it creates `~/.duckdb`, keeping extensions in one place for the whole run
and matching the duckdb repo, and points `DUCKDB_R_HOME` at that directory.
The home is derived from `USERPROFILE` on Windows and `HOME` elsewhere,
mirroring how duckdb resolves it, instead of relying on shell `~` expansion.

Only CI is affected; local test runs keep whatever storage location
the developer's machine resolves to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BaFr76qw4LnQjeV2s6gKhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BaFr76qw4LnQjeV2s6gKhQ)_