### PR TITLE
fix(ci): Run MariaDB 12.3, the line that reaches Resolute

### DIFF
--- a/.github/workflows/custom/after-install/action.yml
+++ b/.github/workflows/custom/after-install/action.yml
@@ -14,10 +14,21 @@ runs:
 
     # Must happen after installing system dependencies,
     # https://github.com/ankane/setup-mariadb/issues/2
+    #
+    # The version has to be one MariaDB publishes for the runner's Ubuntu.
+    # `ubuntu-26.04` is Resolute, and the 10.11 line stops before it:
+    # `apt-get update` then fails the whole step with
+    # "The repository '.../mariadb-server/10.11/repo/ubuntu resolute Release'
+    # does not have a Release file".
+    # The action itself needs no help with a new codename -- it reads
+    # `lsb_release -cs` -- and its own CI matrix marks the boundary:
+    # `ubuntu-26.04` is tested with 12.3 and 11.8, 11.4 and 10.11 only up to
+    # `ubuntu-24.04`. 12.3 is the current LTS, what the download page serves for
+    # Resolute, and the action's own default.
     - uses: ankane/setup-mariadb@v1
       if: env.DM_TEST_SRC == 'test-maria'
       with:
-        mariadb-version: 10.11
+        mariadb-version: "12.3"
 
     - uses: ankane/setup-mysql@v1
       if: env.DM_TEST_SRC == 'test-mysql-maria'
@@ -26,8 +37,13 @@ runs:
 
     - name: Create database (MariaDB), set it to UTF-8, add time zone info
       if: env.DM_TEST_SRC == 'test-maria' || env.DM_TEST_SRC == 'test-mysql-maria'
+      # MariaDB renamed its client binaries to `mariadb*` in 11.0 and keeps the
+      # `mysql*` names as deprecated symlinks, so prefer the name the server
+      # actually ships. The MySQL entry of the matrix has no `mariadb` binary
+      # and lands on the fallback, which is the name it wants anyway.
       run: |
-        mysql -e "CREATE DATABASE IF NOT EXISTS test; ALTER DATABASE test CHARACTER SET 'utf8'; FLUSH PRIVILEGES;"
+        client="$(command -v mariadb || command -v mysql)"
+        "${client}" -e "CREATE DATABASE IF NOT EXISTS test; ALTER DATABASE test CHARACTER SET 'utf8'; FLUSH PRIVILEGES;"
       shell: bash
 
     - uses: ankane/setup-sqlserver@v1


### PR DESCRIPTION
The MariaDB entry of the `rcc` matrix fails two seconds into `custom/after-install`, on every run:

```
E: The repository 'https://dlm.mariadb.com/repo/mariadb-server/10.11/repo/ubuntu resolute Release' does not have a Release file.
```

`ubuntu-26.04` is Resolute, and MariaDB publishes no Resolute suite for the 10.11 line. The action is not at fault and needs no change for a new codename — it builds the apt source from `lsb_release -cs`. Its own CI matrix marks where the lines end: `ubuntu-26.04` is tested with 12.3 and 11.8, while 11.4 and 10.11 stop at `ubuntu-24.04`. 12.3 is the current LTS, the action's own default, and what the MariaDB download page serves for Ubuntu 26.04 Resolute.

The client call moves with the server: MariaDB renamed its client binaries to `mariadb*` in 11.0 and keeps the `mysql*` names as deprecated symlinks, so the database is now created with whichever name the server ships — `mariadb` first, `mysql` as the fallback. That step is shared with the MySQL entry of the matrix, which has no `mariadb` binary and lands on the fallback, the name it wants anyway.

### Verification, and what this PR's own CI does not tell you

**The green check on this PR does not cover the change.** `rcc-full` runs only when `rcc-smoke` produced a versions matrix, and that step is skipped for a same-repo pull request, so this run was 4 jobs and none of them touched MariaDB. The matrix runs on push, on schedule, and on `workflow_dispatch` with `versions-matrix` and `run-rcc-full` — say the word and I'll dispatch one against this branch before merge.

What has been exercised, on `ubuntu-26.04`:

- **The same version against the same action, in CI**: r-dbi/DBI#744 carries an identical `ankane/setup-mariadb@v1` step pinned to 12.3, plus the identical client-name line, and its `after-install` passed in 15 seconds where 10.11 had aborted in 2.
- **The client selection, locally**: both branches against stub binaries under the same `bash -eo pipefail` the runner uses — `mariadb` preferred when present, `mysql` when it is not.

Whether MariaDB 12.3 shifts anything dm's own checks observe is genuinely open until the matrix runs; 11.8 is the conservative alternative if it does.

### Scope

This clears one of the three database entries that fail in `after-install`. The other two are left for a separate decision:

- **MySQL** pins `8.0`, which Oracle does not publish for Resolute either; `ankane/setup-mysql` defaults to `8.4` on that image and tests only `8.4` there. A pin bump (or dropping the pin) is the same shape of fix.
- **SQL Server** is blocked further upstream: `packages.microsoft.com/config/ubuntu/26.04/` carries no `mssql-server-*.list` at all (24.04's is served), and `ankane/setup-sqlserver` has no `ubuntu-26.04` row in its matrix for that reason. Until Microsoft publishes one, the only lever is running that entry on `ubuntu-24.04`.

The `… with covr` entries for DuckDB, Postgres and SQLite fail for an unrelated reason — snapshot drift from upstream SQL generation (`CAST` → `TRY_CAST`, `) values_table` → `) AS values_table`) — and are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhGEM4XYNJyH6ZG4JjBTML