### PR TITLE
fix(ci): Trust the SQL Server certificate when creating the test database

### DIFF
--- a/.github/workflows/custom/after-install/action.yml
+++ b/.github/workflows/custom/after-install/action.yml
@@ -59,8 +59,13 @@ runs:
 
     - name: Create database (SQL Server)
       if: env.DM_TEST_SRC == 'test-mssql'
+      # `-C` trusts the server certificate, for the same reason
+      # `.github/odbc/odbc.ini` sets `TrustServerCertificate`: the `sqlcmd` that
+      # comes with SQL Server 2025 is the `mssql-tools18` build, which encrypts
+      # by default and then rejects the self-signed certificate a freshly
+      # provisioned local server presents.
       run: |
-        sqlcmd -U SA -P 'YourStrong!Passw0rd' -Q 'CREATE DATABASE test;'
+        sqlcmd -C -U SA -P 'YourStrong!Passw0rd' -Q 'CREATE DATABASE test;'
       shell: bash
 
     - name: Set ODBCSYSINI (SQL Server)


### PR DESCRIPTION
Follow-up to #2497, which moved the SQL Server matrix entry to `ubuntu-24.04`. The entry now gets as far as provisioning the server, but `after-install` still dies one step later, in "Create database (SQL Server)":

```
Sqlcmd: Error: Microsoft ODBC Driver 18 for SQL Server : SSL Provider: [error:0A000086:SSL routines::certificate verify failed:self-signed certificate].
Sqlcmd: Error: Microsoft ODBC Driver 18 for SQL Server : Client unable to establish connection.
```

On Noble the action installs SQL Server 2025 and with it `mssql-tools18`. That `sqlcmd` is built against ODBC Driver 18, which encrypts by default and verifies the server certificate — and a freshly provisioned local server can only present a self-signed one. So `sqlcmd` aborts and the test database is never created.

`-C` trusts the certificate. This is the same concession `.github/odbc/odbc.ini` already makes for the ODBC connection through `TrustServerCertificate`, and the same one `tests/testthat/helper-config-db.R` makes for the docker path.

As with #2497, the SQL Server entry lives in the `rcc-full` matrix, which is gated on the versions-matrix step that is skipped for same-repo pull requests — so this PR's own CI cannot exercise it. The proof is the first `main` run after the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhGEM4XYNJyH6ZG4JjBTML

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhGEM4XYNJyH6ZG4JjBTML)_