### PR TITLE
fix(ci): Run SQL Server on Noble, and MySQL on 8.4

### DIFF
--- a/.github/odbc/odbc.ini
+++ b/.github/odbc/odbc.ini
@@ -34,6 +34,10 @@ Database    = /tmp/test
 Timeout     = 2000
 
 [mssql-test]
-Driver = ODBC Driver 17 for SQL Server
+Driver = ODBC Driver 18 for SQL Server
 Server = localhost
 Port = 1433
+# Driver 18 encrypts by default and verifies the server certificate, which a
+# freshly provisioned local SQL Server cannot present. The docker path in
+# `tests/testthat/helper-config-db.R` already passes this for the same reason.
+TrustServerCertificate = Yes

--- a/.github/odbc/odbcinst.ini
+++ b/.github/odbc/odbcinst.ini
@@ -9,7 +9,7 @@ Threading=2
 [SQLite Driver]
 Driver=/usr/lib/x86_64-linux-gnu/odbc/libsqlite3odbc.so
 
-[ODBC Driver 17 for SQL Server]
-Description=Microsoft ODBC Driver 17 for SQL Server
-Driver=/opt/microsoft/msodbcsql17/lib64/libmsodbcsql-17.so
+[ODBC Driver 18 for SQL Server]
+Description=Microsoft ODBC Driver 18 for SQL Server
+Driver=/opt/microsoft/msodbcsql18/lib64/libmsodbcsql-18.so
 UsageCount=1

--- a/.github/versions-matrix.R
+++ b/.github/versions-matrix.R
@@ -12,7 +12,6 @@ list(
     env = paste0(
       "DM_TEST_SRC=",
       c(
-        "test-mssql",
         "test-postgres",
         "test-maria",
         "test-mysql-maria",
@@ -23,13 +22,35 @@ list(
     ),
     covr = "true",
     desc = c(
-      "SQL Server with covr",
       "Postgres with covr",
       "MariaDB with covr",
       "MySQL with covr",
       "DuckDB with covr",
       "SQLite with covr"
     )
+  ),
+  # SQL Server is the one backend that cannot run on the default runner, and
+  # the reason is upstream of both this repository and `ankane/setup-sqlserver`:
+  # Microsoft publishes no `mssql-server-*.list` under
+  # packages.microsoft.com/config/ubuntu/26.04/ at all, so the action's
+  # `apt-get` step has no repository to add and the entry dies in
+  # `after-install`. Of the images that are served, 24.04 (Noble) carries only
+  # SQL Server 2025, which is what the action installs by default, and
+  # `ankane/setup-sqlserver` tests exactly that combination; 22.04 also offers
+  # 2022 but is a generation further back. Nothing is lost by staying here:
+  # Posit Package Manager serves a full Noble CRAN mirror and r-universe builds
+  # the same binaries for Noble as for Resolute, so this entry still installs
+  # binaries rather than compiling.
+  #
+  # Move this row back to the default once Microsoft publishes a 26.04
+  # repository, and then revisit the ODBC driver generation pinned in
+  # `.github/odbc/`, which follows whatever `mssql-tools` installs here.
+  data.frame(
+    os = "ubuntu-24.04",
+    r = "release",
+    env = "DM_TEST_SRC=test-mssql\nSKIP_UPDATE_SNAPSHOTS=true",
+    covr = "true",
+    desc = "SQL Server with covr"
   ),
   # Instrumented validation run. DM_VALIDATE makes the custom after-install
   # action uncomment code marked "# INSTRUMENT: validate"; covr then builds

--- a/.github/workflows/custom/after-install/action.yml
+++ b/.github/workflows/custom/after-install/action.yml
@@ -30,10 +30,16 @@ runs:
       with:
         mariadb-version: "12.3"
 
+    # Same story as MariaDB above, one release line further along: Oracle
+    # publishes no `resolute` suite for the 8.0 line, so `mysql-apt-config`
+    # leaves the action nothing to install. 8.4 is the current LTS and the
+    # version the action itself defaults to on this image -- which also means
+    # it is the one already on the runner, so the action starts the preinstalled
+    # server instead of fetching a second one.
     - uses: ankane/setup-mysql@v1
       if: env.DM_TEST_SRC == 'test-mysql-maria'
       with:
-        mysql-version: "8.0"
+        mysql-version: "8.4"
 
     - name: Create database (MariaDB), set it to UTF-8, add time zone info
       if: env.DM_TEST_SRC == 'test-maria' || env.DM_TEST_SRC == 'test-mysql-maria'
@@ -59,8 +65,14 @@ runs:
 
     - name: Set ODBCSYSINI (SQL Server)
       if: env.DM_TEST_SRC == 'test-mssql'
+      # The driver generation follows the server: on the only image Microsoft
+      # still serves a repository for, the action installs SQL Server 2025 and
+      # with it `mssql-tools18`, which carries `msodbcsql18`. The package ships
+      # the library under its full version, so link the plain name that
+      # `.github/odbc/odbcinst.ini` points at; `-f` because a future package may
+      # ship that link itself, and a second run must not fail on it.
       run: |
-        ln -s /opt/microsoft/msodbcsql17/lib64/libmsodbcsql-17.*.so.* /opt/microsoft/msodbcsql17/lib64/libmsodbcsql-17.so
+        ln -sf /opt/microsoft/msodbcsql18/lib64/libmsodbcsql-18.*.so.* /opt/microsoft/msodbcsql18/lib64/libmsodbcsql-18.so
         echo "ODBCSYSINI=${{ github.workspace }}/.github/odbc" | tee -a $GITHUB_ENV
       shell: bash
 


### PR DESCRIPTION
The two backend entries still dying in `after-install` after #2496, each on a version its vendor does not publish for Resolute. Verified against run [34684246553](https://github.com/cynkra/dm/actions/runs/34684246553) on `main`, where MariaDB now clears setup in 15 seconds while MySQL fails in 5 and SQL Server in 2.

## MySQL: 8.0 → 8.4

Oracle serves no `resolute` suite for the 8.0 line, so `mysql-apt-config` leaves the action nothing to install. 8.4 is the current LTS and the version `ankane/setup-mysql` defaults to on this image — which also means it is the one already on the runner, so the action skips the apt dance entirely and starts the preinstalled server.

## SQL Server: `ubuntu-24.04`

This one no version can fix. Microsoft publishes no `mssql-server-*.list` under `packages.microsoft.com/config/ubuntu/26.04/` at all — not 2025, not 2022, not 2019 — so the action has no repository to add, and `ankane/setup-sqlserver` has no `ubuntu-26.04` row in its own CI matrix for that reason. What is served:

- `ubuntu/24.04`: 2025 only
- `ubuntu/22.04`: 2022 and 2025
- `ubuntu/26.04`: nothing

So the entry moves to 24.04, which the kit already supports per row through `.github/versions-matrix.R` — no workflow file is touched. Noble costs nothing in install time: P3M serves a full Noble CRAN mirror and r-universe builds the same binaries for Noble as for Resolute, so the entry still installs binaries rather than compiling.

### The driver generation has to move with it

Noble carries only SQL Server 2025, which is what the action installs by default, and that brings `mssql-tools18` → `msodbcsql18`. `msodbcsql17` is then never on the runner, so `.github/odbc/` and the symlink in `custom/after-install` follow it to 18, and the DSN gains `TrustServerCertificate` because driver 18 encrypts by default and verifies a certificate that a freshly provisioned local server cannot present.

Worth noting: `tests/testthat/helper-config-db.R` has been on driver 18 with that flag all along for its docker path. Only the CI DSN was still on 17, so this brings the two into line.

If you would rather not move the driver generation yet, the alternative is `ubuntu-22.04` with `sqlserver-version: "2022"`, which keeps driver 17 — at the cost of a runner image one generation further back.

## Verified

The matrix still evaluates: three frames, SQL Server alone on Noble, the other five backends and the instrumented-validation entry unmoved. Everything past that is for CI to answer — this is the first time either entry will get past provisioning, so the tests behind them are unexercised.

The `… with covr` entries for DuckDB, Postgres and SQLite remain red on the unrelated snapshot drift (`CAST` → `TRY_CAST`, `) values_table` → `) AS values_table`), and SQL Server and MySQL may well land there too once they provision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhGEM4XYNJyH6ZG4JjBTML

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhGEM4XYNJyH6ZG4JjBTML)_